### PR TITLE
feat(capi,wasm): expose add_batch through the C ABI and wasm bindings

### DIFF
--- a/vanedb-capi/include/vanedb_rs_capi.h
+++ b/vanedb-capi/include/vanedb_rs_capi.h
@@ -51,6 +51,17 @@ int32_t vanedb_rs_store_add(VectorStore *s, uint64_t id, const float *v);
 
 /**
  * # Safety
+ * `s` must be a live handle from `vanedb_rs_store_new` (or null); `ids` must point to
+ * `n` valid `u64`s and `vecs` to `n * dim` valid `f32`s (both may be null when `n` is 0).
+ * All-or-nothing: on error (duplicate id, length mismatch) the store is unchanged.
+ */
+int32_t vanedb_rs_store_add_batch(VectorStore *s,
+                                  const uint64_t *ids,
+                                  const float *vecs,
+                                  uintptr_t n);
+
+/**
+ * # Safety
  * `s` must be a live handle from `vanedb_rs_store_new` (or null); `q` must point to
  * `dim` valid `f32`s; `out_ids` and `out_dists` must each have room for `k` elements.
  */
@@ -85,6 +96,14 @@ HnswIndex *vanedb_rs_hnsw_new(uintptr_t dim,
  * `v` must point to at least `dim` valid `f32` values (where `dim` matches the index).
  */
 int32_t vanedb_rs_hnsw_add(HnswIndex *h, uint64_t id, const float *v);
+
+/**
+ * # Safety
+ * `h` must be a live handle from `vanedb_rs_hnsw_new` (or null); `ids` must point to
+ * `n` valid `u64`s and `vecs` to `n * dim` valid `f32`s (both may be null when `n` is 0).
+ * All-or-nothing: on error (duplicate id, capacity, length mismatch) the index is unchanged.
+ */
+int32_t vanedb_rs_hnsw_add_batch(HnswIndex *h, const uint64_t *ids, const float *vecs, uintptr_t n);
 
 /**
  * # Safety

--- a/vanedb-capi/src/lib.rs
+++ b/vanedb-capi/src/lib.rs
@@ -78,6 +78,35 @@ pub unsafe extern "C" fn vanedb_rs_store_add(s: *mut VectorStore, id: u64, v: *c
 }
 
 /// # Safety
+/// `s` must be a live handle from `vanedb_rs_store_new` (or null); `ids` must point to
+/// `n` valid `u64`s and `vecs` to `n * dim` valid `f32`s (both may be null when `n` is 0).
+/// All-or-nothing: on error (duplicate id, length mismatch) the store is unchanged.
+#[no_mangle]
+pub unsafe extern "C" fn vanedb_rs_store_add_batch(
+    s: *mut VectorStore,
+    ids: *const u64,
+    vecs: *const f32,
+    n: usize,
+) -> i32 {
+    if s.is_null() {
+        return 1;
+    }
+    let store = &*s;
+    let (id_slice, vec_slice): (&[u64], &[f32]) = if n == 0 {
+        (&[], &[])
+    } else {
+        (
+            slice::from_raw_parts(ids, n),
+            slice::from_raw_parts(vecs, n * store.dimension()),
+        )
+    };
+    match store.add_batch(id_slice, vec_slice) {
+        Ok(()) => 0,
+        Err(_) => 1,
+    }
+}
+
+/// # Safety
 /// `s` must be a live handle from `vanedb_rs_store_new` (or null); `q` must point to
 /// `dim` valid `f32`s; `out_ids` and `out_dists` must each have room for `k` elements.
 #[no_mangle]
@@ -151,6 +180,35 @@ pub unsafe extern "C" fn vanedb_rs_hnsw_add(h: *mut HnswIndex, id: u64, v: *cons
     let idx = &*h;
     let vec = slice::from_raw_parts(v, idx.dimension());
     match idx.add(id, vec) {
+        Ok(()) => 0,
+        Err(_) => 1,
+    }
+}
+
+/// # Safety
+/// `h` must be a live handle from `vanedb_rs_hnsw_new` (or null); `ids` must point to
+/// `n` valid `u64`s and `vecs` to `n * dim` valid `f32`s (both may be null when `n` is 0).
+/// All-or-nothing: on error (duplicate id, capacity, length mismatch) the index is unchanged.
+#[no_mangle]
+pub unsafe extern "C" fn vanedb_rs_hnsw_add_batch(
+    h: *mut HnswIndex,
+    ids: *const u64,
+    vecs: *const f32,
+    n: usize,
+) -> i32 {
+    if h.is_null() {
+        return 1;
+    }
+    let idx = &*h;
+    let (id_slice, vec_slice): (&[u64], &[f32]) = if n == 0 {
+        (&[], &[])
+    } else {
+        (
+            slice::from_raw_parts(ids, n),
+            slice::from_raw_parts(vecs, n * idx.dimension()),
+        )
+    };
+    match idx.add_batch(id_slice, vec_slice) {
         Ok(()) => 0,
         Err(_) => 1,
     }

--- a/vanedb-capi/tests/capi.rs
+++ b/vanedb-capi/tests/capi.rs
@@ -186,3 +186,96 @@ fn store() {
         );
     }
 }
+
+#[test]
+fn store_add_batch() {
+    let ids = [1u64, 2, 3];
+    let flat = [0.0f32, 0.0, 1.0, 1.0, 5.0, 5.0];
+    unsafe {
+        let s = vanedb_capi::vanedb_rs_store_new(2, 0);
+        assert_eq!(
+            vanedb_capi::vanedb_rs_store_add_batch(s, ids.as_ptr(), flat.as_ptr(), 3),
+            0
+        );
+        let q = [0.9f32, 0.9];
+        let mut out_ids = [0u64; 1];
+        let mut out_ds = [0.0f32; 1];
+        let n = vanedb_capi::vanedb_rs_store_search(
+            s,
+            q.as_ptr(),
+            1,
+            out_ids.as_mut_ptr(),
+            out_ds.as_mut_ptr(),
+        );
+        assert_eq!(n, 1);
+        assert_eq!(out_ids[0], 2);
+
+        // duplicate id -> error, all-or-nothing (store unchanged: id 4 absent)
+        let dup_ids = [4u64, 1];
+        assert_eq!(
+            vanedb_capi::vanedb_rs_store_add_batch(s, dup_ids.as_ptr(), flat.as_ptr(), 2),
+            1
+        );
+
+        // empty batch is a no-op success, even with null pointers
+        assert_eq!(
+            vanedb_capi::vanedb_rs_store_add_batch(s, std::ptr::null(), std::ptr::null(), 0),
+            0
+        );
+
+        // null handle guard
+        assert_eq!(
+            vanedb_capi::vanedb_rs_store_add_batch(
+                std::ptr::null_mut(),
+                ids.as_ptr(),
+                flat.as_ptr(),
+                3
+            ),
+            1
+        );
+        vanedb_capi::vanedb_rs_store_free(s);
+    }
+}
+
+#[test]
+fn hnsw_add_batch() {
+    let ids = [10u64, 20];
+    let flat = [0.0f32, 0.0, 1.0, 1.0];
+    unsafe {
+        let h = vanedb_capi::vanedb_rs_hnsw_new(2, 0, 100, 16, 200, 42);
+        assert_eq!(
+            vanedb_capi::vanedb_rs_hnsw_add_batch(h, ids.as_ptr(), flat.as_ptr(), 2),
+            0
+        );
+        let q = [0.1f32, 0.1];
+        let mut out_ids = [0u64; 2];
+        let mut out_ds = [0.0f32; 2];
+        let n = vanedb_capi::vanedb_rs_hnsw_search(
+            h,
+            q.as_ptr(),
+            2,
+            50,
+            out_ids.as_mut_ptr(),
+            out_ds.as_mut_ptr(),
+        );
+        assert_eq!(n, 2);
+        assert_eq!(out_ids[0], 10);
+
+        // duplicate -> error
+        assert_eq!(
+            vanedb_capi::vanedb_rs_hnsw_add_batch(h, ids.as_ptr(), flat.as_ptr(), 2),
+            1
+        );
+        // null handle guard
+        assert_eq!(
+            vanedb_capi::vanedb_rs_hnsw_add_batch(
+                std::ptr::null_mut(),
+                ids.as_ptr(),
+                flat.as_ptr(),
+                2
+            ),
+            1
+        );
+        vanedb_capi::vanedb_rs_hnsw_free(h);
+    }
+}

--- a/vanedb-wasm/src/lib.rs
+++ b/vanedb-wasm/src/lib.rs
@@ -43,6 +43,13 @@ impl WasmVectorStore {
         self.inner.add(id, vector).map_err(to_jserr)
     }
 
+    /// Bulk insert in one wasm call: `ids` is a BigUint64Array of n ids and
+    /// `vectors` a Float32Array of n × dim values (row-major). All-or-nothing:
+    /// on error the store is unchanged.
+    pub fn add_batch(&self, ids: &[u64], vectors: &[f32]) -> Result<(), JsError> {
+        self.inner.add_batch(ids, vectors).map_err(to_jserr)
+    }
+
     /// Search for k nearest neighbors. Returns flat array: [id0, dist0, id1, dist1, ...].
     pub fn search(&self, query: &[f32], k: usize) -> Result<Vec<f32>, JsError> {
         let results = self.inner.search(query, k).map_err(to_jserr)?;
@@ -104,6 +111,13 @@ impl WasmHnswIndex {
 
     pub fn add(&self, id: u64, vector: &[f32]) -> Result<(), JsError> {
         self.inner.add(id, vector).map_err(to_jserr)
+    }
+
+    /// Bulk insert in one wasm call: `ids` is a BigUint64Array of n ids and
+    /// `vectors` a Float32Array of n × dim values (row-major). All-or-nothing:
+    /// on error the index is unchanged.
+    pub fn add_batch(&self, ids: &[u64], vectors: &[f32]) -> Result<(), JsError> {
+        self.inner.add_batch(ids, vectors).map_err(to_jserr)
     }
 
     /// Search for k nearest neighbors. Returns flat array: [id0, dist0, id1, dist1, ...].

--- a/vanedb-wasm/tests/web.rs
+++ b/vanedb-wasm/tests/web.rs
@@ -62,3 +62,30 @@ fn test_invalid_metric() {
     let result = WasmVectorStore::new(3, "invalid");
     assert!(result.is_err());
 }
+
+#[wasm_bindgen_test]
+fn test_store_add_batch() {
+    let store = WasmVectorStore::new(2, "l2").unwrap();
+    let ids = [1u64, 2, 3];
+    let flat = [0.0f32, 0.0, 1.0, 1.0, 5.0, 5.0];
+    store.add_batch(&ids, &flat).unwrap();
+    assert_eq!(store.size(), 3);
+    let results = store.search(&[0.9, 0.9], 1).unwrap();
+    assert_eq!(results[0] as u64, 2);
+
+    // duplicate -> Err, all-or-nothing
+    assert!(store.add_batch(&[4, 1], &flat[..4]).is_err());
+    assert_eq!(store.size(), 3);
+    assert!(!store.contains(4));
+}
+
+#[wasm_bindgen_test]
+fn test_hnsw_add_batch() {
+    let index = WasmHnswIndex::new(2, "l2", 100, 16, 200).unwrap();
+    let ids = [10u64, 20];
+    let flat = [0.0f32, 0.0, 1.0, 1.0];
+    index.add_batch(&ids, &flat).unwrap();
+    assert_eq!(index.size(), 2);
+    let results = index.search(&[0.1, 0.1], 1).unwrap();
+    assert_eq!(results[0] as u64, 10);
+}


### PR DESCRIPTION
## Summary
Third PR in the #19 stack (**base: `feat/add-batch-core`**, retarget to `main` after #28; independent of the Python PR #29).

- **C ABI**: `vanedb_rs_store_add_batch` / `vanedb_rs_hnsw_add_batch` — `(handle, ids*, vecs*, n)`, matching the existing convention (null-guarded handle, `0`/`1` return, inputs valid by contract). `n == 0` is a no-op success even with null data pointers, so callers don't need a special case for empty batches. The committed cbindgen header is regenerated.
- **wasm**: `add_batch(BigUint64Array, Float32Array)` on both classes — one JS→wasm boundary crossing per batch instead of per vector, which is where FFI amortization actually pays in the browser.
- Same all-or-nothing semantics as the core (documented in the header comments).

## Tests
- capi: 2 new native tests (search-after-batch, duplicate → error with rollback, empty batch with null pointers, null handle) — 7/7 pass.
- wasm: 2 new `wasm-bindgen-test` cases — 9/9 pass under `wasm-pack test --node` locally.
- `cargo fmt --check` / clippy `-D warnings` / full workspace tests clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)