### PR TITLE
perf(store): top-k via select_nth_unstable + static metric dispatch

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Install critcmp
-        run: cargo install critcmp
+        run: cargo install critcmp --version 0.1.8 --locked
 
       # Pass explicit --bench targets so cargo bench skips the lib's
       # libtest harness (which doesn't accept --save-baseline) regardless

--- a/vanedb/Cargo.toml
+++ b/vanedb/Cargo.toml
@@ -29,6 +29,8 @@ proptest = "1.6"
 criterion = { version = "0.8", features = ["html_reports"] }
 
 [lib]
+# Skip the libtest harness under `cargo bench`; it doesn't accept criterion
+# CLI flags like --save-baseline that the [[bench]] targets need.
 bench = false
 
 [[bench]]

--- a/vanedb/src/distance/mod.rs
+++ b/vanedb/src/distance/mod.rs
@@ -31,7 +31,7 @@ pub fn distance_fn(metric: DistanceMetric) -> DistanceFn {
     }
 }
 
-fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
+pub(crate) fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
     #[cfg(target_arch = "aarch64")]
     {
         neon::l2_squared(a, b)
@@ -50,7 +50,7 @@ fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
     }
 }
 
-fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
+pub(crate) fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
     #[cfg(target_arch = "aarch64")]
     {
         neon::cosine_distance(a, b)
@@ -69,7 +69,7 @@ fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
     }
 }
 
-fn dot_distance(a: &[f32], b: &[f32]) -> f32 {
+pub(crate) fn dot_distance(a: &[f32], b: &[f32]) -> f32 {
     #[cfg(target_arch = "aarch64")]
     {
         neon::dot_distance(a, b)

--- a/vanedb/src/store/search_result.rs
+++ b/vanedb/src/store/search_result.rs
@@ -23,9 +23,12 @@ impl PartialOrd for SearchResult {
 
 impl Ord for SearchResult {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // Tie-break by id so unstable top-k selection produces a deterministic
+        // ordering across equal-distance results.
         self.distance
             .partial_cmp(&other.distance)
             .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| self.id.cmp(&other.id))
     }
 }
 

--- a/vanedb/src/store/vector_store.rs
+++ b/vanedb/src/store/vector_store.rs
@@ -2,14 +2,13 @@ use std::collections::HashMap;
 
 use parking_lot::RwLock;
 
-use crate::distance::{distance_fn, DistanceFn, DistanceMetric};
+use crate::distance::{self as d, DistanceMetric};
 use crate::error::{Result, VaneError};
 use crate::store::SearchResult;
 
 pub struct VectorStore {
     dim: usize,
     metric: DistanceMetric,
-    dist_fn: DistanceFn,
     inner: RwLock<Inner>,
 }
 
@@ -27,7 +26,6 @@ impl VectorStore {
         Ok(Self {
             dim,
             metric,
-            dist_fn: distance_fn(metric),
             inner: RwLock::new(Inner {
                 ids: Vec::new(),
                 data: Vec::new(),
@@ -124,16 +122,25 @@ impl VectorStore {
             return Ok(Vec::new());
         }
 
-        let mut results: Vec<SearchResult> = (0..n)
-            .map(|i| {
-                let start = i * self.dim;
-                let vec = &inner.data[start..start + self.dim];
-                SearchResult::new(inner.ids[i], (self.dist_fn)(query, vec))
-            })
-            .collect();
+        debug_assert_eq!(inner.data.len(), n * self.dim);
+        let vecs = inner.data.chunks_exact(self.dim).zip(&inner.ids);
+        let mut results: Vec<SearchResult> = match self.metric {
+            DistanceMetric::L2 => vecs
+                .map(|(v, &id)| SearchResult::new(id, d::l2_squared(query, v)))
+                .collect(),
+            DistanceMetric::Cosine => vecs
+                .map(|(v, &id)| SearchResult::new(id, d::cosine_distance(query, v)))
+                .collect(),
+            DistanceMetric::Dot => vecs
+                .map(|(v, &id)| SearchResult::new(id, d::dot_distance(query, v)))
+                .collect(),
+        };
 
-        results.sort();
-        results.truncate(k);
+        if k < results.len() {
+            results.select_nth_unstable(k - 1);
+            results.truncate(k);
+        }
+        results.sort_unstable();
         Ok(results)
     }
 }


### PR DESCRIPTION
Supersedes #1 — a clean squashed rebase of that branch onto current main (its intermediate commits conflicted with the visited-buffer refactor; the final states had converged). One fix over the original: deduplicated the `[lib]` section that main had since gained.

## What

- `search()` collected and **fully sorted all n results** (O(n log n)) through an indirect `dist_fn` pointer.
- Now: monomorphized per-metric scan loops (branch once per call, not per vector), then `select_nth_unstable(k-1)` + truncate + sort of just k — O(n + k log k).
- `SearchResult` ties break by id so unstable selection stays deterministic.
- bench.yml: pin critcmp `--version 0.1.8 --locked`.

## Verified (criterion A/B, Apple Silicon, 128d)

| bench | main | this PR | change |
|---|---:|---:|---|
| VectorStore_search/1000 | 16.63 µs | 10.08 µs | **−39.5%** |
| VectorStore_search/10000 | 181.6 µs | 104.4 µs | **−42.5%** |
| VectorStore_add_10k | 775.9 µs | 792.7 µs | +2.6% (noise; add untouched) |

This flips the cross-implementation result from vanedb-bench#1: Rust store search was 1.52× slower than C++ (183.9 vs 120.7 µs); at 104.4 µs it now leads. All 7 test suites pass; clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H