### PR TITLE
Sync from vanedb-cpp v0.1.0 (HNSW perf, persistence hardening)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -21,14 +21,17 @@ jobs:
       - name: Install critcmp
         run: cargo install critcmp
 
+      # Pass explicit --bench targets so cargo bench skips the lib's
+      # libtest harness (which doesn't accept --save-baseline) regardless
+      # of Cargo.toml settings on either branch.
       - name: Benchmark (PR branch)
-        run: cargo bench -- --save-baseline pr
+        run: cargo bench --bench distance_bench --bench store_bench --bench hnsw_bench -- --save-baseline pr
 
       - name: Checkout main
         run: git checkout origin/main
 
       - name: Benchmark (main baseline)
-        run: cargo bench -- --save-baseline main
+        run: cargo bench --bench distance_bench --bench store_bench --bench hnsw_bench -- --save-baseline main
 
       - name: Compare benchmarks
         run: |

--- a/vanedb/Cargo.toml
+++ b/vanedb/Cargo.toml
@@ -28,6 +28,9 @@ bincode = "1.3"
 proptest = "1.6"
 criterion = { version = "0.5", features = ["html_reports"] }
 
+[lib]
+bench = false
+
 [[bench]]
 name = "distance_bench"
 harness = false

--- a/vanedb/src/hnsw/mod.rs
+++ b/vanedb/src/hnsw/mod.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::cmp::Reverse;
 use std::collections::{BinaryHeap, HashMap, HashSet};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -11,6 +12,52 @@ use crate::error::{Result, VaneError};
 use crate::store::SearchResult;
 
 mod persistence;
+
+// Versioned thread-local visited tracker. `marks[i] == epoch` means visited;
+// the epoch is bumped each `search_layer` call, so the per-search work stays
+// O(visited) instead of O(N) (which a fresh-bitmap-per-call or HashSet
+// becomes at scale). On the rare epoch wrap (every 65k searches with u16
+// the buffer is reset once. Buffer is shared across HnswIndex instances on
+// a thread (monotonic epoch keeps cross-index marks distinct) and is
+// retained across calls so we pay the allocation cost at most once.
+//
+// Mirrors the optimization in vanedb-cpp src/core/hnsw_index.h.
+thread_local! {
+    static VISITED: RefCell<VisitedBuffer> = const { RefCell::new(VisitedBuffer::new()) };
+}
+
+struct VisitedBuffer {
+    marks: Vec<u16>,
+    epoch: u16,
+}
+
+impl VisitedBuffer {
+    const fn new() -> Self {
+        Self {
+            marks: Vec::new(),
+            epoch: 0,
+        }
+    }
+
+    /// Begin a new search pass over `total` nodes. Returns the epoch tag for
+    /// this call; callers compare `marks[i] == ep` to test visited.
+    fn begin(&mut self, total: usize) -> u16 {
+        if self.marks.len() < total {
+            self.marks.resize(total, 0);
+        }
+        self.epoch = self.epoch.wrapping_add(1);
+        if self.epoch == 0 {
+            // Wrap: zero the active range so stale marks can't masquerade as
+            // current. uint16 wraps every 65536 searches, frequently enough
+            // that a real test exercises this path.
+            for m in self.marks.iter_mut().take(total) {
+                *m = 0;
+            }
+            self.epoch = 1;
+        }
+        self.epoch
+    }
+}
 
 /// Wrapper for f32 that implements Ord (needed for BinaryHeap).
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -32,7 +79,7 @@ impl Ord for FloatOrd {
     }
 }
 
-const MAX_LEVEL: i32 = 32;
+pub(super) const MAX_LEVEL: i32 = 32;
 const MIN_LEVEL_RANDOM: f64 = 1e-9;
 
 pub struct HnswIndex {
@@ -46,6 +93,9 @@ pub struct HnswIndex {
     pub(super) ef_construction: usize,
     pub(super) ef_search: AtomicUsize,
     pub(super) mult: f64,
+    /// Original RNG seed; persisted on save and used to deterministically
+    /// rewind the RNG to its post-`count`-inserts state on load.
+    pub(super) seed: u64,
     pub(super) inner: RwLock<Inner>,
 }
 
@@ -203,6 +253,7 @@ impl HnswIndex {
                 ep_for_layer,
                 self.ef_construction,
                 lev,
+                inner.count,
             );
 
             let m_for_layer = if lev == 0 { self.m_max0 } else { self.m_max };
@@ -237,7 +288,7 @@ impl HnswIndex {
                                 (d, n)
                             })
                             .collect();
-                        candidates.sort_by(|a, b| FloatOrd(a.0).cmp(&FloatOrd(b.0)));
+                        candidates.sort_by_key(|a| FloatOrd(a.0));
                         let pruned = Self::select_neighbors(
                             &inner.vectors,
                             self.dist_fn,
@@ -313,6 +364,7 @@ impl HnswIndex {
             curr,
             ef,
             0,
+            inner.count,
         );
 
         let mut results: Vec<SearchResult> = top
@@ -326,7 +378,7 @@ impl HnswIndex {
     }
 
     /// Generate a random level using exponential distribution.
-    fn get_level(rng: &mut StdRng, mult: f64) -> i32 {
+    pub(super) fn get_level(rng: &mut StdRng, mult: f64) -> i32 {
         use rand::Rng;
         let r: f64 = rng.random::<f64>().max(MIN_LEVEL_RANDOM);
         let level = (-r.ln() * mult) as i32;
@@ -341,6 +393,9 @@ impl HnswIndex {
 
     /// Beam search on a single graph layer.
     /// Returns results sorted by distance ascending.
+    ///
+    /// `total` is the number of live nodes (== `inner.count`) and bounds the
+    /// thread-local visited bitmap. Caller must guarantee `entry < total`.
     #[allow(clippy::too_many_arguments)]
     fn search_layer(
         vectors: &[f32],
@@ -351,63 +406,70 @@ impl HnswIndex {
         entry: usize,
         ef: usize,
         level: usize,
+        total: usize,
     ) -> Vec<(f32, usize)> {
-        let entry_dist = dist_fn(Self::get_vec(vectors, entry, dim), query);
+        debug_assert!(entry < total, "search_layer: entry out of range");
 
-        // Min-heap of candidates (closest first)
-        let mut candidates: BinaryHeap<Reverse<(FloatOrd, usize)>> = BinaryHeap::new();
-        candidates.push(Reverse((FloatOrd(entry_dist), entry)));
+        VISITED.with_borrow_mut(|vb| {
+            let epoch = vb.begin(total);
 
-        // Max-heap of results (farthest first, capped at ef)
-        let mut results: BinaryHeap<(FloatOrd, usize)> = BinaryHeap::new();
-        results.push((FloatOrd(entry_dist), entry));
+            let entry_dist = dist_fn(Self::get_vec(vectors, entry, dim), query);
 
-        let mut visited = HashSet::new();
-        visited.insert(entry);
+            // Min-heap of candidates (closest first)
+            let mut candidates: BinaryHeap<Reverse<(FloatOrd, usize)>> = BinaryHeap::new();
+            candidates.push(Reverse((FloatOrd(entry_dist), entry)));
 
-        while let Some(Reverse((FloatOrd(c_dist), c_id))) = candidates.pop() {
-            // Stop if closest candidate is farther than farthest result
-            if let Some(&(FloatOrd(f_dist), _)) = results.peek() {
-                if c_dist > f_dist {
-                    break;
+            // Max-heap of results (farthest first, capped at ef)
+            let mut results: BinaryHeap<(FloatOrd, usize)> = BinaryHeap::new();
+            results.push((FloatOrd(entry_dist), entry));
+
+            vb.marks[entry] = epoch;
+
+            while let Some(Reverse((FloatOrd(c_dist), c_id))) = candidates.pop() {
+                // Stop if closest candidate is farther than farthest result
+                if let Some(&(FloatOrd(f_dist), _)) = results.peek() {
+                    if c_dist > f_dist {
+                        break;
+                    }
                 }
-            }
 
-            // Expand candidate's neighbors at this layer
-            let nb_list = neighbors[c_id].get(level).cloned().unwrap_or_default();
-            for &nb in &nb_list {
-                if visited.contains(&nb) {
+                let Some(nb_list) = neighbors[c_id].get(level) else {
                     continue;
-                }
-                visited.insert(nb);
-
-                let nb_dist = dist_fn(Self::get_vec(vectors, nb, dim), query);
-
-                let should_add = if results.len() < ef {
-                    true
-                } else if let Some(&(FloatOrd(f_dist), _)) = results.peek() {
-                    nb_dist < f_dist
-                } else {
-                    true
                 };
+                for &nb in nb_list {
+                    if vb.marks[nb] == epoch {
+                        continue;
+                    }
+                    vb.marks[nb] = epoch;
 
-                if should_add {
-                    candidates.push(Reverse((FloatOrd(nb_dist), nb)));
-                    results.push((FloatOrd(nb_dist), nb));
-                    if results.len() > ef {
-                        results.pop();
+                    let nb_dist = dist_fn(Self::get_vec(vectors, nb, dim), query);
+
+                    let should_add = if results.len() < ef {
+                        true
+                    } else if let Some(&(FloatOrd(f_dist), _)) = results.peek() {
+                        nb_dist < f_dist
+                    } else {
+                        true
+                    };
+
+                    if should_add {
+                        candidates.push(Reverse((FloatOrd(nb_dist), nb)));
+                        results.push((FloatOrd(nb_dist), nb));
+                        if results.len() > ef {
+                            results.pop();
+                        }
                     }
                 }
             }
-        }
 
-        // Convert to sorted vec (ascending distance)
-        let mut result_vec: Vec<(f32, usize)> = results
-            .into_iter()
-            .map(|(FloatOrd(d), id)| (d, id))
-            .collect();
-        result_vec.sort_by(|a, b| FloatOrd(a.0).cmp(&FloatOrd(b.0)));
-        result_vec
+            // Convert to sorted vec (ascending distance)
+            let mut result_vec: Vec<(f32, usize)> = results
+                .into_iter()
+                .map(|(FloatOrd(d), id)| (d, id))
+                .collect();
+            result_vec.sort_by_key(|a| FloatOrd(a.0));
+            result_vec
+        })
     }
 
     /// Heuristic neighbor selection (Algorithm 4 from HNSW paper).
@@ -423,7 +485,7 @@ impl HnswIndex {
         }
 
         let mut sorted = candidates.to_vec();
-        sorted.sort_by(|a, b| FloatOrd(a.0).cmp(&FloatOrd(b.0)));
+        sorted.sort_by_key(|a| FloatOrd(a.0));
 
         let mut selected: Vec<(f32, usize)> = Vec::with_capacity(m);
         let mut remaining: Vec<(f32, usize)> = Vec::new();
@@ -514,6 +576,7 @@ impl HnswIndexBuilder {
             ef_construction,
             ef_search: AtomicUsize::new(50),
             mult,
+            seed: self.seed,
             inner: RwLock::new(Inner {
                 vectors: vec![0.0; self.capacity * self.dim],
                 ext_ids: vec![0; self.capacity],

--- a/vanedb/src/hnsw/persistence.rs
+++ b/vanedb/src/hnsw/persistence.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::fs;
+use std::io::Write;
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -8,9 +9,19 @@ use rand::rngs::StdRng;
 use rand::SeedableRng;
 use serde::{Deserialize, Serialize};
 
-use super::{HnswIndex, Inner};
+use super::{HnswIndex, Inner, MAX_LEVEL};
 use crate::distance::{distance_fn, DistanceMetric};
 use crate::error::{Result, VaneError};
+
+/// On-disk magic ("HNSW" little-endian) and format version.
+///
+/// Mirrors the framing in vanedb-cpp src/core/hnsw_index.h. The C++ side
+/// uses a different MAGIC (legacy "QVRD") because it needs on-disk
+/// compatibility with files written before the rename. Rust never shipped
+/// pre-rename, so we use a clean per-format magic.
+const MAGIC: u32 = u32::from_le_bytes(*b"HNSW");
+const VERSION: u32 = 1;
+const HEADER_LEN: usize = 8;
 
 #[derive(Serialize, Deserialize)]
 struct HnswData {
@@ -23,6 +34,11 @@ struct HnswData {
     ef_construction: usize,
     ef_search: usize,
     mult: f64,
+    /// Original seed; replayed forward `count` times on load to restore
+    /// determinism for subsequent inserts. Matches the v2 RNG-state
+    /// preservation in the C++ implementation, just stored as the seed
+    /// rather than a serialized engine.
+    seed: u64,
     count: usize,
     entry_point: Option<usize>,
     max_level: i32,
@@ -63,6 +79,7 @@ impl HnswIndex {
             ef_construction: self.ef_construction,
             ef_search: self.ef_search.load(Ordering::Relaxed),
             mult: self.mult,
+            seed: self.seed,
             count: inner.count,
             entry_point: inner.entry_point,
             max_level: inner.max_level,
@@ -73,22 +90,150 @@ impl HnswIndex {
             id_map: inner.id_map.clone(),
         };
 
-        let bytes =
+        let payload =
             bincode::serialize(&data).map_err(|e| VaneError::Io(format!("serialize: {e}")))?;
 
         let path = path.as_ref();
         let tmp = path.with_extension("tmp");
-        fs::write(&tmp, &bytes).map_err(|e| VaneError::Io(format!("write: {e}")))?;
+        let mut f = fs::File::create(&tmp).map_err(|e| VaneError::Io(format!("create: {e}")))?;
+        f.write_all(&MAGIC.to_le_bytes())
+            .map_err(|e| VaneError::Io(format!("write: {e}")))?;
+        f.write_all(&VERSION.to_le_bytes())
+            .map_err(|e| VaneError::Io(format!("write: {e}")))?;
+        f.write_all(&payload)
+            .map_err(|e| VaneError::Io(format!("write: {e}")))?;
+        // Durability: fsync data + metadata before rename so a crash mid-write
+        // can't leave a half-written file in place. Mirrors fsync_file in
+        // vanedb-cpp src/core/detail/file_utils.h.
+        f.sync_all()
+            .map_err(|e| VaneError::Io(format!("sync: {e}")))?;
+        drop(f);
+
         fs::rename(&tmp, path).map_err(|e| VaneError::Io(format!("rename: {e}")))?;
         Ok(())
     }
 
     pub fn load(path: impl AsRef<Path>) -> Result<Self> {
         let bytes = fs::read(path.as_ref()).map_err(|e| VaneError::Io(format!("read: {e}")))?;
-        let data: HnswData =
-            bincode::deserialize(&bytes).map_err(|e| VaneError::Io(format!("deserialize: {e}")))?;
+        if bytes.len() < HEADER_LEN {
+            return Err(VaneError::Io("file too small for header".to_string()));
+        }
+        let magic = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        if magic != MAGIC {
+            return Err(VaneError::Io("invalid magic".to_string()));
+        }
+        let version = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
+        if version != VERSION {
+            return Err(VaneError::Io(format!("unsupported version: {version}")));
+        }
 
+        let data: HnswData = bincode::deserialize(&bytes[HEADER_LEN..])
+            .map_err(|e| VaneError::Io(format!("deserialize: {e}")))?;
+
+        // Validate semantic invariants. bincode catches schema mismatches but
+        // never validates values, so a corrupt or hostile file could otherwise
+        // claim e.g. count > max_elements, an out-of-range entry point, or
+        // neighbor indices pointing past the live set. Each check below maps
+        // to one in the C++ load() path (vanedb-cpp src/core/hnsw_index.h).
         let metric = u32_to_metric(data.metric)?;
+        if data.dim == 0 {
+            return Err(VaneError::Io("invalid dim: 0".to_string()));
+        }
+        if data.max_elements == 0 {
+            return Err(VaneError::Io("invalid max_elements: 0".to_string()));
+        }
+        if data.count > data.max_elements {
+            return Err(VaneError::Io(format!(
+                "corrupted file: count {} exceeds max_elements {}",
+                data.count, data.max_elements
+            )));
+        }
+        if data.max_level > MAX_LEVEL {
+            return Err(VaneError::Io(format!(
+                "corrupted file: max_level {} exceeds bound {}",
+                data.max_level, MAX_LEVEL
+            )));
+        }
+        match data.entry_point {
+            Some(ep) => {
+                if ep >= data.count {
+                    return Err(VaneError::Io(format!(
+                        "corrupted file: entry point {ep} >= count {}",
+                        data.count
+                    )));
+                }
+                if data.max_level < 0 {
+                    return Err(VaneError::Io(
+                        "corrupted file: entry point set but max_level < 0".to_string(),
+                    ));
+                }
+            }
+            None => {
+                if data.count > 0 {
+                    return Err(VaneError::Io(
+                        "corrupted file: count > 0 with no entry point".to_string(),
+                    ));
+                }
+            }
+        }
+        if data.id_map.len() != data.count {
+            return Err(VaneError::Io(format!(
+                "corrupted file: id_map size {} != count {}",
+                data.id_map.len(),
+                data.count
+            )));
+        }
+        for &iid in data.id_map.values() {
+            if iid >= data.count {
+                return Err(VaneError::Io(
+                    "corrupted file: id_map value out of range".to_string(),
+                ));
+            }
+        }
+        if data.neighbors.len() > data.max_elements {
+            return Err(VaneError::Io(
+                "corrupted file: neighbors size exceeds max_elements".to_string(),
+            ));
+        }
+        for nbs in data.neighbors.iter().take(data.count) {
+            if nbs.len() > (MAX_LEVEL as usize) + 1 {
+                return Err(VaneError::Io(
+                    "corrupted file: too many neighbor levels".to_string(),
+                ));
+            }
+            for layer in nbs {
+                for &n in layer {
+                    if n >= data.count {
+                        return Err(VaneError::Io(
+                            "corrupted file: neighbor index out of range".to_string(),
+                        ));
+                    }
+                }
+            }
+        }
+        let expected_vecs_len = data
+            .max_elements
+            .checked_mul(data.dim)
+            .ok_or_else(|| VaneError::Io("size overflow".to_string()))?;
+        if data.vectors.len() != expected_vecs_len {
+            return Err(VaneError::Io(
+                "corrupted file: vectors length != max_elements * dim".to_string(),
+            ));
+        }
+        if data.ext_ids.len() != data.max_elements || data.levels.len() != data.max_elements {
+            return Err(VaneError::Io(
+                "corrupted file: ext_ids/levels length != max_elements".to_string(),
+            ));
+        }
+
+        // Reconstitute RNG: seed from the original seed, then advance through
+        // `count` get_level calls so the next add() resumes the original
+        // sequence. This is the equivalent of the C++ v2 file format that
+        // serializes the std::mt19937 engine state directly.
+        let mut rng = StdRng::seed_from_u64(data.seed);
+        for _ in 0..data.count {
+            let _ = HnswIndex::get_level(&mut rng, data.mult);
+        }
 
         Ok(HnswIndex {
             dim: data.dim,
@@ -101,6 +246,7 @@ impl HnswIndex {
             ef_construction: data.ef_construction,
             ef_search: AtomicUsize::new(data.ef_search),
             mult: data.mult,
+            seed: data.seed,
             inner: RwLock::new(Inner {
                 vectors: data.vectors,
                 ext_ids: data.ext_ids,
@@ -110,7 +256,7 @@ impl HnswIndex {
                 entry_point: data.entry_point,
                 max_level: data.max_level,
                 count: data.count,
-                rng: StdRng::seed_from_u64(data.count as u64),
+                rng,
             }),
         })
     }

--- a/vanedb/src/mmap.rs
+++ b/vanedb/src/mmap.rs
@@ -105,6 +105,11 @@ impl MmapVectorStoreBuilder {
 
         f.flush()
             .map_err(|e| VaneError::Io(format!("flush: {e}")))?;
+        // Durability: fsync data + metadata before rename so a crash mid-write
+        // can't leave a half-written file in place. Mirrors fsync_file in
+        // vanedb-cpp src/core/detail/file_utils.h.
+        f.sync_all()
+            .map_err(|e| VaneError::Io(format!("sync: {e}")))?;
         drop(f);
 
         fs::rename(&tmp, path).map_err(|e| VaneError::Io(format!("rename: {e}")))?;

--- a/vanedb/tests/corruption_tests.rs
+++ b/vanedb/tests/corruption_tests.rs
@@ -1,0 +1,259 @@
+//! Corruption and validation tests for HNSW persistence and mmap files.
+//!
+//! Mirrors the corruption/validation suite from vanedb-cpp PR #5
+//! (tests/test_hnsw_index.cpp + tests/test_mmap_vector_store.cpp).
+
+use std::fs;
+use std::io::Write;
+
+use vanedb::{DistanceMetric, HnswIndex};
+
+#[cfg(feature = "mmap")]
+use vanedb::{MmapVectorStore, MmapVectorStoreBuilder};
+
+const HNSW_MAGIC: u32 = u32::from_le_bytes(*b"HNSW");
+const HNSW_VERSION: u32 = 1;
+
+/// Build a minimal valid HNSW file on disk, then return the bytes so tests can
+/// mutate specific fields and exercise validation paths in `load`. The `tag`
+/// scopes the temp-file path so parallel tests don't collide on the same name.
+fn valid_hnsw_bytes(tag: &str) -> Vec<u8> {
+    let path = std::env::temp_dir().join(format!("vanedb_corruption_seed_{tag}.bin"));
+    let idx = HnswIndex::builder(4, DistanceMetric::L2)
+        .capacity(8)
+        .seed(7)
+        .build()
+        .unwrap();
+    idx.add(1, &[1.0, 0.0, 0.0, 0.0]).unwrap();
+    idx.add(2, &[0.0, 1.0, 0.0, 0.0]).unwrap();
+    idx.add(3, &[0.0, 0.0, 1.0, 0.0]).unwrap();
+    idx.save(&path).unwrap();
+    let bytes = fs::read(&path).unwrap();
+    let _ = fs::remove_file(&path);
+    bytes
+}
+
+fn write_tmp(name: &str, bytes: &[u8]) -> std::path::PathBuf {
+    let p = std::env::temp_dir().join(format!("vanedb_corruption_{name}.bin"));
+    let mut f = fs::File::create(&p).unwrap();
+    f.write_all(bytes).unwrap();
+    p
+}
+
+#[test]
+fn hnsw_load_rejects_invalid_magic() {
+    let mut bytes = valid_hnsw_bytes("bad_magic");
+    bytes[0..4].copy_from_slice(&0xDEADBEEFu32.to_le_bytes());
+    let p = write_tmp("bad_magic", &bytes);
+    let err = match HnswIndex::load(&p) {
+        Ok(_) => panic!("load should have failed"),
+        Err(e) => e,
+    };
+    assert!(format!("{err}").contains("magic"), "got: {err}");
+    let _ = fs::remove_file(&p);
+}
+
+#[test]
+fn hnsw_load_rejects_unsupported_version() {
+    let mut bytes = valid_hnsw_bytes("bad_version");
+    bytes[4..8].copy_from_slice(&999u32.to_le_bytes());
+    let p = write_tmp("bad_version", &bytes);
+    let err = match HnswIndex::load(&p) {
+        Ok(_) => panic!("load should have failed"),
+        Err(e) => e,
+    };
+    assert!(format!("{err}").contains("version"), "got: {err}");
+    let _ = fs::remove_file(&p);
+}
+
+#[test]
+fn hnsw_load_rejects_truncated_header() {
+    let p = write_tmp("trunc_header", b"HNS"); // 3 bytes — shorter than 8-byte header
+    assert!(HnswIndex::load(&p).is_err());
+    let _ = fs::remove_file(&p);
+}
+
+#[test]
+fn hnsw_load_rejects_garbage_payload() {
+    // Valid magic+version but bincode payload is junk.
+    let mut bytes = HNSW_MAGIC.to_le_bytes().to_vec();
+    bytes.extend_from_slice(&HNSW_VERSION.to_le_bytes());
+    bytes.extend_from_slice(&[0xFF; 32]);
+    let p = write_tmp("garbage_payload", &bytes);
+    assert!(HnswIndex::load(&p).is_err());
+    let _ = fs::remove_file(&p);
+}
+
+#[test]
+fn hnsw_load_rejects_invalid_metric() {
+    // Path: build a valid index, save, then patch the serialized `metric` u32
+    // to an invalid value. We can't surgically patch a bincode field without
+    // parsing — but we can construct a bad index in memory by saving with a
+    // valid metric and then trying to load with the metric u32 mutated.
+    //
+    // Easier strategy: load + re-save with serde isn't exposed, so instead we
+    // test the path indirectly by creating a custom HnswData. That requires
+    // private types — so we settle for the public-API smoke test below
+    // (a real malformed file just ends up failing earlier in deserialize).
+    //
+    // The metric validation IS exercised in the public API by the round-trip:
+    // saving/loading with each valid metric must succeed.
+    for &metric in &[
+        DistanceMetric::L2,
+        DistanceMetric::Cosine,
+        DistanceMetric::Dot,
+    ] {
+        let path = std::env::temp_dir().join(format!("vanedb_metric_{metric:?}.bin"));
+        let idx = HnswIndex::builder(3, metric).capacity(4).build().unwrap();
+        idx.add(1, &[1.0, 0.0, 0.0]).unwrap();
+        idx.save(&path).unwrap();
+        let loaded = HnswIndex::load(&path).unwrap();
+        assert_eq!(loaded.metric(), metric);
+        let _ = fs::remove_file(&path);
+    }
+}
+
+#[test]
+fn hnsw_save_load_preserves_rng_determinism() {
+    // Critical regression test for the post-load RNG state. Before this port,
+    // `load()` reseeded the RNG with `seed_from_u64(count as u64)` instead of
+    // the original seed, so subsequent inserts diverged from a never-saved
+    // index using the same builder seed. Now `load()` replays `count`
+    // get_level calls so the next insert sees the same RNG state.
+    let path = std::env::temp_dir().join("vanedb_rng_determinism.bin");
+
+    // Reference: build, insert 5, then insert 5 more, never saving.
+    let reference = HnswIndex::builder(4, DistanceMetric::L2)
+        .capacity(20)
+        .seed(123)
+        .build()
+        .unwrap();
+    for i in 0..10u64 {
+        reference.add(i, &[i as f32, 0.0, 0.0, 0.0]).unwrap();
+    }
+
+    // Round-trip: build, insert 5, save, load, insert 5 more.
+    let saved = HnswIndex::builder(4, DistanceMetric::L2)
+        .capacity(20)
+        .seed(123)
+        .build()
+        .unwrap();
+    for i in 0..5u64 {
+        saved.add(i, &[i as f32, 0.0, 0.0, 0.0]).unwrap();
+    }
+    saved.save(&path).unwrap();
+
+    let loaded = HnswIndex::load(&path).unwrap();
+    for i in 5..10u64 {
+        loaded.add(i, &[i as f32, 0.0, 0.0, 0.0]).unwrap();
+    }
+
+    // Search results must match: same seed + same insertion order should yield
+    // identical graph topology, hence identical search results.
+    let q = [3.5, 0.0, 0.0, 0.0];
+    let r_ref = reference.search(&q, 5).unwrap();
+    let r_loaded = loaded.search(&q, 5).unwrap();
+    assert_eq!(r_ref.len(), r_loaded.len());
+    for (a, b) in r_ref.iter().zip(r_loaded.iter()) {
+        assert_eq!(a.id, b.id, "RNG state drift after save/load");
+    }
+
+    let _ = fs::remove_file(&path);
+}
+
+// ---- mmap corruption tests ----
+
+#[cfg(feature = "mmap")]
+#[test]
+fn mmap_load_rejects_unsupported_version() {
+    let path = std::env::temp_dir().join("vanedb_mmap_bad_version.bin");
+    let mut data = Vec::new();
+    data.extend_from_slice(&0x564E4442u32.to_le_bytes()); // "VNDB"
+    data.extend_from_slice(&999u32.to_le_bytes()); // unsupported
+    data.extend_from_slice(&3u64.to_le_bytes()); // dim
+    data.extend_from_slice(&0u64.to_le_bytes()); // num_vectors
+    data.extend_from_slice(&0u32.to_le_bytes()); // metric
+    data.extend_from_slice(&0u32.to_le_bytes()); // reserved
+    fs::write(&path, &data).unwrap();
+    assert!(MmapVectorStore::open(&path).is_err());
+    let _ = fs::remove_file(&path);
+}
+
+#[cfg(feature = "mmap")]
+#[test]
+fn mmap_load_rejects_zero_dim_with_vectors() {
+    let path = std::env::temp_dir().join("vanedb_mmap_zero_dim.bin");
+    let mut data = Vec::new();
+    data.extend_from_slice(&0x564E4442u32.to_le_bytes());
+    data.extend_from_slice(&1u32.to_le_bytes());
+    data.extend_from_slice(&0u64.to_le_bytes()); // dim = 0 (corrupted)
+    data.extend_from_slice(&5u64.to_le_bytes()); // but claims 5 vectors
+    data.extend_from_slice(&0u32.to_le_bytes());
+    data.extend_from_slice(&0u32.to_le_bytes());
+    fs::write(&path, &data).unwrap();
+    assert!(MmapVectorStore::open(&path).is_err());
+    let _ = fs::remove_file(&path);
+}
+
+#[cfg(feature = "mmap")]
+#[test]
+fn mmap_load_rejects_truncated_data() {
+    // Header claims 1000 vectors but file ends after the header.
+    let path = std::env::temp_dir().join("vanedb_mmap_truncated.bin");
+    let mut data = Vec::new();
+    data.extend_from_slice(&0x564E4442u32.to_le_bytes());
+    data.extend_from_slice(&1u32.to_le_bytes());
+    data.extend_from_slice(&3u64.to_le_bytes());
+    data.extend_from_slice(&1000u64.to_le_bytes());
+    data.extend_from_slice(&0u32.to_le_bytes());
+    data.extend_from_slice(&0u32.to_le_bytes());
+    fs::write(&path, &data).unwrap();
+    assert!(MmapVectorStore::open(&path).is_err());
+    let _ = fs::remove_file(&path);
+}
+
+#[cfg(feature = "mmap")]
+#[test]
+fn mmap_load_rejects_size_overflow() {
+    // num_vectors * dim that overflows usize when multiplied by sizeof(f32).
+    let path = std::env::temp_dir().join("vanedb_mmap_overflow.bin");
+    let mut data = Vec::new();
+    data.extend_from_slice(&0x564E4442u32.to_le_bytes());
+    data.extend_from_slice(&1u32.to_le_bytes());
+    data.extend_from_slice(&u64::MAX.to_le_bytes()); // dim huge
+    data.extend_from_slice(&u64::MAX.to_le_bytes()); // num_vectors huge
+    data.extend_from_slice(&0u32.to_le_bytes());
+    data.extend_from_slice(&0u32.to_le_bytes());
+    fs::write(&path, &data).unwrap();
+    assert!(MmapVectorStore::open(&path).is_err());
+    let _ = fs::remove_file(&path);
+}
+
+#[cfg(feature = "mmap")]
+#[test]
+fn mmap_load_rejects_invalid_metric() {
+    let path = std::env::temp_dir().join("vanedb_mmap_bad_metric.bin");
+    // Valid header, dim=3, num=0, metric=99 (out of range)
+    let mut data = Vec::new();
+    data.extend_from_slice(&0x564E4442u32.to_le_bytes());
+    data.extend_from_slice(&1u32.to_le_bytes());
+    data.extend_from_slice(&3u64.to_le_bytes());
+    data.extend_from_slice(&0u64.to_le_bytes());
+    data.extend_from_slice(&99u32.to_le_bytes()); // bogus metric
+    data.extend_from_slice(&0u32.to_le_bytes());
+    fs::write(&path, &data).unwrap();
+    assert!(MmapVectorStore::open(&path).is_err());
+    let _ = fs::remove_file(&path);
+}
+
+#[cfg(feature = "mmap")]
+#[test]
+fn mmap_search_rejects_zero_k() {
+    let path = std::env::temp_dir().join("vanedb_mmap_zero_k.bin");
+    let mut b = MmapVectorStoreBuilder::new(3, DistanceMetric::L2).unwrap();
+    b.add(1, &[1.0, 2.0, 3.0]).unwrap();
+    b.save(&path).unwrap();
+    let store = MmapVectorStore::open(&path).unwrap();
+    assert!(store.search(&[1.0, 2.0, 3.0], 0).is_err());
+    let _ = fs::remove_file(&path);
+}

--- a/vanedb/tests/hnsw_tests.rs
+++ b/vanedb/tests/hnsw_tests.rs
@@ -157,3 +157,38 @@ fn hnsw_is_send_sync() {
     fn assert_send_sync<T: Send + Sync>() {}
     assert_send_sync::<HnswIndex>();
 }
+
+/// Drive the thread-local visited bitmap through at least one u16 epoch wrap
+/// (~65k searches) and verify the zero-out fallback path still produces
+/// correct nearest-neighbor results. Mirrors the wrap test from
+/// vanedb-cpp PR #8 ("search_layer epoch wrap").
+#[test]
+fn hnsw_visited_bitmap_epoch_wrap_correctness() {
+    let dim = 4;
+    let n = 100usize;
+    let idx = HnswIndex::builder(dim, DistanceMetric::L2)
+        .capacity(n)
+        .seed(42)
+        .build()
+        .unwrap();
+    for i in 0..n as u64 {
+        let v: Vec<f32> = (0..dim).map(|d| (i + d as u64) as f32).collect();
+        idx.add(i, &v).unwrap();
+    }
+
+    // First search establishes a baseline before any wrap.
+    let query: Vec<f32> = vec![5.0, 5.0, 5.0, 5.0];
+    let baseline = idx.search(&query, 5).unwrap();
+
+    // Drive the per-thread epoch counter past the u16 boundary. 70_000 searches
+    // wraps once and exercises the zero-out fallback inside `VisitedBuffer::begin`.
+    for _ in 0..70_000 {
+        let _ = idx.search(&query, 5).unwrap();
+    }
+
+    let after_wrap = idx.search(&query, 5).unwrap();
+    assert_eq!(baseline.len(), after_wrap.len());
+    for (a, b) in baseline.iter().zip(after_wrap.iter()) {
+        assert_eq!(a.id, b.id, "result drifted across epoch wrap");
+    }
+}


### PR DESCRIPTION
## Summary
Pulls in changes from [tsvet01/vanedb](https://github.com/tsvet01/vanedb) (the C++ reference implementation) since the last sync. Three categories:

- **Perf**: HNSW search hot path now uses a thread-local versioned `u16` bitmap for the visited set instead of a per-call `HashSet`. Sized once per max-elements; epoch wraps every ~65k searches. Mirrors the C++ optimization in [PR #8](https://github.com/tsvet01/vanedb/pull/8).
- **Hardening**: HNSW persistence gains a `MAGIC` + `VERSION` header and full semantic-invariant validation on load (`count <= max_elements`, `entry_point < count`, `max_level` bounds, neighbor indices all live). RNG state is preserved across save/load by storing the original seed and replaying `count` `get_level` calls — matches the v2 C++ file format. Both `HnswIndex::save` and `MmapVectorStoreBuilder::save` now `sync_all()` before rename. Mirrors C++ [PR #5](https://github.com/tsvet01/vanedb/pull/5) + production hardening.
- **Tests**: +13 (75 → 88). New `tests/corruption_tests.rs` covers magic/version/truncation/overflow/invalid-metric paths plus an end-to-end RNG-determinism regression. New `hnsw_visited_bitmap_epoch_wrap_correctness` drives 70k searches to exercise the bitmap wrap.

The C++ Distance Strategy Pattern refactor ([PR #7](https://github.com/tsvet01/vanedb/pull/7)) needs no port — Rust always dispatched distance via function pointer at construction time. The `quiverdb → vanedb` rename ([PR #9](https://github.com/tsvet01/vanedb/pull/9)) is also not applicable; this Rust crate never used the old name.

## Breaking change
On-disk HNSW file format gains an 8-byte header. Files written by previous versions cannot be loaded. Pre-1.0, breakage in this lane is expected.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --exclude vanedb-py --all-targets --features mmap -- -D warnings`
- [x] `cargo test --workspace --exclude vanedb-py --features mmap` — 88 passing
- [ ] Benchmark delta on `hnsw_bench` (running locally; will paste numbers as a comment)
- [ ] CI green

## Branch ordering
This is independent of `perf/vector-store-search` (no overlapping files). Suggest landing `sync/from-cpp-v0.1.0` first so the perf branch rebases onto a hardened persistence layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)