### PR TITLE
chore(security): add CODEOWNERS and Dependabot config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-# See https://docs.github.com/repositories/managing-your-repositorys-settings-and-policies/about-code-owners
-# Default owner for everything in this repo.
 * @tsvet01

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# See https://docs.github.com/repositories/managing-your-repositorys-settings-and-policies/about-code-owners
+# Default owner for everything in this repo.
+* @tsvet01

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
Adds a minimal security baseline for this repo: a CODEOWNERS file and a Dependabot config.

## Changes
- `.github/CODEOWNERS` — `* @tsvet01`. Low immediate value while solo, but future-proofs review routing if additional maintainers are added later.
- `.github/dependabot.yml` — weekly updates for:
  - `github-actions` (workflow `uses:` pins)
  - `cargo` (workspace: `vanedb`, `vanedb-py`, `vanedb-wasm`)

## Notes
- Companion PR in `vanedb/vanedb-cpp` covers the C++ repo's pip/actions ecosystems.
- This is the first PR that exercises the newly-applied ruleset on `main` (5 required status checks: Check & Lint + Test x4 platforms; Performance Regression Check intentionally not required to keep merges fast).
- Manual settings still pending in the UI: 2FA enforcement (org), fork-PR workflow approval (org/repo Actions), secret scanning + push protection (per repo).

## Test plan
- [ ] CI green (Check & Lint, Test x4)
- [ ] Codeowner auto-assignment fires on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)