### PR TITLE
fix(hnsw): persist only inserted vectors, not full capacity (v2 format)

### DIFF
--- a/vanedb/src/hnsw/persistence.rs
+++ b/vanedb/src/hnsw/persistence.rs
@@ -20,7 +20,11 @@ use crate::error::{Result, VaneError};
 /// compatibility with files written before the rename. Rust never shipped
 /// pre-rename, so we use a clean per-format magic.
 const MAGIC: u32 = u32::from_le_bytes(*b"HNSW");
-const VERSION: u32 = 1;
+/// v1 stored the full pre-allocated arrays (`max_elements` entries even when
+/// only `count` were inserted). v2 stores only the `count` live entries and
+/// re-expands to `max_elements` on load (issue #18). v1 files remain loadable.
+const VERSION: u32 = 2;
+const V1: u32 = 1;
 const HEADER_LEN: usize = 8;
 
 #[derive(Serialize, Deserialize)]
@@ -83,10 +87,12 @@ impl HnswIndex {
             count: inner.count,
             entry_point: inner.entry_point,
             max_level: inner.max_level,
-            vectors: inner.vectors.clone(),
-            ext_ids: inner.ext_ids.clone(),
-            levels: inner.levels.clone(),
-            neighbors: inner.neighbors.clone(),
+            // v2: persist only the `count` live entries, not the full
+            // pre-allocated capacity; load() re-expands to max_elements.
+            vectors: inner.vectors[..inner.count * self.dim].to_vec(),
+            ext_ids: inner.ext_ids[..inner.count].to_vec(),
+            levels: inner.levels[..inner.count].to_vec(),
+            neighbors: inner.neighbors[..inner.count].to_vec(),
             id_map: inner.id_map.clone(),
         };
 
@@ -123,7 +129,7 @@ impl HnswIndex {
             return Err(VaneError::Io("invalid magic".to_string()));
         }
         let version = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
-        if version != VERSION {
+        if version != V1 && version != VERSION {
             return Err(VaneError::Io(format!("unsupported version: {version}")));
         }
 
@@ -190,10 +196,18 @@ impl HnswIndex {
                 ));
             }
         }
-        if data.neighbors.len() > data.max_elements {
-            return Err(VaneError::Io(
-                "corrupted file: neighbors size exceeds max_elements".to_string(),
-            ));
+        // Array lengths are version-specific: v1 stored full pre-allocated
+        // arrays, v2 stores only the `count` live entries.
+        let stored = if version == V1 {
+            data.max_elements
+        } else {
+            data.count
+        };
+        if data.neighbors.len() != stored {
+            return Err(VaneError::Io(format!(
+                "corrupted file: neighbors length {} != expected {stored}",
+                data.neighbors.len()
+            )));
         }
         for nbs in data.neighbors.iter().take(data.count) {
             if nbs.len() > (MAX_LEVEL as usize) + 1 {
@@ -211,20 +225,31 @@ impl HnswIndex {
                 }
             }
         }
-        let expected_vecs_len = data
+        let full_vecs_len = data
             .max_elements
             .checked_mul(data.dim)
             .ok_or_else(|| VaneError::Io("size overflow".to_string()))?;
-        if data.vectors.len() != expected_vecs_len {
+        if data.vectors.len() != stored * data.dim {
             return Err(VaneError::Io(
-                "corrupted file: vectors length != max_elements * dim".to_string(),
+                "corrupted file: vectors length != expected * dim".to_string(),
             ));
         }
-        if data.ext_ids.len() != data.max_elements || data.levels.len() != data.max_elements {
+        if data.ext_ids.len() != stored || data.levels.len() != stored {
             return Err(VaneError::Io(
-                "corrupted file: ext_ids/levels length != max_elements".to_string(),
+                "corrupted file: ext_ids/levels length != expected".to_string(),
             ));
         }
+
+        // Re-expand to the pre-allocated capacity layout Inner expects. For
+        // v1 the arrays are already full-length, so these are no-ops.
+        let mut vectors = data.vectors;
+        vectors.resize(full_vecs_len, 0.0);
+        let mut ext_ids = data.ext_ids;
+        ext_ids.resize(data.max_elements, 0);
+        let mut levels = data.levels;
+        levels.resize(data.max_elements, 0);
+        let mut neighbors = data.neighbors;
+        neighbors.resize_with(data.max_elements, Vec::new);
 
         // Reconstitute RNG: seed from the original seed, then advance through
         // `count` get_level calls so the next add() resumes the original
@@ -248,11 +273,11 @@ impl HnswIndex {
             mult: data.mult,
             seed: data.seed,
             inner: RwLock::new(Inner {
-                vectors: data.vectors,
-                ext_ids: data.ext_ids,
+                vectors,
+                ext_ids,
                 id_map: data.id_map,
-                levels: data.levels,
-                neighbors: data.neighbors,
+                levels,
+                neighbors,
                 entry_point: data.entry_point,
                 max_level: data.max_level,
                 count: data.count,

--- a/vanedb/tests/corruption_tests.rs
+++ b/vanedb/tests/corruption_tests.rs
@@ -12,7 +12,94 @@ use vanedb::{DistanceMetric, HnswIndex};
 use vanedb::{MmapVectorStore, MmapVectorStoreBuilder};
 
 const HNSW_MAGIC: u32 = u32::from_le_bytes(*b"HNSW");
-const HNSW_VERSION: u32 = 1;
+const HNSW_VERSION: u32 = 2;
+
+/// Field-order mirror of the private `HnswData` struct in
+/// `src/hnsw/persistence.rs` (bincode encodes by field order, so this
+/// serializes identically). Used to hand-craft v1/v2 payloads.
+#[derive(serde::Serialize)]
+struct HnswDataMirror {
+    dim: usize,
+    metric: u32,
+    max_elements: usize,
+    m: usize,
+    m_max: usize,
+    m_max0: usize,
+    ef_construction: usize,
+    ef_search: usize,
+    mult: f64,
+    seed: u64,
+    count: usize,
+    entry_point: Option<usize>,
+    max_level: i32,
+    vectors: Vec<f32>,
+    ext_ids: Vec<u64>,
+    levels: Vec<i32>,
+    neighbors: Vec<Vec<Vec<usize>>>,
+    id_map: std::collections::HashMap<u64, usize>,
+}
+
+/// A consistent 2-of-4-slots index in the legacy v1 layout: arrays span the
+/// full pre-allocated capacity, not just the inserted count.
+fn v1_full_capacity_payload() -> HnswDataMirror {
+    HnswDataMirror {
+        dim: 2,
+        metric: 0, // L2
+        max_elements: 4,
+        m: 2,
+        m_max: 2,
+        m_max0: 4,
+        ef_construction: 10,
+        ef_search: 10,
+        mult: 1.0,
+        seed: 7,
+        count: 2,
+        entry_point: Some(0),
+        max_level: 0,
+        vectors: vec![1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+        ext_ids: vec![10, 20, 0, 0],
+        levels: vec![0; 4],
+        neighbors: vec![vec![vec![1]], vec![vec![0]], vec![], vec![]],
+        id_map: std::collections::HashMap::from([(10, 0), (20, 1)]),
+    }
+}
+
+fn hnsw_file_bytes(version: u32, data: &HnswDataMirror) -> Vec<u8> {
+    let mut bytes = HNSW_MAGIC.to_le_bytes().to_vec();
+    bytes.extend_from_slice(&version.to_le_bytes());
+    bytes.extend_from_slice(&bincode::serialize(data).unwrap());
+    bytes
+}
+
+#[test]
+fn hnsw_load_accepts_v1_full_capacity_files() {
+    let bytes = hnsw_file_bytes(1, &v1_full_capacity_payload());
+    let p = write_tmp("v1_compat", &bytes);
+    let idx = HnswIndex::load(&p).unwrap();
+    assert_eq!(idx.size(), 2);
+    assert_eq!(idx.capacity(), 4);
+    assert_eq!(idx.get_vector(10).unwrap(), vec![1.0, 0.0]);
+    let results = idx.search(&[1.0, 0.1], 1).unwrap();
+    assert_eq!(results[0].id, 10);
+    // Spare capacity from the v1 file must remain usable.
+    idx.add(30, &[0.5, 0.5]).unwrap();
+    assert_eq!(idx.size(), 3);
+    let _ = fs::remove_file(&p);
+}
+
+#[test]
+fn hnsw_load_rejects_v2_with_capacity_sized_arrays() {
+    // The same full-capacity arrays are NOT valid under v2, which stores
+    // exactly `count` entries per array.
+    let bytes = hnsw_file_bytes(2, &v1_full_capacity_payload());
+    let p = write_tmp("v2_full_arrays", &bytes);
+    let err = match HnswIndex::load(&p) {
+        Ok(_) => panic!("load should have failed"),
+        Err(e) => e,
+    };
+    assert!(format!("{err}").contains("length"), "got: {err}");
+    let _ = fs::remove_file(&p);
+}
 
 /// Build a minimal valid HNSW file on disk, then return the bytes so tests can
 /// mutate specific fields and exercise validation paths in `load`. The `tag`

--- a/vanedb/tests/hnsw_tests.rs
+++ b/vanedb/tests/hnsw_tests.rs
@@ -72,6 +72,31 @@ fn hnsw_cosine_search() {
 }
 
 #[test]
+fn hnsw_save_size_proportional_to_count_not_capacity() {
+    // Issue #18: a capacity-1000 index holding 10 vectors must not write
+    // ~capacity worth of data. 10 vectors x 32 dims x 4 bytes is ~1.3 KB of
+    // payload; 20 KB allows generous encoding overhead, while the full
+    // pre-allocated arrays would exceed 140 KB.
+    let path = std::env::temp_dir().join("vanedb_test_hnsw_compact.bin");
+    let idx = HnswIndex::builder(32, DistanceMetric::L2)
+        .capacity(1000)
+        .seed(42)
+        .build()
+        .unwrap();
+    for i in 0..10u64 {
+        let v: Vec<f32> = (0..32).map(|d| (i * 32 + d) as f32).collect();
+        idx.add(i, &v).unwrap();
+    }
+    idx.save(&path).unwrap();
+    let size = std::fs::metadata(&path).unwrap().len();
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        size < 20_000,
+        "saved file is {size} bytes — it scales with capacity, not inserted count"
+    );
+}
+
+#[test]
 fn hnsw_save_load_roundtrip() {
     let dim = 8;
     let path = std::env::temp_dir().join("vanedb_test_hnsw.bin");

--- a/vanedb/tests/hnsw_tests.rs
+++ b/vanedb/tests/hnsw_tests.rs
@@ -97,6 +97,26 @@ fn hnsw_save_size_proportional_to_count_not_capacity() {
 }
 
 #[test]
+fn hnsw_empty_index_save_load_roundtrip() {
+    // v2 stores zero-length arrays for an empty index; load must re-expand
+    // to full capacity so subsequent adds work.
+    let path = std::env::temp_dir().join("vanedb_test_hnsw_empty.bin");
+    let idx = HnswIndex::builder(4, DistanceMetric::L2)
+        .capacity(10)
+        .seed(42)
+        .build()
+        .unwrap();
+    idx.save(&path).unwrap();
+    let loaded = HnswIndex::load(&path).unwrap();
+    let _ = std::fs::remove_file(&path);
+    assert_eq!(loaded.size(), 0);
+    assert_eq!(loaded.capacity(), 10);
+    assert!(loaded.search(&[0.0; 4], 3).unwrap().is_empty());
+    loaded.add(1, &[1.0, 2.0, 3.0, 4.0]).unwrap();
+    assert_eq!(loaded.size(), 1);
+}
+
+#[test]
 fn hnsw_save_load_roundtrip() {
     let dim = 8;
     let path = std::env::temp_dir().join("vanedb_test_hnsw.bin");


### PR DESCRIPTION
Fixes #18.

## Problem

`HnswIndex::save()` cloned every pre-allocated array wholesale: `vectors` is `max_elements * dim` floats and `ext_ids`/`levels`/`neighbors` are `max_elements` long regardless of how many vectors were actually inserted. A capacity-1000 index holding 10x32-dim vectors wrote **149,145 bytes** for ~1.3 KB of live data; the reporter measured 18x bloat in real use.

## Fix

File format **v2**: each array stores exactly `count` entries. `load()` re-expands to `max_elements`, so capacity, subsequent inserts, and RNG-replay determinism are preserved. The same 10-vector index now writes **2,625 bytes** (57x smaller for this shape; savings grow with unused capacity).

**v1 files remain loadable** — the version gate accepts both, and length validation is version-aware.

## Tests

- `hnsw_save_size_proportional_to_count_not_capacity` — red before the fix (149 KB), green after (2.6 KB)
- `hnsw_load_accepts_v1_full_capacity_files` — hand-crafted v1 payload loads, searches, and accepts new inserts (mutation-checked: fails if v1 support is dropped)
- `hnsw_load_rejects_v2_with_capacity_sized_arrays` — v2 length validation
- `hnsw_empty_index_save_load_roundtrip` — count=0 edge through the compact path
- All existing suites pass, including `hnsw_save_load_preserves_rng_determinism` which exercises the re-expansion path

Note: vanedb-cpp has the same bug (`write_vec(f, vectors_)` writes the full pre-allocated array) — filing a mirror issue there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H