### PR TITLE
docs: mark CUDA stub as experimental/unimplemented

### DIFF
--- a/vanedb/src/gpu/cuda.rs
+++ b/vanedb/src/gpu/cuda.rs
@@ -1,9 +1,15 @@
+//! EXPERIMENTAL / UNIMPLEMENTED: this is a stub. Every method returns an error.
+//! There is no NVIDIA hardware in CI to validate a real implementation, so CUDA
+//! is intentionally unimplemented. Metal (`gpu::metal`) is the supported GPU path.
+//! Mirrors the dormant `cuda_distance.cuh` in the C++ implementation — neither
+//! has a working CUDA backend today.
+
 use crate::error::{Result, VaneError};
 use crate::gpu::GpuMetric;
 use crate::store::SearchResult;
 
-/// CUDA GPU compute for distance calculations.
-/// Requires NVIDIA GPU with CUDA toolkit installed.
+/// Unimplemented CUDA compute stub. Construction always fails — see the module
+/// docs. Requires NVIDIA GPU + CUDA toolkit and a real implementation first.
 pub struct CudaCompute {
     _private: (),
 }


### PR DESCRIPTION
## Summary
`cuda.rs`'s doc implied a working CUDA backend, but every method returns an error — it's a stub. Adds a module banner stating it's unimplemented (no NVIDIA hardware in CI to validate one). Metal is the supported GPU path.

## Why
Companion to the same labeling pass on `vanedb-cpp` (its `cuda_distance.cuh` kernels are dormant/unwired). The honest parity statement: neither implementation has a working CUDA backend today, so both repos now say so plainly rather than implying otherwise.

## Test plan
- [ ] CI green (doc-only change; `cargo fmt`/clippy unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)