### PR TITLE
docs(readme): replace stub with implementations overview and cross-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # VaneDB
 
-Embeddable vector database for edge AI.
+Embeddable vector database for edge AI — Rust crate with Python (PyO3) and WASM bindings.
 
-## Status
+## Implementations
 
-Under construction — Rust rewrite of [QuiverDB](https://github.com/tsvet01/quiverdb).
+- **Rust** (this repo) — `cargo add vanedb`, Python via `vanedb-py` (PyO3), WASM via `vanedb-wasm` (wasm-bindgen).
+- **C++** — [vanedb/vanedb-cpp](https://github.com/vanedb/vanedb-cpp), header-only, no Rust toolchain required.
+
+Both maintained side-by-side under the [@vanedb](https://github.com/vanedb) org. Features generally land in Rust first; core algorithms and persistence formats are synced to C++.
 
 ## License
 


### PR DESCRIPTION
## Summary
The README still said "Under construction — Rust rewrite of QuiverDB" with a link to a doubly-renamed repo. This repo is now feature-complete (Rust core + Python via PyO3 + WASM) and the C++ implementation now lives at [vanedb/vanedb-cpp](https://github.com/vanedb/vanedb-cpp) under the same org.

## Changes
- Replace the one-line "Under construction" tagline with an honest description (Rust crate, PyO3, WASM).
- Add an "Implementations" section pointing at `vanedb-cpp` and stating the Rust-leads-features alignment policy.

This is a minimal cross-link pass — a fuller README (quickstart, performance, API examples) is a separate task.

## Test plan
- [x] Markdown renders correctly (trivial)
- [ ] Reviewer to confirm tone/voice matches the project

🤖 Generated with [Claude Code](https://claude.com/claude-code)