### PR TITLE
perf(hnsw): 2.7× faster build — align link count and pruning with vanedb-cpp

### DIFF
--- a/vanedb/examples/profile_hnsw_build.rs
+++ b/vanedb/examples/profile_hnsw_build.rs
@@ -1,0 +1,70 @@
+//! Profiling target: builds a 10k x 128d HNSW index repeatedly so an external
+//! sampler (macOS `sample`, samply, perf) can attribute build-phase hot spots.
+//! Temporary tool for investigating the 2.5x build gap vs vanedb-cpp
+//! (vanedb-bench#1); not part of the public API surface.
+
+use vanedb::{DistanceMetric, HnswIndex};
+
+fn splitmix64(state: &mut u64) -> u64 {
+    *state = state.wrapping_add(0x9E3779B97F4A7C15);
+    let mut z = *state;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+    z ^ (z >> 31)
+}
+
+fn main() {
+    const DIM: usize = 128;
+    const N: usize = 10_000;
+    let mut s = 3u64;
+    let vectors: Vec<f32> = (0..N * DIM)
+        .map(|_| (splitmix64(&mut s) >> 40) as f32 / (1u64 << 24) as f32)
+        .collect();
+
+    let rounds: usize = std::env::args()
+        .nth(1)
+        .and_then(|a| a.parse().ok())
+        .unwrap_or(10);
+
+    let mut last = None;
+    for round in 0..rounds {
+        let start = std::time::Instant::now();
+        let idx = HnswIndex::builder(DIM, DistanceMetric::L2)
+            .capacity(N)
+            .m(16)
+            .ef_construction(200)
+            .seed(7)
+            .build()
+            .unwrap();
+        for i in 0..N {
+            idx.add(i as u64, &vectors[i * DIM..(i + 1) * DIM]).unwrap();
+        }
+        println!("round {round}: {:?} (size {})", start.elapsed(), idx.size());
+        last = Some(idx);
+    }
+
+    // recall@10 over 100 queries vs brute force
+    let ef: usize = std::env::args()
+        .nth(2)
+        .and_then(|a| a.parse().ok())
+        .unwrap_or(50);
+    let idx = last.unwrap();
+    idx.set_ef_search(ef);
+    let brute = vanedb::VectorStore::new(DIM, DistanceMetric::L2).unwrap();
+    for i in 0..N {
+        brute
+            .add(i as u64, &vectors[i * DIM..(i + 1) * DIM])
+            .unwrap();
+    }
+    let mut recall = 0.0f64;
+    for _ in 0..100 {
+        let q: Vec<f32> = (0..DIM)
+            .map(|_| (splitmix64(&mut s) >> 40) as f32 / (1u64 << 24) as f32)
+            .collect();
+        let truth: std::collections::HashSet<u64> =
+            brute.search(&q, 10).unwrap().iter().map(|r| r.id).collect();
+        let got = idx.search(&q, 10).unwrap();
+        recall += got.iter().filter(|r| truth.contains(&r.id)).count() as f64 / 10.0;
+    }
+    println!("recall@10 (100 queries, ef={ef}): {:.3}", recall / 100.0);
+}

--- a/vanedb/src/hnsw/mod.rs
+++ b/vanedb/src/hnsw/mod.rs
@@ -256,14 +256,12 @@ impl HnswIndex {
                 inner.count,
             );
 
+            // New nodes get M links; m_for_layer (2M at level 0) is only the
+            // overflow cap for existing nodes' reverse links. Mirrors
+            // vanedb-cpp add() / hnswlib semantics.
             let m_for_layer = if lev == 0 { self.m_max0 } else { self.m_max };
-            let neighbors_to_add = Self::select_neighbors(
-                &inner.vectors,
-                self.dist_fn,
-                self.dim,
-                &results,
-                m_for_layer,
-            );
+            let neighbors_to_add =
+                Self::select_neighbors(&inner.vectors, self.dist_fn, self.dim, &results, self.m);
 
             // Set neighbors for the new node at this layer
             if lev < inner.neighbors[iid].len() {
@@ -289,14 +287,13 @@ impl HnswIndex {
                             })
                             .collect();
                         candidates.sort_by_key(|a| FloatOrd(a.0));
-                        let pruned = Self::select_neighbors(
-                            &inner.vectors,
-                            self.dist_fn,
-                            self.dim,
-                            &candidates,
-                            m_for_layer,
-                        );
-                        inner.neighbors[nb][lev] = pruned.iter().map(|&(_, n)| n).collect();
+                        // Keep the m_for_layer closest (plain truncate, no
+                        // diversity heuristic) — mirrors vanedb-cpp. The
+                        // heuristic here re-scanned every overflowing list
+                        // pairwise, costing ~36% of build time for no
+                        // measurable recall gain (see PR benchmarks).
+                        candidates.truncate(m_for_layer);
+                        inner.neighbors[nb][lev] = candidates.iter().map(|&(_, n)| n).collect();
                     }
                 }
             }


### PR DESCRIPTION
Root-caused from vanedb-bench#1's finding that Rust HNSW build was 2.5× slower than C++ while search was at parity. Profiling (macOS `sample`, example included) showed **59% of build time in `l2_squared`**, concentrated in `select_neighbors` — the eval *count* was the problem, not eval speed (our kernels are faster than C++'s per the distance benches).

## Two divergences from the C++ reference

1. **New nodes got `m_max0` = 2M initial links at level 0** — C++/hnswlib always select M for the new node; `m_max0` is only the overflow *cap* for reverse links. The doubled links also doubled downstream reverse-prunes.
2. **Overflowing reverse links were re-pruned with the full diversity heuristic** (a pairwise distance pass on ~every add at steady state) — C++ sorts and truncates.

## Measurements (10k × 128d, M=16, efC=200, Apple Silicon)

| variant | build | recall@10 @ef=50 |
|---|---:|---:|
| before | 2.65 s | 0.726 |
| M-links fix only | 1.34 s | 0.665 |
| **this PR (both)** | **0.98 s** | 0.671 |
| vanedb-cpp | 1.12 s | 0.689 |

The heuristic re-prune cost ~36% of build time for **no measurable recall gain** (0.671 vs 0.665). Rust build now beats C++.

**Recall trade-off is a query-time knob:** at ef=75 the new graph reaches **0.780 — above the old code's 0.726 at ef=50** (ef=100 → 0.838). Search latency scales ~linearly with ef, so recovering the old recall costs ~50% of a 29 µs search, vs 2.7× on every build.

All 7 test suites pass (including the ≥0.8 recall bound at ef=100); fmt/clippy clean. Includes `examples/profile_hnsw_build.rs` used for these measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H