### PR TITLE
feat(core): add_batch bulk insert for VectorStore and HnswIndex

### DIFF
--- a/vanedb/src/hnsw/mod.rs
+++ b/vanedb/src/hnsw/mod.rs
@@ -189,6 +189,45 @@ impl HnswIndex {
             return Err(VaneError::DuplicateId { id });
         }
 
+        self.insert_into(&mut inner, id, vector);
+        Ok(())
+    }
+
+    /// Insert many vectors under a single lock acquisition. `vectors` is the
+    /// row-major concatenation of `ids.len()` vectors of `dimension()` floats.
+    /// All-or-nothing: capacity and every id are validated before any insert,
+    /// so an error leaves the index unchanged. Levels are drawn from the RNG
+    /// in batch order, so the resulting graph is identical to serial `add`.
+    pub fn add_batch(&self, ids: &[u64], vectors: &[f32]) -> Result<()> {
+        if vectors.len() != ids.len() * self.dim {
+            return Err(VaneError::DimensionMismatch {
+                expected: ids.len() * self.dim,
+                got: vectors.len(),
+            });
+        }
+
+        let mut inner = self.inner.write();
+
+        if inner.count + ids.len() > self.max_elements {
+            return Err(VaneError::IndexFull);
+        }
+        let mut seen = HashSet::with_capacity(ids.len());
+        for &id in ids {
+            if inner.id_map.contains_key(&id) || !seen.insert(id) {
+                return Err(VaneError::DuplicateId { id });
+            }
+        }
+
+        for (&id, chunk) in ids.iter().zip(vectors.chunks_exact(self.dim)) {
+            self.insert_into(&mut inner, id, chunk);
+        }
+        Ok(())
+    }
+
+    /// Graph insertion body shared by `add` and `add_batch`. Caller must hold
+    /// the write lock and have already validated dimension, capacity, and id
+    /// uniqueness — from here on insertion cannot fail.
+    fn insert_into(&self, inner: &mut Inner, id: u64, vector: &[f32]) {
         let iid = inner.count;
         inner.count += 1;
 
@@ -209,7 +248,7 @@ impl HnswIndex {
         if iid == 0 {
             inner.entry_point = Some(0);
             inner.max_level = level;
-            return Ok(());
+            return;
         }
 
         let mut cur_ep = inner.entry_point.unwrap();
@@ -309,8 +348,6 @@ impl HnswIndex {
             inner.entry_point = Some(iid);
             inner.max_level = level;
         }
-
-        Ok(())
     }
 
     pub fn search(&self, query: &[f32], k: usize) -> Result<Vec<SearchResult>> {

--- a/vanedb/src/store/vector_store.rs
+++ b/vanedb/src/store/vector_store.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use parking_lot::RwLock;
 
@@ -49,6 +49,35 @@ impl VectorStore {
         inner.ids.push(id);
         inner.data.extend_from_slice(vector);
         inner.id_to_index.insert(id, index);
+        Ok(())
+    }
+
+    /// Insert many vectors under a single lock acquisition. `vectors` is the
+    /// row-major concatenation of `ids.len()` vectors of `dimension()` floats.
+    /// All-or-nothing: every length and id is validated before any insert, so
+    /// an error leaves the store unchanged.
+    pub fn add_batch(&self, ids: &[u64], vectors: &[f32]) -> Result<()> {
+        if vectors.len() != ids.len() * self.dim {
+            return Err(VaneError::DimensionMismatch {
+                expected: ids.len() * self.dim,
+                got: vectors.len(),
+            });
+        }
+        let mut inner = self.inner.write();
+        let mut seen = HashSet::with_capacity(ids.len());
+        for &id in ids {
+            if inner.id_to_index.contains_key(&id) || !seen.insert(id) {
+                return Err(VaneError::DuplicateId { id });
+            }
+        }
+        inner.ids.reserve(ids.len());
+        inner.data.reserve(vectors.len());
+        for (&id, chunk) in ids.iter().zip(vectors.chunks_exact(self.dim)) {
+            let index = inner.ids.len();
+            inner.ids.push(id);
+            inner.data.extend_from_slice(chunk);
+            inner.id_to_index.insert(id, index);
+        }
         Ok(())
     }
 
@@ -324,5 +353,56 @@ mod tests {
     fn store_is_send_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<VectorStore>();
+    }
+
+    #[test]
+    fn add_batch_inserts_all() {
+        let store = VectorStore::new(3, DistanceMetric::L2).unwrap();
+        let ids = [1u64, 2, 3];
+        let vectors = [1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0];
+        store.add_batch(&ids, &vectors).unwrap();
+        assert_eq!(store.len(), 3);
+        assert_eq!(store.get(2).unwrap(), vec![2.0, 2.0, 2.0]);
+        let results = store.search(&[2.0, 2.0, 2.1], 1).unwrap();
+        assert_eq!(results[0].id, 2);
+    }
+
+    #[test]
+    fn add_batch_empty_is_noop() {
+        let store = VectorStore::new(3, DistanceMetric::L2).unwrap();
+        store.add_batch(&[], &[]).unwrap();
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn add_batch_flat_length_mismatch() {
+        let store = VectorStore::new(3, DistanceMetric::L2).unwrap();
+        let result = store.add_batch(&[1, 2], &[1.0, 2.0, 3.0, 4.0, 5.0]);
+        assert!(matches!(
+            result,
+            Err(VaneError::DimensionMismatch {
+                expected: 6,
+                got: 5
+            })
+        ));
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn add_batch_duplicate_within_batch_is_all_or_nothing() {
+        let store = VectorStore::new(2, DistanceMetric::L2).unwrap();
+        let result = store.add_batch(&[1, 2, 1], &[1.0; 6]);
+        assert!(matches!(result, Err(VaneError::DuplicateId { id: 1 })));
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn add_batch_duplicate_with_existing_is_all_or_nothing() {
+        let store = VectorStore::new(2, DistanceMetric::L2).unwrap();
+        store.add(7, &[0.0, 0.0]).unwrap();
+        let result = store.add_batch(&[8, 7], &[1.0; 4]);
+        assert!(matches!(result, Err(VaneError::DuplicateId { id: 7 })));
+        assert_eq!(store.len(), 1);
+        assert!(!store.contains(8));
     }
 }

--- a/vanedb/tests/hnsw_tests.rs
+++ b/vanedb/tests/hnsw_tests.rs
@@ -237,3 +237,96 @@ fn hnsw_visited_bitmap_epoch_wrap_correctness() {
         assert_eq!(a.id, b.id, "result drifted across epoch wrap");
     }
 }
+
+/// add_batch must produce a graph identical to serial add: same seed means the
+/// level RNG is drawn in the same order, so searches must return identical
+/// results, not merely similar recall.
+#[test]
+fn hnsw_add_batch_matches_serial_add() {
+    let dim = 16;
+    let n = 300;
+
+    let mk = || {
+        HnswIndex::builder(dim, DistanceMetric::L2)
+            .capacity(n)
+            .m(8)
+            .ef_construction(100)
+            .seed(7)
+            .build()
+            .unwrap()
+    };
+    let serial = mk();
+    let batched = mk();
+
+    let mut ids = Vec::with_capacity(n);
+    let mut flat = Vec::with_capacity(n * dim);
+    for i in 0..n {
+        let v: Vec<f32> = (0..dim)
+            .map(|j| ((i * 31 + j * 17) % 97) as f32 / 97.0)
+            .collect();
+        serial.add(i as u64, &v).unwrap();
+        ids.push(i as u64);
+        flat.extend_from_slice(&v);
+    }
+    batched.add_batch(&ids, &flat).unwrap();
+
+    assert_eq!(batched.size(), n);
+    for i in (0..n).step_by(23) {
+        let q: Vec<f32> = (0..dim)
+            .map(|j| ((i * 13 + j * 29) % 89) as f32 / 89.0)
+            .collect();
+        let a = serial.search(&q, 10).unwrap();
+        let b = batched.search(&q, 10).unwrap();
+        assert_eq!(a, b, "query {i} diverged between serial and batch build");
+    }
+}
+
+#[test]
+fn hnsw_add_batch_capacity_exceeded_is_all_or_nothing() {
+    let index = HnswIndex::builder(4, DistanceMetric::L2)
+        .capacity(4)
+        .build()
+        .unwrap();
+    index.add(99, &[0.5; 4]).unwrap();
+
+    let ids: Vec<u64> = (0..4).collect();
+    let flat = vec![1.0f32; 16];
+    let result = index.add_batch(&ids, &flat);
+    assert!(matches!(result, Err(vanedb::VaneError::IndexFull)));
+    assert_eq!(index.size(), 1);
+    assert!(!index.contains(0));
+}
+
+#[test]
+fn hnsw_add_batch_duplicate_is_all_or_nothing() {
+    let index = HnswIndex::builder(2, DistanceMetric::L2)
+        .capacity(10)
+        .build()
+        .unwrap();
+    index.add(5, &[0.1, 0.2]).unwrap();
+
+    let result = index.add_batch(&[4, 5], &[1.0, 2.0, 3.0, 4.0]);
+    assert!(matches!(
+        result,
+        Err(vanedb::VaneError::DuplicateId { id: 5 })
+    ));
+    assert_eq!(index.size(), 1);
+    assert!(!index.contains(4));
+
+    let result = index.add_batch(&[6, 6], &[1.0, 2.0, 3.0, 4.0]);
+    assert!(matches!(
+        result,
+        Err(vanedb::VaneError::DuplicateId { id: 6 })
+    ));
+    assert_eq!(index.size(), 1);
+}
+
+#[test]
+fn hnsw_add_batch_empty_is_noop() {
+    let index = HnswIndex::builder(2, DistanceMetric::L2)
+        .capacity(10)
+        .build()
+        .unwrap();
+    index.add_batch(&[], &[]).unwrap();
+    assert!(index.is_empty());
+}


### PR DESCRIPTION
## Summary
Core half of #19: a bulk insert API on both `VectorStore` and `HnswIndex`.

- `add_batch(ids: &[u64], vectors: &[f32])` — flat row-major input (`ids.len() × dim` floats), which is exactly what a contiguous 2-D numpy array, a C pointer, or a wasm `Float32Array` hands us with zero conversion. The Python/capi/wasm surfaces land in follow-up PRs stacked on this branch.
- **One write-lock acquisition per batch** instead of per vector.
- **All-or-nothing semantics**: flat length, in-batch duplicate ids, ids already present, and (HNSW) capacity are all validated before the first insert — an error leaves the index untouched.
- HNSW: the post-validation body of `add()` is factored into `insert_into()` (infallible once validated), shared by both entry points. Level RNG draws happen in insert order, so **a batch build produces a graph bit-identical to serial adds** — `hnsw_add_batch_matches_serial_add` asserts identical search results, not merely similar recall.

## Tests
- VectorStore: insert-all, empty no-op, flat-length mismatch, in-batch dup, dup-vs-existing (each error case asserts the store is unchanged).
- HNSW: serial/batch graph equivalence, capacity overflow all-or-nothing, dup all-or-nothing (both flavors), empty no-op.
- `cargo fmt --check`, `cargo clippy --workspace --exclude vanedb-py --all-targets --features mmap -D warnings`, `cargo test --workspace --exclude vanedb-py --features mmap` all clean locally (macOS ARM).

Part of #19 (the issue's Python-facing ask is completed by the stacked bindings PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)