### PR TITLE
ci: compile-check vanedb-py on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,18 @@ jobs:
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --exclude vanedb-py --all-targets --features mmap -- -D warnings
 
+  check-py:
+    name: Check (Python bindings)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      # vanedb-py is excluded from the workspace jobs (building a wheel needs
+      # maturin), but `cargo check` needs only a Python interpreter, so the
+      # crate at least compiling is verified on every PR. Full behavior tests
+      # still run locally via maturin develop + pytest.
+      - run: cargo check -p vanedb-py
+
   test-linux:
     name: Test (Linux x86_64)
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes the CI hole found in the #29 review: **no CI job compiles vanedb-py at all** (every workspace job passes `--exclude vanedb-py` because a wheel build needs maturin). A breaking pyo3 or core-API change in the crate would only surface at the next local `maturin develop`.

`cargo check -p vanedb-py` needs only a Python interpreter (present on ubuntu runners) — no maturin, no linking. Behavior tests still run locally via `maturin develop --release` + pytest, per AGENTS.md.

The job is static — no `${{ }}` interpolation, read-only permissions inherited from the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H