### PR TITLE
perf(distance): multi-accumulator SIMD unrolling (l2/dot ~2.2× on NEON)

### DIFF
--- a/vanedb/src/distance/avx2.rs
+++ b/vanedb/src/distance/avx2.rs
@@ -25,7 +25,27 @@ pub unsafe fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
     debug_assert_eq!(a.len(), b.len());
     let n = a.len();
     let mut i = 0;
-    let mut acc = _mm256_setzero_ps();
+    // Four independent accumulators hide the FMA latency; a single-acc
+    // loop is latency-bound. Mirrors vanedb-cpp src/core/distance.h.
+    let mut acc0 = _mm256_setzero_ps();
+    let mut acc1 = _mm256_setzero_ps();
+    let mut acc2 = _mm256_setzero_ps();
+    let mut acc3 = _mm256_setzero_ps();
+
+    while i + 32 <= n {
+        let p = a.as_ptr().add(i);
+        let q = b.as_ptr().add(i);
+        let d0 = _mm256_sub_ps(_mm256_loadu_ps(p), _mm256_loadu_ps(q));
+        let d1 = _mm256_sub_ps(_mm256_loadu_ps(p.add(8)), _mm256_loadu_ps(q.add(8)));
+        let d2 = _mm256_sub_ps(_mm256_loadu_ps(p.add(16)), _mm256_loadu_ps(q.add(16)));
+        let d3 = _mm256_sub_ps(_mm256_loadu_ps(p.add(24)), _mm256_loadu_ps(q.add(24)));
+        acc0 = _mm256_fmadd_ps(d0, d0, acc0);
+        acc1 = _mm256_fmadd_ps(d1, d1, acc1);
+        acc2 = _mm256_fmadd_ps(d2, d2, acc2);
+        acc3 = _mm256_fmadd_ps(d3, d3, acc3);
+        i += 32;
+    }
+    let mut acc = _mm256_add_ps(_mm256_add_ps(acc0, acc1), _mm256_add_ps(acc2, acc3));
 
     while i + 8 <= n {
         let va = _mm256_loadu_ps(a.as_ptr().add(i));
@@ -54,9 +74,32 @@ pub unsafe fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
     debug_assert_eq!(a.len(), b.len());
     let n = a.len();
     let mut i = 0;
-    let mut vdot = _mm256_setzero_ps();
-    let mut vna = _mm256_setzero_ps();
-    let mut vnb = _mm256_setzero_ps();
+    // Two-way unroll on top of the three naturally independent chains.
+    let mut vdot0 = _mm256_setzero_ps();
+    let mut vna0 = _mm256_setzero_ps();
+    let mut vnb0 = _mm256_setzero_ps();
+    let mut vdot1 = _mm256_setzero_ps();
+    let mut vna1 = _mm256_setzero_ps();
+    let mut vnb1 = _mm256_setzero_ps();
+
+    while i + 16 <= n {
+        let p = a.as_ptr().add(i);
+        let q = b.as_ptr().add(i);
+        let va0 = _mm256_loadu_ps(p);
+        let vb0 = _mm256_loadu_ps(q);
+        let va1 = _mm256_loadu_ps(p.add(8));
+        let vb1 = _mm256_loadu_ps(q.add(8));
+        vdot0 = _mm256_fmadd_ps(va0, vb0, vdot0);
+        vna0 = _mm256_fmadd_ps(va0, va0, vna0);
+        vnb0 = _mm256_fmadd_ps(vb0, vb0, vnb0);
+        vdot1 = _mm256_fmadd_ps(va1, vb1, vdot1);
+        vna1 = _mm256_fmadd_ps(va1, va1, vna1);
+        vnb1 = _mm256_fmadd_ps(vb1, vb1, vnb1);
+        i += 16;
+    }
+    let mut vdot = _mm256_add_ps(vdot0, vdot1);
+    let mut vna = _mm256_add_ps(vna0, vna1);
+    let mut vnb = _mm256_add_ps(vnb0, vnb1);
 
     while i + 8 <= n {
         let va = _mm256_loadu_ps(a.as_ptr().add(i));
@@ -96,7 +139,22 @@ pub unsafe fn dot_distance(a: &[f32], b: &[f32]) -> f32 {
     debug_assert_eq!(a.len(), b.len());
     let n = a.len();
     let mut i = 0;
-    let mut acc = _mm256_setzero_ps();
+    // Same latency-hiding unroll as l2_squared.
+    let mut acc0 = _mm256_setzero_ps();
+    let mut acc1 = _mm256_setzero_ps();
+    let mut acc2 = _mm256_setzero_ps();
+    let mut acc3 = _mm256_setzero_ps();
+
+    while i + 32 <= n {
+        let p = a.as_ptr().add(i);
+        let q = b.as_ptr().add(i);
+        acc0 = _mm256_fmadd_ps(_mm256_loadu_ps(p), _mm256_loadu_ps(q), acc0);
+        acc1 = _mm256_fmadd_ps(_mm256_loadu_ps(p.add(8)), _mm256_loadu_ps(q.add(8)), acc1);
+        acc2 = _mm256_fmadd_ps(_mm256_loadu_ps(p.add(16)), _mm256_loadu_ps(q.add(16)), acc2);
+        acc3 = _mm256_fmadd_ps(_mm256_loadu_ps(p.add(24)), _mm256_loadu_ps(q.add(24)), acc3);
+        i += 32;
+    }
+    let mut acc = _mm256_add_ps(_mm256_add_ps(acc0, acc1), _mm256_add_ps(acc2, acc3));
 
     while i + 8 <= n {
         let va = _mm256_loadu_ps(a.as_ptr().add(i));

--- a/vanedb/src/distance/neon.rs
+++ b/vanedb/src/distance/neon.rs
@@ -12,11 +12,30 @@ pub fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
     // SAFETY: NEON is always available on aarch64.
     // Pointer arithmetic stays within slice bounds (i + 4 <= n).
     let mut sum = unsafe {
-        let mut acc = vdupq_n_f32(0.0);
+        // Four independent accumulators hide the fused multiply-add latency
+        // (~4 cycles); a single-accumulator loop is latency-bound at one
+        // vector per FMA latency regardless of ALU width. Mirrors
+        // vanedb-cpp src/core/distance.h.
+        let mut acc0 = vdupq_n_f32(0.0);
+        let mut acc1 = vdupq_n_f32(0.0);
+        let mut acc2 = vdupq_n_f32(0.0);
+        let mut acc3 = vdupq_n_f32(0.0);
+        while i + 16 <= n {
+            let p = a.as_ptr().add(i);
+            let q = b.as_ptr().add(i);
+            let d0 = vsubq_f32(vld1q_f32(p), vld1q_f32(q));
+            let d1 = vsubq_f32(vld1q_f32(p.add(4)), vld1q_f32(q.add(4)));
+            let d2 = vsubq_f32(vld1q_f32(p.add(8)), vld1q_f32(q.add(8)));
+            let d3 = vsubq_f32(vld1q_f32(p.add(12)), vld1q_f32(q.add(12)));
+            acc0 = vmlaq_f32(acc0, d0, d0);
+            acc1 = vmlaq_f32(acc1, d1, d1);
+            acc2 = vmlaq_f32(acc2, d2, d2);
+            acc3 = vmlaq_f32(acc3, d3, d3);
+            i += 16;
+        }
+        let mut acc = vaddq_f32(vaddq_f32(acc0, acc1), vaddq_f32(acc2, acc3));
         while i + 4 <= n {
-            let va = vld1q_f32(a.as_ptr().add(i));
-            let vb = vld1q_f32(b.as_ptr().add(i));
-            let d = vsubq_f32(va, vb);
+            let d = vsubq_f32(vld1q_f32(a.as_ptr().add(i)), vld1q_f32(b.as_ptr().add(i)));
             acc = vmlaq_f32(acc, d, d);
             i += 4;
         }
@@ -39,9 +58,31 @@ pub fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
     let mut i = 0;
 
     let (mut dot, mut norm_a, mut norm_b) = unsafe {
-        let mut vdot = vdupq_n_f32(0.0);
-        let mut vna = vdupq_n_f32(0.0);
-        let mut vnb = vdupq_n_f32(0.0);
+        // Two-way unroll on top of the three naturally independent chains.
+        let mut vdot0 = vdupq_n_f32(0.0);
+        let mut vna0 = vdupq_n_f32(0.0);
+        let mut vnb0 = vdupq_n_f32(0.0);
+        let mut vdot1 = vdupq_n_f32(0.0);
+        let mut vna1 = vdupq_n_f32(0.0);
+        let mut vnb1 = vdupq_n_f32(0.0);
+        while i + 8 <= n {
+            let p = a.as_ptr().add(i);
+            let q = b.as_ptr().add(i);
+            let va0 = vld1q_f32(p);
+            let vb0 = vld1q_f32(q);
+            let va1 = vld1q_f32(p.add(4));
+            let vb1 = vld1q_f32(q.add(4));
+            vdot0 = vmlaq_f32(vdot0, va0, vb0);
+            vna0 = vmlaq_f32(vna0, va0, va0);
+            vnb0 = vmlaq_f32(vnb0, vb0, vb0);
+            vdot1 = vmlaq_f32(vdot1, va1, vb1);
+            vna1 = vmlaq_f32(vna1, va1, va1);
+            vnb1 = vmlaq_f32(vnb1, vb1, vb1);
+            i += 8;
+        }
+        let mut vdot = vaddq_f32(vdot0, vdot1);
+        let mut vna = vaddq_f32(vna0, vna1);
+        let mut vnb = vaddq_f32(vnb0, vnb1);
         while i + 4 <= n {
             let va = vld1q_f32(a.as_ptr().add(i));
             let vb = vld1q_f32(b.as_ptr().add(i));
@@ -75,11 +116,27 @@ pub fn dot_distance(a: &[f32], b: &[f32]) -> f32 {
     let mut i = 0;
 
     let mut sum = unsafe {
-        let mut acc = vdupq_n_f32(0.0);
+        // Same latency-hiding unroll as l2_squared.
+        let mut acc0 = vdupq_n_f32(0.0);
+        let mut acc1 = vdupq_n_f32(0.0);
+        let mut acc2 = vdupq_n_f32(0.0);
+        let mut acc3 = vdupq_n_f32(0.0);
+        while i + 16 <= n {
+            let p = a.as_ptr().add(i);
+            let q = b.as_ptr().add(i);
+            acc0 = vmlaq_f32(acc0, vld1q_f32(p), vld1q_f32(q));
+            acc1 = vmlaq_f32(acc1, vld1q_f32(p.add(4)), vld1q_f32(q.add(4)));
+            acc2 = vmlaq_f32(acc2, vld1q_f32(p.add(8)), vld1q_f32(q.add(8)));
+            acc3 = vmlaq_f32(acc3, vld1q_f32(p.add(12)), vld1q_f32(q.add(12)));
+            i += 16;
+        }
+        let mut acc = vaddq_f32(vaddq_f32(acc0, acc1), vaddq_f32(acc2, acc3));
         while i + 4 <= n {
-            let va = vld1q_f32(a.as_ptr().add(i));
-            let vb = vld1q_f32(b.as_ptr().add(i));
-            acc = vmlaq_f32(acc, va, vb);
+            acc = vmlaq_f32(
+                acc,
+                vld1q_f32(a.as_ptr().add(i)),
+                vld1q_f32(b.as_ptr().add(i)),
+            );
             i += 4;
         }
         vaddvq_f32(acc)


### PR DESCRIPTION
Mirror of vanedb-cpp#31, keeping the twins' kernels in sync: single-accumulator FMA loops are latency-bound on the accumulator dependency chain (~4 cycles per fused multiply-add), so one vector retires per FMA latency regardless of ALU width. Four independent accumulators for `l2`/`dot` (16 floats/NEON iter, 32/AVX2 iter), two-way unroll for cosine's three naturally independent chains.

## Measured (criterion, Apple Silicon)

| kernel 768d | before | after |
|---|---:|---:|
| L2 | ~79 ns | **36.9 ns** |
| dot | ~79 ns | **36.6 ns** |
| cosine | ~103 ns | **74.6 ns** |

Identical to the unrolled C++ kernels (36.9 ns) — both implementations are now throughput-bound. This also feeds every distance-bound op (store/mmap/HNSW search + build).

AVX2 path mirrored (validated by x86 CI runners). All 7 test suites pass; NEON≍scalar equality tests hold within tolerances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H