### PR TITLE
test+fix: add_batch non-empty coverage and mmap_build null-guard (review follow-ups)

### DIFF
--- a/vanedb-capi/include/vanedb_rs_capi.h
+++ b/vanedb-capi/include/vanedb_rs_capi.h
@@ -140,8 +140,8 @@ void vanedb_rs_hnsw_free(HnswIndex *h);
 
 /**
  * # Safety
- * `path` must be a valid NUL-terminated C string; `ids` must point to `n` valid `u64`s;
- * `vecs` must point to `n * dim` valid `f32`s.
+ * `path` must be a valid NUL-terminated C string; `ids` must point to `n` valid `u64`s
+ * and `vecs` to `n * dim` valid `f32`s (both may be null when `n` is 0).
  */
 int32_t vanedb_rs_mmap_build(const char *path,
                              uintptr_t dim,

--- a/vanedb-capi/src/lib.rs
+++ b/vanedb-capi/src/lib.rs
@@ -294,8 +294,8 @@ pub unsafe extern "C" fn vanedb_rs_hnsw_free(h: *mut HnswIndex) {
 }
 
 /// # Safety
-/// `path` must be a valid NUL-terminated C string; `ids` must point to `n` valid `u64`s;
-/// `vecs` must point to `n * dim` valid `f32`s.
+/// `path` must be a valid NUL-terminated C string; `ids` must point to `n` valid `u64`s
+/// and `vecs` to `n * dim` valid `f32`s (both may be null when `n` is 0).
 #[no_mangle]
 pub unsafe extern "C" fn vanedb_rs_mmap_build(
     path: *const c_char,
@@ -316,7 +316,11 @@ pub unsafe extern "C" fn vanedb_rs_mmap_build(
         Ok(b) => b,
         Err(_) => return 1,
     };
-    let id_slice = slice::from_raw_parts(ids, n);
+    let id_slice: &[u64] = if n == 0 {
+        &[]
+    } else {
+        slice::from_raw_parts(ids, n)
+    };
     for (i, &id) in id_slice.iter().enumerate() {
         let v = slice::from_raw_parts(vecs.add(i * dim), dim);
         if b.add(id, v).is_err() {

--- a/vanedb-capi/tests/capi.rs
+++ b/vanedb-capi/tests/capi.rs
@@ -131,6 +131,36 @@ fn mmap() {
     let _ = std::fs::remove_file("rs_capi_mmap.bin");
 }
 
+/// n == 0 with null ids/vecs must build a valid empty store, matching the
+/// null-safe-when-empty contract of the add_batch entry points.
+#[test]
+fn mmap_build_empty_with_null_pointers() {
+    let path = std::ffi::CString::new("rs_capi_mmap_empty.bin").unwrap();
+    unsafe {
+        assert_eq!(
+            vanedb_capi::vanedb_rs_mmap_build(
+                path.as_ptr(),
+                2,
+                0,
+                std::ptr::null(),
+                std::ptr::null(),
+                0
+            ),
+            0
+        );
+        let m = vanedb_capi::vanedb_rs_mmap_open(path.as_ptr());
+        assert!(!m.is_null());
+        let q = [0.0f32, 0.0];
+        let mut ids = [0u64; 2];
+        let mut ds = [0.0f32; 2];
+        let n =
+            vanedb_capi::vanedb_rs_mmap_search(m, q.as_ptr(), 2, ids.as_mut_ptr(), ds.as_mut_ptr());
+        assert_eq!(n, 0);
+        vanedb_capi::vanedb_rs_mmap_free(m);
+    }
+    let _ = std::fs::remove_file("rs_capi_mmap_empty.bin");
+}
+
 #[test]
 fn distance() {
     let a = [1.0f32, 2.0, 3.0, 4.0];

--- a/vanedb/src/store/vector_store.rs
+++ b/vanedb/src/store/vector_store.rs
@@ -405,4 +405,26 @@ mod tests {
         assert_eq!(store.len(), 1);
         assert!(!store.contains(8));
     }
+
+    /// Success path onto a non-empty store: the positions recorded in
+    /// id_to_index must be global (existing rows + batch offset), not
+    /// batch-local, or every batched id resolves to the wrong vector.
+    #[test]
+    fn add_batch_onto_nonempty_store() {
+        let store = VectorStore::new(3, DistanceMetric::L2).unwrap();
+        store.add(1, &[1.0, 1.0, 1.0]).unwrap();
+        store.add(2, &[2.0, 2.0, 2.0]).unwrap();
+
+        let ids = [3u64, 4, 5];
+        let vectors = [3.0, 3.0, 3.0, 4.0, 4.0, 4.0, 5.0, 5.0, 5.0];
+        store.add_batch(&ids, &vectors).unwrap();
+
+        assert_eq!(store.len(), 5);
+        for id in 1..=5u64 {
+            let v = id as f32;
+            assert_eq!(store.get(id).unwrap(), vec![v, v, v], "wrong data for id {id}");
+        }
+        let results = store.search(&[4.0, 4.0, 4.1], 1).unwrap();
+        assert_eq!(results[0].id, 4);
+    }
 }

--- a/vanedb/src/store/vector_store.rs
+++ b/vanedb/src/store/vector_store.rs
@@ -422,7 +422,11 @@ mod tests {
         assert_eq!(store.len(), 5);
         for id in 1..=5u64 {
             let v = id as f32;
-            assert_eq!(store.get(id).unwrap(), vec![v, v, v], "wrong data for id {id}");
+            assert_eq!(
+                store.get(id).unwrap(),
+                vec![v, v, v],
+                "wrong data for id {id}"
+            );
         }
         let results = store.search(&[4.0, 4.0, 4.1], 1).unwrap();
         assert_eq!(results[0].id, 4);

--- a/vanedb/tests/hnsw_tests.rs
+++ b/vanedb/tests/hnsw_tests.rs
@@ -330,3 +330,67 @@ fn hnsw_add_batch_empty_is_noop() {
     index.add_batch(&[], &[]).unwrap();
     assert!(index.is_empty());
 }
+
+/// Batching onto a NON-EMPTY index must extend the graph exactly as serial
+/// adds would: internal slots continue from the existing count rather than
+/// restarting at zero, so with the same seed searches stay identical and
+/// no pre-existing vector gets overwritten.
+#[test]
+fn hnsw_add_batch_onto_nonempty_matches_serial_add() {
+    let dim = 16;
+    let pre = 100;
+    let n = 300;
+
+    let mk = || {
+        HnswIndex::builder(dim, DistanceMetric::L2)
+            .capacity(n)
+            .m(8)
+            .ef_construction(100)
+            .seed(7)
+            .build()
+            .unwrap()
+    };
+    let serial = mk();
+    let mixed = mk();
+
+    // The first `pre` vectors go in serially on BOTH indexes; the rest
+    // arrive on `mixed` as one batch.
+    let mut ids = Vec::with_capacity(n - pre);
+    let mut flat = Vec::with_capacity((n - pre) * dim);
+    let vec_for = |i: usize| -> Vec<f32> {
+        (0..dim)
+            .map(|j| ((i * 31 + j * 17) % 97) as f32 / 97.0)
+            .collect()
+    };
+    for i in 0..n {
+        let v = vec_for(i);
+        serial.add(i as u64, &v).unwrap();
+        if i < pre {
+            mixed.add(i as u64, &v).unwrap();
+        } else {
+            ids.push(i as u64);
+            flat.extend_from_slice(&v);
+        }
+    }
+    mixed.add_batch(&ids, &flat).unwrap();
+
+    assert_eq!(mixed.size(), n);
+    // Both the pre-existing and the batched ids must still resolve to their
+    // own data — a batch that restarts at slot zero clobbers the former and
+    // misfiles the latter.
+    for i in (0..n).step_by(7) {
+        assert_eq!(
+            mixed.get_vector(i as u64).unwrap(),
+            vec_for(i),
+            "wrong data for id {i}"
+        );
+    }
+    for i in (0..n).step_by(23) {
+        let q: Vec<f32> = (0..dim)
+            .map(|j| ((i * 13 + j * 29) % 89) as f32 / 89.0)
+            .collect();
+        let a = serial.search(&q, 10).unwrap();
+        let b = mixed.search(&q, 10).unwrap();
+        assert_eq!(a, b, "query {i} diverged between serial and mixed build");
+    }
+}


### PR DESCRIPTION
Follow-ups from the #28/#30 reviews, targeting the integration branch so the whole stack lands in main together.

## test(core): add_batch onto a non-empty store/index
Every *successful* `add_batch` in the suite started from an empty store/index, where batch-local positions coincide with global ones. A regression recording batch-local offsets in `id_to_index` (or restarting HNSW slots at zero) would have passed every existing test.

Both new tests were verified by mutation: injecting exactly those regressions fails only the new tests while all pre-existing tests stay green.

- `add_batch_onto_nonempty_store`: serial adds then a batch; `get()` must resolve every id to its own vector.
- `hnsw_add_batch_onto_nonempty_matches_serial_add`: serial+batch build must be bit-identical (same seed) to a pure-serial build, and `get_vector` must stay correct for both pre-existing and batched ids.

## fix(capi): vanedb_rs_mmap_build null-safe when n == 0
The add_batch entry points from #30 document and guard "ids/vecs may be null when n == 0"; `vanedb_rs_mmap_build` predates that contract and called `slice::from_raw_parts` unguarded — instant UB with null pointers (the new test aborts under the debug-build precondition check without the fix). Guarded the empty case the same way, aligned the safety docs, header regenerated by cbindgen.

Verified: `cargo fmt --check`, `cargo clippy --workspace --exclude vanedb-py --all-targets --features mmap -- -D warnings`, `cargo test --workspace --exclude vanedb-py --features mmap` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H