### PR TITLE
ci: add iOS and Android cross-compile jobs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+# Least privilege: checks out and benchmarks code, writes only to the step summary.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+# Least privilege: every job here only reads the repo and runs builds/tests.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,32 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Test WASM
         run: cd vanedb-wasm && wasm-pack test --node
+
+  build-ios:
+    name: Build (iOS arm64)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios
+      # Cross-compile only: there is no iOS test runner, mirroring the
+      # build-only verification the C++ repo uses for mobile.
+      - run: cargo build -p vanedb --target aarch64-apple-ios --features mmap --release
+
+  build-android:
+    name: Build (Android arm64-v8a, x86_64)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android, x86_64-linux-android
+      - name: Set up Android NDK
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r26b
+      - name: Install cargo-ndk
+        run: cargo install cargo-ndk --locked
+      - name: Cross-compile core for Android
+        run: cargo ndk -t arm64-v8a -t x86_64 build -p vanedb --features mmap --release


### PR DESCRIPTION
## Summary
Brings mobile build coverage to parity with `vanedb-cpp` (which already has CI-verified iOS arm64 + Android arm64-v8a builds).

- **build-ios** — `aarch64-apple-ios` on `macos-latest`, build-only (no iOS test runner, same as the C++ repo's model).
- **build-android** — `arm64-v8a` + `x86_64` via `cargo-ndk` (NDK r26b) on `ubuntu-latest`.

Both are **informational** checks — not added to the required-status-checks ruleset, matching how the C++ repo treats its mobile jobs.

## Why build-only
There's no hosted iOS/Android test runner; the C++ repo verifies mobile by successful cross-compilation, and this mirrors that.

## Note
Couldn't verify locally — this dev machine has a Homebrew-rust-vs-rustup PATH conflict that breaks local cross-compilation. The CI uses a clean `dtolnay/rust-toolchain`, so this PR's own run is the verification.

## Test plan
- [ ] build-ios job green
- [ ] build-android job green (both ABIs)
- [ ] existing 5 required checks still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)