### PR TITLE
feat: add_batch bulk insert across py, capi, and wasm bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,39 @@
 
 Embeddable vector database for edge AI — Rust crate with Python (PyO3) and WASM bindings.
 
+## Quick start
+
+### Rust
+
+```rust
+use vanedb::{DistanceMetric, HnswIndex};
+
+let index = HnswIndex::builder(768, DistanceMetric::Cosine)
+    .capacity(100_000)
+    .build()?;
+index.add(1, &embedding)?;             // single insert
+index.add_batch(&ids, &flat_vectors)?; // bulk insert, row-major n × dim floats
+let hits = index.search(&query, 10)?;
+```
+
+### Python
+
+```python
+import numpy as np
+import vanedb
+
+index = vanedb.PyHnswIndex(768, vanedb.PyDistanceMetric.Cosine, capacity=100_000)
+vecs = np.asarray(embeddings, dtype=np.float32)  # shape (n, 768)
+index.add_batch(np.arange(len(vecs), dtype=np.uint64), vecs)
+hits = index.search(vecs[0], 10)  # [(id, distance), ...]
+```
+
+Vector arguments accept any buffer-protocol object (numpy `float32` arrays,
+`array.array`, memoryviews) as well as plain Python lists. `add_batch` is
+all-or-nothing and releases the GIL while the index builds. The same batch
+API is exposed in the wasm bindings (`Float32Array`/`BigUint64Array`) and
+the C ABI (`vanedb_rs_*_add_batch`).
+
 ## Implementations
 
 - **Rust** (this repo) — `cargo add vanedb`, Python via `vanedb-py` (PyO3), WASM via `vanedb-wasm` (wasm-bindgen).

--- a/vanedb-capi/include/vanedb_rs_capi.h
+++ b/vanedb-capi/include/vanedb_rs_capi.h
@@ -51,6 +51,17 @@ int32_t vanedb_rs_store_add(VectorStore *s, uint64_t id, const float *v);
 
 /**
  * # Safety
+ * `s` must be a live handle from `vanedb_rs_store_new` (or null); `ids` must point to
+ * `n` valid `u64`s and `vecs` to `n * dim` valid `f32`s (both may be null when `n` is 0).
+ * All-or-nothing: on error (duplicate id, length mismatch) the store is unchanged.
+ */
+int32_t vanedb_rs_store_add_batch(VectorStore *s,
+                                  const uint64_t *ids,
+                                  const float *vecs,
+                                  uintptr_t n);
+
+/**
+ * # Safety
  * `s` must be a live handle from `vanedb_rs_store_new` (or null); `q` must point to
  * `dim` valid `f32`s; `out_ids` and `out_dists` must each have room for `k` elements.
  */
@@ -85,6 +96,14 @@ HnswIndex *vanedb_rs_hnsw_new(uintptr_t dim,
  * `v` must point to at least `dim` valid `f32` values (where `dim` matches the index).
  */
 int32_t vanedb_rs_hnsw_add(HnswIndex *h, uint64_t id, const float *v);
+
+/**
+ * # Safety
+ * `h` must be a live handle from `vanedb_rs_hnsw_new` (or null); `ids` must point to
+ * `n` valid `u64`s and `vecs` to `n * dim` valid `f32`s (both may be null when `n` is 0).
+ * All-or-nothing: on error (duplicate id, capacity, length mismatch) the index is unchanged.
+ */
+int32_t vanedb_rs_hnsw_add_batch(HnswIndex *h, const uint64_t *ids, const float *vecs, uintptr_t n);
 
 /**
  * # Safety

--- a/vanedb-capi/include/vanedb_rs_capi.h
+++ b/vanedb-capi/include/vanedb_rs_capi.h
@@ -140,8 +140,8 @@ void vanedb_rs_hnsw_free(HnswIndex *h);
 
 /**
  * # Safety
- * `path` must be a valid NUL-terminated C string; `ids` must point to `n` valid `u64`s;
- * `vecs` must point to `n * dim` valid `f32`s.
+ * `path` must be a valid NUL-terminated C string; `ids` must point to `n` valid `u64`s
+ * and `vecs` to `n * dim` valid `f32`s (both may be null when `n` is 0).
  */
 int32_t vanedb_rs_mmap_build(const char *path,
                              uintptr_t dim,

--- a/vanedb-capi/src/lib.rs
+++ b/vanedb-capi/src/lib.rs
@@ -78,6 +78,35 @@ pub unsafe extern "C" fn vanedb_rs_store_add(s: *mut VectorStore, id: u64, v: *c
 }
 
 /// # Safety
+/// `s` must be a live handle from `vanedb_rs_store_new` (or null); `ids` must point to
+/// `n` valid `u64`s and `vecs` to `n * dim` valid `f32`s (both may be null when `n` is 0).
+/// All-or-nothing: on error (duplicate id, length mismatch) the store is unchanged.
+#[no_mangle]
+pub unsafe extern "C" fn vanedb_rs_store_add_batch(
+    s: *mut VectorStore,
+    ids: *const u64,
+    vecs: *const f32,
+    n: usize,
+) -> i32 {
+    if s.is_null() {
+        return 1;
+    }
+    let store = &*s;
+    let (id_slice, vec_slice): (&[u64], &[f32]) = if n == 0 {
+        (&[], &[])
+    } else {
+        (
+            slice::from_raw_parts(ids, n),
+            slice::from_raw_parts(vecs, n * store.dimension()),
+        )
+    };
+    match store.add_batch(id_slice, vec_slice) {
+        Ok(()) => 0,
+        Err(_) => 1,
+    }
+}
+
+/// # Safety
 /// `s` must be a live handle from `vanedb_rs_store_new` (or null); `q` must point to
 /// `dim` valid `f32`s; `out_ids` and `out_dists` must each have room for `k` elements.
 #[no_mangle]
@@ -151,6 +180,35 @@ pub unsafe extern "C" fn vanedb_rs_hnsw_add(h: *mut HnswIndex, id: u64, v: *cons
     let idx = &*h;
     let vec = slice::from_raw_parts(v, idx.dimension());
     match idx.add(id, vec) {
+        Ok(()) => 0,
+        Err(_) => 1,
+    }
+}
+
+/// # Safety
+/// `h` must be a live handle from `vanedb_rs_hnsw_new` (or null); `ids` must point to
+/// `n` valid `u64`s and `vecs` to `n * dim` valid `f32`s (both may be null when `n` is 0).
+/// All-or-nothing: on error (duplicate id, capacity, length mismatch) the index is unchanged.
+#[no_mangle]
+pub unsafe extern "C" fn vanedb_rs_hnsw_add_batch(
+    h: *mut HnswIndex,
+    ids: *const u64,
+    vecs: *const f32,
+    n: usize,
+) -> i32 {
+    if h.is_null() {
+        return 1;
+    }
+    let idx = &*h;
+    let (id_slice, vec_slice): (&[u64], &[f32]) = if n == 0 {
+        (&[], &[])
+    } else {
+        (
+            slice::from_raw_parts(ids, n),
+            slice::from_raw_parts(vecs, n * idx.dimension()),
+        )
+    };
+    match idx.add_batch(id_slice, vec_slice) {
         Ok(()) => 0,
         Err(_) => 1,
     }

--- a/vanedb-capi/src/lib.rs
+++ b/vanedb-capi/src/lib.rs
@@ -294,8 +294,8 @@ pub unsafe extern "C" fn vanedb_rs_hnsw_free(h: *mut HnswIndex) {
 }
 
 /// # Safety
-/// `path` must be a valid NUL-terminated C string; `ids` must point to `n` valid `u64`s;
-/// `vecs` must point to `n * dim` valid `f32`s.
+/// `path` must be a valid NUL-terminated C string; `ids` must point to `n` valid `u64`s
+/// and `vecs` to `n * dim` valid `f32`s (both may be null when `n` is 0).
 #[no_mangle]
 pub unsafe extern "C" fn vanedb_rs_mmap_build(
     path: *const c_char,
@@ -316,7 +316,11 @@ pub unsafe extern "C" fn vanedb_rs_mmap_build(
         Ok(b) => b,
         Err(_) => return 1,
     };
-    let id_slice = slice::from_raw_parts(ids, n);
+    let id_slice: &[u64] = if n == 0 {
+        &[]
+    } else {
+        slice::from_raw_parts(ids, n)
+    };
     for (i, &id) in id_slice.iter().enumerate() {
         let v = slice::from_raw_parts(vecs.add(i * dim), dim);
         if b.add(id, v).is_err() {

--- a/vanedb-capi/tests/capi.rs
+++ b/vanedb-capi/tests/capi.rs
@@ -186,3 +186,96 @@ fn store() {
         );
     }
 }
+
+#[test]
+fn store_add_batch() {
+    let ids = [1u64, 2, 3];
+    let flat = [0.0f32, 0.0, 1.0, 1.0, 5.0, 5.0];
+    unsafe {
+        let s = vanedb_capi::vanedb_rs_store_new(2, 0);
+        assert_eq!(
+            vanedb_capi::vanedb_rs_store_add_batch(s, ids.as_ptr(), flat.as_ptr(), 3),
+            0
+        );
+        let q = [0.9f32, 0.9];
+        let mut out_ids = [0u64; 1];
+        let mut out_ds = [0.0f32; 1];
+        let n = vanedb_capi::vanedb_rs_store_search(
+            s,
+            q.as_ptr(),
+            1,
+            out_ids.as_mut_ptr(),
+            out_ds.as_mut_ptr(),
+        );
+        assert_eq!(n, 1);
+        assert_eq!(out_ids[0], 2);
+
+        // duplicate id -> error, all-or-nothing (store unchanged: id 4 absent)
+        let dup_ids = [4u64, 1];
+        assert_eq!(
+            vanedb_capi::vanedb_rs_store_add_batch(s, dup_ids.as_ptr(), flat.as_ptr(), 2),
+            1
+        );
+
+        // empty batch is a no-op success, even with null pointers
+        assert_eq!(
+            vanedb_capi::vanedb_rs_store_add_batch(s, std::ptr::null(), std::ptr::null(), 0),
+            0
+        );
+
+        // null handle guard
+        assert_eq!(
+            vanedb_capi::vanedb_rs_store_add_batch(
+                std::ptr::null_mut(),
+                ids.as_ptr(),
+                flat.as_ptr(),
+                3
+            ),
+            1
+        );
+        vanedb_capi::vanedb_rs_store_free(s);
+    }
+}
+
+#[test]
+fn hnsw_add_batch() {
+    let ids = [10u64, 20];
+    let flat = [0.0f32, 0.0, 1.0, 1.0];
+    unsafe {
+        let h = vanedb_capi::vanedb_rs_hnsw_new(2, 0, 100, 16, 200, 42);
+        assert_eq!(
+            vanedb_capi::vanedb_rs_hnsw_add_batch(h, ids.as_ptr(), flat.as_ptr(), 2),
+            0
+        );
+        let q = [0.1f32, 0.1];
+        let mut out_ids = [0u64; 2];
+        let mut out_ds = [0.0f32; 2];
+        let n = vanedb_capi::vanedb_rs_hnsw_search(
+            h,
+            q.as_ptr(),
+            2,
+            50,
+            out_ids.as_mut_ptr(),
+            out_ds.as_mut_ptr(),
+        );
+        assert_eq!(n, 2);
+        assert_eq!(out_ids[0], 10);
+
+        // duplicate -> error
+        assert_eq!(
+            vanedb_capi::vanedb_rs_hnsw_add_batch(h, ids.as_ptr(), flat.as_ptr(), 2),
+            1
+        );
+        // null handle guard
+        assert_eq!(
+            vanedb_capi::vanedb_rs_hnsw_add_batch(
+                std::ptr::null_mut(),
+                ids.as_ptr(),
+                flat.as_ptr(),
+                2
+            ),
+            1
+        );
+        vanedb_capi::vanedb_rs_hnsw_free(h);
+    }
+}

--- a/vanedb-capi/tests/capi.rs
+++ b/vanedb-capi/tests/capi.rs
@@ -131,6 +131,36 @@ fn mmap() {
     let _ = std::fs::remove_file("rs_capi_mmap.bin");
 }
 
+/// n == 0 with null ids/vecs must build a valid empty store, matching the
+/// null-safe-when-empty contract of the add_batch entry points.
+#[test]
+fn mmap_build_empty_with_null_pointers() {
+    let path = std::ffi::CString::new("rs_capi_mmap_empty.bin").unwrap();
+    unsafe {
+        assert_eq!(
+            vanedb_capi::vanedb_rs_mmap_build(
+                path.as_ptr(),
+                2,
+                0,
+                std::ptr::null(),
+                std::ptr::null(),
+                0
+            ),
+            0
+        );
+        let m = vanedb_capi::vanedb_rs_mmap_open(path.as_ptr());
+        assert!(!m.is_null());
+        let q = [0.0f32, 0.0];
+        let mut ids = [0u64; 2];
+        let mut ds = [0.0f32; 2];
+        let n =
+            vanedb_capi::vanedb_rs_mmap_search(m, q.as_ptr(), 2, ids.as_mut_ptr(), ds.as_mut_ptr());
+        assert_eq!(n, 0);
+        vanedb_capi::vanedb_rs_mmap_free(m);
+    }
+    let _ = std::fs::remove_file("rs_capi_mmap_empty.bin");
+}
+
 #[test]
 fn distance() {
     let a = [1.0f32, 2.0, 3.0, 4.0];

--- a/vanedb-py/src/lib.rs
+++ b/vanedb-py/src/lib.rs
@@ -1,4 +1,5 @@
-use pyo3::exceptions::PyValueError;
+use pyo3::buffer::PyBuffer;
+use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 
 use ::vanedb::distance::DistanceMetric;
@@ -10,8 +11,115 @@ fn to_pyerr(e: VaneError) -> PyErr {
     PyValueError::new_err(e.to_string())
 }
 
+/// Extract a single vector. Fast paths: any 1-D float32 or float64 buffer
+/// (numpy array, array.array, memoryview) copied wholesale; fallback: generic
+/// sequence extraction (lists), matching the pre-buffer behavior. Rank is
+/// validated in every buffer branch so shape errors do not depend on dtype.
+fn vec_f32(obj: &Bound<'_, PyAny>) -> PyResult<Vec<f32>> {
+    if let Ok(buf) = PyBuffer::<f32>::get(obj) {
+        check_rank(buf.dimensions(), 1, "expected a 1-D vector")?;
+        return buf.to_vec(obj.py());
+    }
+    if let Ok(buf) = PyBuffer::<f64>::get(obj) {
+        check_rank(buf.dimensions(), 1, "expected a 1-D vector")?;
+        return Ok(buf.to_vec(obj.py())?.iter().map(|&x| x as f32).collect());
+    }
+    obj.extract()
+}
+
+fn check_rank(got: usize, expected: usize, what: &str) -> PyResult<()> {
+    if got != expected {
+        return Err(PyValueError::new_err(format!(
+            "{what}, got a {got}-D buffer"
+        )));
+    }
+    Ok(())
+}
+
+/// Extract a batch of vectors as (row_count, flat row-major f32).
+/// Fast paths: a 2-D float32 or float64 buffer of shape (n, dim); fallback: a
+/// sequence of float sequences. Row width is validated here because the core's
+/// flat-length check alone cannot catch ragged rows whose total happens to
+/// match. Rank and width are validated in every buffer branch so shape errors
+/// do not depend on dtype.
+fn batch_f32(obj: &Bound<'_, PyAny>, dim: usize) -> PyResult<(usize, Vec<f32>)> {
+    fn check_shape(rank: usize, shape: &[usize], dim: usize) -> PyResult<()> {
+        check_rank(
+            rank,
+            2,
+            &format!("expected a 2-D array of shape (n, {dim})"),
+        )?;
+        if shape[1] != dim {
+            return Err(PyValueError::new_err(format!(
+                "dimension mismatch: expected vectors of dimension {dim}, got {}",
+                shape[1]
+            )));
+        }
+        Ok(())
+    }
+    if let Ok(buf) = PyBuffer::<f32>::get(obj) {
+        check_shape(buf.dimensions(), buf.shape(), dim)?;
+        return Ok((buf.shape()[0], buf.to_vec(obj.py())?));
+    }
+    if let Ok(buf) = PyBuffer::<f64>::get(obj) {
+        check_shape(buf.dimensions(), buf.shape(), dim)?;
+        let flat = buf.to_vec(obj.py())?.iter().map(|&x| x as f32).collect();
+        return Ok((buf.shape()[0], flat));
+    }
+    let rows: Vec<Vec<f32>> = obj.extract().map_err(|_| {
+        PyTypeError::new_err(
+            "vectors must be a 2-D float32 buffer (e.g. numpy array) or a sequence of float sequences",
+        )
+    })?;
+    let mut flat = Vec::with_capacity(rows.len() * dim);
+    for row in &rows {
+        if row.len() != dim {
+            return Err(PyValueError::new_err(format!(
+                "dimension mismatch: expected vectors of dimension {dim}, got {}",
+                row.len()
+            )));
+        }
+        flat.extend_from_slice(row);
+    }
+    Ok((rows.len(), flat))
+}
+
+/// Extract ids. Fast paths: 1-D uint64 or int64 buffers (int64 is numpy's
+/// default integer dtype; negative values are rejected); fallback: sequence.
+fn ids_u64(obj: &Bound<'_, PyAny>) -> PyResult<Vec<u64>> {
+    if let Ok(buf) = PyBuffer::<u64>::get(obj) {
+        if buf.dimensions() != 1 {
+            return Err(PyValueError::new_err("ids must be 1-D"));
+        }
+        return buf.to_vec(obj.py());
+    }
+    if let Ok(buf) = PyBuffer::<i64>::get(obj) {
+        if buf.dimensions() != 1 {
+            return Err(PyValueError::new_err("ids must be 1-D"));
+        }
+        return buf
+            .to_vec(obj.py())?
+            .into_iter()
+            .map(|x| {
+                u64::try_from(x).map_err(|_| PyValueError::new_err(format!("negative id: {x}")))
+            })
+            .collect();
+    }
+    obj.extract()
+}
+
+fn check_batch_len(ids: &[u64], rows: usize) -> PyResult<()> {
+    if ids.len() != rows {
+        return Err(PyValueError::new_err(format!(
+            "ids length {} does not match number of vectors {rows}",
+            ids.len()
+        )));
+    }
+    Ok(())
+}
+
 /// Distance metric enum.
-#[pyclass(eq, eq_int)]
+#[pyclass(eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq)]
 enum PyDistanceMetric {
     L2 = 0,
@@ -44,12 +152,37 @@ impl PyVectorStore {
         Ok(Self { inner })
     }
 
-    fn add(&self, id: u64, vector: Vec<f32>) -> PyResult<()> {
-        self.inner.add(id, &vector).map_err(to_pyerr)
+    /// Add one vector. Accepts a 1-D float32 buffer (numpy) or any float sequence.
+    fn add(&self, id: u64, vector: &Bound<'_, PyAny>) -> PyResult<()> {
+        let v = vec_f32(vector)?;
+        self.inner.add(id, &v).map_err(to_pyerr)
     }
 
-    fn search(&self, query: Vec<f32>, k: usize) -> PyResult<Vec<(u64, f32)>> {
-        let results = self.inner.search(&query, k).map_err(to_pyerr)?;
+    /// Bulk insert. `ids`: 1-D uint64/int64 buffer or int sequence; `vectors`:
+    /// 2-D float32 buffer of shape (n, dim) or sequence of float sequences.
+    /// All-or-nothing; the GIL is released while inserting.
+    fn add_batch(
+        &self,
+        py: Python<'_>,
+        ids: &Bound<'_, PyAny>,
+        vectors: &Bound<'_, PyAny>,
+    ) -> PyResult<()> {
+        let ids = ids_u64(ids)?;
+        let (rows, flat) = batch_f32(vectors, self.inner.dimension())?;
+        check_batch_len(&ids, rows)?;
+        py.detach(|| self.inner.add_batch(&ids, &flat))
+            .map_err(to_pyerr)
+    }
+
+    /// k-NN search. Accepts a 1-D float32 buffer (numpy) or any float sequence.
+    fn search(
+        &self,
+        py: Python<'_>,
+        query: &Bound<'_, PyAny>,
+        k: usize,
+    ) -> PyResult<Vec<(u64, f32)>> {
+        let q = vec_f32(query)?;
+        let results = py.detach(|| self.inner.search(&q, k)).map_err(to_pyerr)?;
         Ok(results.into_iter().map(|r| (r.id, r.distance)).collect())
     }
 
@@ -103,12 +236,37 @@ impl PyHnswIndex {
         Ok(Self { inner })
     }
 
-    fn add(&self, id: u64, vector: Vec<f32>) -> PyResult<()> {
-        self.inner.add(id, &vector).map_err(to_pyerr)
+    /// Add one vector. Accepts a 1-D float32 buffer (numpy) or any float sequence.
+    fn add(&self, py: Python<'_>, id: u64, vector: &Bound<'_, PyAny>) -> PyResult<()> {
+        let v = vec_f32(vector)?;
+        py.detach(|| self.inner.add(id, &v)).map_err(to_pyerr)
     }
 
-    fn search(&self, query: Vec<f32>, k: usize) -> PyResult<Vec<(u64, f32)>> {
-        let results = self.inner.search(&query, k).map_err(to_pyerr)?;
+    /// Bulk insert. `ids`: 1-D uint64/int64 buffer or int sequence; `vectors`:
+    /// 2-D float32 buffer of shape (n, dim) or sequence of float sequences.
+    /// All-or-nothing; the GIL is released while the graph is built.
+    fn add_batch(
+        &self,
+        py: Python<'_>,
+        ids: &Bound<'_, PyAny>,
+        vectors: &Bound<'_, PyAny>,
+    ) -> PyResult<()> {
+        let ids = ids_u64(ids)?;
+        let (rows, flat) = batch_f32(vectors, self.inner.dimension())?;
+        check_batch_len(&ids, rows)?;
+        py.detach(|| self.inner.add_batch(&ids, &flat))
+            .map_err(to_pyerr)
+    }
+
+    /// k-NN search. Accepts a 1-D float32 buffer (numpy) or any float sequence.
+    fn search(
+        &self,
+        py: Python<'_>,
+        query: &Bound<'_, PyAny>,
+        k: usize,
+    ) -> PyResult<Vec<(u64, f32)>> {
+        let q = vec_f32(query)?;
+        let results = py.detach(|| self.inner.search(&q, k)).map_err(to_pyerr)?;
         Ok(results.into_iter().map(|r| (r.id, r.distance)).collect())
     }
 

--- a/vanedb-py/tests/test_numpy_batch.py
+++ b/vanedb-py/tests/test_numpy_batch.py
@@ -1,0 +1,162 @@
+"""Buffer-protocol (numpy) input and add_batch — issues #19 and #20.
+
+CI excludes vanedb-py; these run locally via maturin develop + pytest.
+"""
+import pytest
+
+np = pytest.importorskip("numpy")
+import vanedb
+
+
+# --- single-vector buffer input (issue #20) ---
+
+def test_store_add_and_search_numpy_f32():
+    store = vanedb.PyVectorStore(3)
+    store.add(1, np.array([1.0, 2.0, 3.0], dtype=np.float32))
+    store.add(2, np.array([4.0, 5.0, 6.0], dtype=np.float32))
+    assert store.get(1) == [1.0, 2.0, 3.0]
+    results = store.search(np.array([1.0, 2.0, 3.1], dtype=np.float32), 1)
+    assert results[0][0] == 1
+
+
+def test_store_add_numpy_f64_falls_back():
+    # float64 has no f32 fast path but must still work via the sequence path
+    store = vanedb.PyVectorStore(2)
+    store.add(1, np.array([1.0, 2.0]))  # default dtype float64
+    assert store.get(1) == [1.0, 2.0]
+
+
+def test_store_add_2d_buffer_rejected_for_single_add():
+    store = vanedb.PyVectorStore(2)
+    with pytest.raises(ValueError, match="1-D"):
+        store.add(1, np.zeros((2, 2), dtype=np.float32))
+
+
+def test_lists_still_work():
+    store = vanedb.PyVectorStore(2)
+    store.add(1, [1.0, 2.0])
+    assert store.search([1.0, 2.0], 1)[0][0] == 1
+
+
+# --- add_batch (issue #19) ---
+
+def test_store_add_batch_numpy():
+    rng = np.random.default_rng(0)
+    vecs = rng.random((100, 8), dtype=np.float32)
+    ids = np.arange(100, dtype=np.uint64)
+    store = vanedb.PyVectorStore(8)
+    store.add_batch(ids, vecs)
+    assert len(store) == 100
+    results = store.search(vecs[42], 1)
+    assert results[0][0] == 42
+
+
+def test_store_add_batch_int64_ids():
+    # np.arange default dtype is int64; must be accepted
+    store = vanedb.PyVectorStore(2)
+    store.add_batch(np.arange(3), np.ones((3, 2), dtype=np.float32))
+    assert len(store) == 3
+
+
+def test_store_add_batch_negative_id_raises():
+    store = vanedb.PyVectorStore(2)
+    with pytest.raises(ValueError, match="negative"):
+        store.add_batch(np.array([0, -1]), np.ones((2, 2), dtype=np.float32))
+    assert len(store) == 0
+
+
+def test_store_add_batch_list_fallback():
+    store = vanedb.PyVectorStore(2)
+    store.add_batch([10, 20], [[1.0, 2.0], [3.0, 4.0]])
+    assert store.get(20) == [3.0, 4.0]
+
+
+def test_store_add_batch_ragged_rows_raise():
+    store = vanedb.PyVectorStore(3)
+    # total length 6 == 2*3 would pass a naive flat check; per-row must fail
+    with pytest.raises(ValueError):
+        store.add_batch([1, 2], [[1.0, 2.0], [3.0, 4.0, 5.0, 6.0]])
+    assert len(store) == 0
+
+
+def test_store_add_batch_wrong_width_raises():
+    store = vanedb.PyVectorStore(3)
+    with pytest.raises(ValueError):
+        store.add_batch(np.arange(2), np.ones((2, 4), dtype=np.float32))
+    assert len(store) == 0
+
+
+def test_store_add_batch_ids_vectors_count_mismatch():
+    store = vanedb.PyVectorStore(2)
+    with pytest.raises(ValueError):
+        store.add_batch(np.arange(3), np.ones((2, 2), dtype=np.float32))
+    assert len(store) == 0
+
+
+def test_store_add_batch_numpy_f64_2d():
+    # float64 is numpy's default dtype; a well-formed 2-D batch must insert
+    store = vanedb.PyVectorStore(3)
+    store.add_batch(np.arange(2), np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
+    assert len(store) == 2
+    assert store.get(1) == [4.0, 5.0, 6.0]
+
+
+def test_store_add_batch_f64_wrong_rank_raises():
+    # Shape validation must not depend on dtype: the float32 twin of this
+    # array is rejected as 3-D, so the float64 one must be too — not silently
+    # flattened through numpy's element coercion.
+    store = vanedb.PyVectorStore(3)
+    with pytest.raises(ValueError, match="2-D"):
+        store.add_batch(np.arange(2), np.zeros((2, 3, 1)))
+    assert len(store) == 0
+
+
+def test_store_add_f64_wrong_rank_raises():
+    # float64 twin of test_store_add_2d_buffer_rejected_for_single_add
+    store = vanedb.PyVectorStore(3)
+    with pytest.raises(ValueError, match="1-D"):
+        store.add(1, np.zeros((3, 1)))
+    assert len(store) == 0
+
+
+def test_store_add_batch_duplicate_is_all_or_nothing():
+    store = vanedb.PyVectorStore(2)
+    store.add(5, [0.0, 0.0])
+    with pytest.raises(ValueError, match="duplicate"):
+        store.add_batch(np.array([4, 5], dtype=np.uint64),
+                        np.ones((2, 2), dtype=np.float32))
+    assert len(store) == 1
+    assert not store.contains(4)
+
+
+def test_store_add_batch_noncontiguous_slice():
+    vecs = np.arange(40, dtype=np.float32).reshape(10, 4)
+    view = vecs[::2]  # non C-contiguous
+    store = vanedb.PyVectorStore(4)
+    store.add_batch(np.arange(5, dtype=np.uint64), view)
+    assert store.get(1) == view[1].tolist()
+
+
+# --- HNSW ---
+
+def test_hnsw_add_batch_matches_serial():
+    rng = np.random.default_rng(1)
+    vecs = rng.random((200, 16), dtype=np.float32)
+    ids = np.arange(200, dtype=np.uint64)
+
+    serial = vanedb.PyHnswIndex(16, capacity=200, seed=3)
+    for i in range(200):
+        serial.add(int(ids[i]), vecs[i])
+    batched = vanedb.PyHnswIndex(16, capacity=200, seed=3)
+    batched.add_batch(ids, vecs)
+
+    assert len(batched) == 200
+    q = rng.random(16, dtype=np.float32)
+    assert serial.search(q, 10) == batched.search(q, 10)
+
+
+def test_hnsw_add_batch_capacity_all_or_nothing():
+    index = vanedb.PyHnswIndex(2, capacity=3)
+    with pytest.raises(ValueError, match="full"):
+        index.add_batch(np.arange(4), np.ones((4, 2), dtype=np.float32))
+    assert len(index) == 0

--- a/vanedb-wasm/src/lib.rs
+++ b/vanedb-wasm/src/lib.rs
@@ -43,6 +43,13 @@ impl WasmVectorStore {
         self.inner.add(id, vector).map_err(to_jserr)
     }
 
+    /// Bulk insert in one wasm call: `ids` is a BigUint64Array of n ids and
+    /// `vectors` a Float32Array of n × dim values (row-major). All-or-nothing:
+    /// on error the store is unchanged.
+    pub fn add_batch(&self, ids: &[u64], vectors: &[f32]) -> Result<(), JsError> {
+        self.inner.add_batch(ids, vectors).map_err(to_jserr)
+    }
+
     /// Search for k nearest neighbors. Returns flat array: [id0, dist0, id1, dist1, ...].
     pub fn search(&self, query: &[f32], k: usize) -> Result<Vec<f32>, JsError> {
         let results = self.inner.search(query, k).map_err(to_jserr)?;
@@ -104,6 +111,13 @@ impl WasmHnswIndex {
 
     pub fn add(&self, id: u64, vector: &[f32]) -> Result<(), JsError> {
         self.inner.add(id, vector).map_err(to_jserr)
+    }
+
+    /// Bulk insert in one wasm call: `ids` is a BigUint64Array of n ids and
+    /// `vectors` a Float32Array of n × dim values (row-major). All-or-nothing:
+    /// on error the index is unchanged.
+    pub fn add_batch(&self, ids: &[u64], vectors: &[f32]) -> Result<(), JsError> {
+        self.inner.add_batch(ids, vectors).map_err(to_jserr)
     }
 
     /// Search for k nearest neighbors. Returns flat array: [id0, dist0, id1, dist1, ...].

--- a/vanedb-wasm/tests/web.rs
+++ b/vanedb-wasm/tests/web.rs
@@ -62,3 +62,30 @@ fn test_invalid_metric() {
     let result = WasmVectorStore::new(3, "invalid");
     assert!(result.is_err());
 }
+
+#[wasm_bindgen_test]
+fn test_store_add_batch() {
+    let store = WasmVectorStore::new(2, "l2").unwrap();
+    let ids = [1u64, 2, 3];
+    let flat = [0.0f32, 0.0, 1.0, 1.0, 5.0, 5.0];
+    store.add_batch(&ids, &flat).unwrap();
+    assert_eq!(store.size(), 3);
+    let results = store.search(&[0.9, 0.9], 1).unwrap();
+    assert_eq!(results[0] as u64, 2);
+
+    // duplicate -> Err, all-or-nothing
+    assert!(store.add_batch(&[4, 1], &flat[..4]).is_err());
+    assert_eq!(store.size(), 3);
+    assert!(!store.contains(4));
+}
+
+#[wasm_bindgen_test]
+fn test_hnsw_add_batch() {
+    let index = WasmHnswIndex::new(2, "l2", 100, 16, 200).unwrap();
+    let ids = [10u64, 20];
+    let flat = [0.0f32, 0.0, 1.0, 1.0];
+    index.add_batch(&ids, &flat).unwrap();
+    assert_eq!(index.size(), 2);
+    let results = index.search(&[0.1, 0.1], 1).unwrap();
+    assert_eq!(results[0] as u64, 10);
+}

--- a/vanedb/benches/store_bench.rs
+++ b/vanedb/benches/store_bench.rs
@@ -44,5 +44,24 @@ fn bench_store_add(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_store_search, bench_store_add);
+fn bench_store_add_batch(c: &mut Criterion) {
+    let dim = 128;
+    let data = gen_data(10_000, dim);
+    let ids: Vec<u64> = (0..data.len() as u64).collect();
+    let flat: Vec<f32> = data.iter().flatten().copied().collect();
+
+    c.bench_function("VectorStore_add_batch_10k", |bench| {
+        bench.iter(|| {
+            let store = VectorStore::new(dim, DistanceMetric::L2).unwrap();
+            store.add_batch(&ids, &flat).unwrap();
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_store_search,
+    bench_store_add,
+    bench_store_add_batch
+);
 criterion_main!(benches);

--- a/vanedb/src/hnsw/mod.rs
+++ b/vanedb/src/hnsw/mod.rs
@@ -189,6 +189,45 @@ impl HnswIndex {
             return Err(VaneError::DuplicateId { id });
         }
 
+        self.insert_into(&mut inner, id, vector);
+        Ok(())
+    }
+
+    /// Insert many vectors under a single lock acquisition. `vectors` is the
+    /// row-major concatenation of `ids.len()` vectors of `dimension()` floats.
+    /// All-or-nothing: capacity and every id are validated before any insert,
+    /// so an error leaves the index unchanged. Levels are drawn from the RNG
+    /// in batch order, so the resulting graph is identical to serial `add`.
+    pub fn add_batch(&self, ids: &[u64], vectors: &[f32]) -> Result<()> {
+        if vectors.len() != ids.len() * self.dim {
+            return Err(VaneError::DimensionMismatch {
+                expected: ids.len() * self.dim,
+                got: vectors.len(),
+            });
+        }
+
+        let mut inner = self.inner.write();
+
+        if inner.count + ids.len() > self.max_elements {
+            return Err(VaneError::IndexFull);
+        }
+        let mut seen = HashSet::with_capacity(ids.len());
+        for &id in ids {
+            if inner.id_map.contains_key(&id) || !seen.insert(id) {
+                return Err(VaneError::DuplicateId { id });
+            }
+        }
+
+        for (&id, chunk) in ids.iter().zip(vectors.chunks_exact(self.dim)) {
+            self.insert_into(&mut inner, id, chunk);
+        }
+        Ok(())
+    }
+
+    /// Graph insertion body shared by `add` and `add_batch`. Caller must hold
+    /// the write lock and have already validated dimension, capacity, and id
+    /// uniqueness — from here on insertion cannot fail.
+    fn insert_into(&self, inner: &mut Inner, id: u64, vector: &[f32]) {
         let iid = inner.count;
         inner.count += 1;
 
@@ -209,7 +248,7 @@ impl HnswIndex {
         if iid == 0 {
             inner.entry_point = Some(0);
             inner.max_level = level;
-            return Ok(());
+            return;
         }
 
         let mut cur_ep = inner.entry_point.unwrap();
@@ -309,8 +348,6 @@ impl HnswIndex {
             inner.entry_point = Some(iid);
             inner.max_level = level;
         }
-
-        Ok(())
     }
 
     pub fn search(&self, query: &[f32], k: usize) -> Result<Vec<SearchResult>> {

--- a/vanedb/src/store/vector_store.rs
+++ b/vanedb/src/store/vector_store.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use parking_lot::RwLock;
 
@@ -49,6 +49,35 @@ impl VectorStore {
         inner.ids.push(id);
         inner.data.extend_from_slice(vector);
         inner.id_to_index.insert(id, index);
+        Ok(())
+    }
+
+    /// Insert many vectors under a single lock acquisition. `vectors` is the
+    /// row-major concatenation of `ids.len()` vectors of `dimension()` floats.
+    /// All-or-nothing: every length and id is validated before any insert, so
+    /// an error leaves the store unchanged.
+    pub fn add_batch(&self, ids: &[u64], vectors: &[f32]) -> Result<()> {
+        if vectors.len() != ids.len() * self.dim {
+            return Err(VaneError::DimensionMismatch {
+                expected: ids.len() * self.dim,
+                got: vectors.len(),
+            });
+        }
+        let mut inner = self.inner.write();
+        let mut seen = HashSet::with_capacity(ids.len());
+        for &id in ids {
+            if inner.id_to_index.contains_key(&id) || !seen.insert(id) {
+                return Err(VaneError::DuplicateId { id });
+            }
+        }
+        inner.ids.reserve(ids.len());
+        inner.data.reserve(vectors.len());
+        for (&id, chunk) in ids.iter().zip(vectors.chunks_exact(self.dim)) {
+            let index = inner.ids.len();
+            inner.ids.push(id);
+            inner.data.extend_from_slice(chunk);
+            inner.id_to_index.insert(id, index);
+        }
         Ok(())
     }
 
@@ -324,5 +353,56 @@ mod tests {
     fn store_is_send_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<VectorStore>();
+    }
+
+    #[test]
+    fn add_batch_inserts_all() {
+        let store = VectorStore::new(3, DistanceMetric::L2).unwrap();
+        let ids = [1u64, 2, 3];
+        let vectors = [1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0];
+        store.add_batch(&ids, &vectors).unwrap();
+        assert_eq!(store.len(), 3);
+        assert_eq!(store.get(2).unwrap(), vec![2.0, 2.0, 2.0]);
+        let results = store.search(&[2.0, 2.0, 2.1], 1).unwrap();
+        assert_eq!(results[0].id, 2);
+    }
+
+    #[test]
+    fn add_batch_empty_is_noop() {
+        let store = VectorStore::new(3, DistanceMetric::L2).unwrap();
+        store.add_batch(&[], &[]).unwrap();
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn add_batch_flat_length_mismatch() {
+        let store = VectorStore::new(3, DistanceMetric::L2).unwrap();
+        let result = store.add_batch(&[1, 2], &[1.0, 2.0, 3.0, 4.0, 5.0]);
+        assert!(matches!(
+            result,
+            Err(VaneError::DimensionMismatch {
+                expected: 6,
+                got: 5
+            })
+        ));
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn add_batch_duplicate_within_batch_is_all_or_nothing() {
+        let store = VectorStore::new(2, DistanceMetric::L2).unwrap();
+        let result = store.add_batch(&[1, 2, 1], &[1.0; 6]);
+        assert!(matches!(result, Err(VaneError::DuplicateId { id: 1 })));
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn add_batch_duplicate_with_existing_is_all_or_nothing() {
+        let store = VectorStore::new(2, DistanceMetric::L2).unwrap();
+        store.add(7, &[0.0, 0.0]).unwrap();
+        let result = store.add_batch(&[8, 7], &[1.0; 4]);
+        assert!(matches!(result, Err(VaneError::DuplicateId { id: 7 })));
+        assert_eq!(store.len(), 1);
+        assert!(!store.contains(8));
     }
 }

--- a/vanedb/src/store/vector_store.rs
+++ b/vanedb/src/store/vector_store.rs
@@ -405,4 +405,30 @@ mod tests {
         assert_eq!(store.len(), 1);
         assert!(!store.contains(8));
     }
+
+    /// Success path onto a non-empty store: the positions recorded in
+    /// id_to_index must be global (existing rows + batch offset), not
+    /// batch-local, or every batched id resolves to the wrong vector.
+    #[test]
+    fn add_batch_onto_nonempty_store() {
+        let store = VectorStore::new(3, DistanceMetric::L2).unwrap();
+        store.add(1, &[1.0, 1.0, 1.0]).unwrap();
+        store.add(2, &[2.0, 2.0, 2.0]).unwrap();
+
+        let ids = [3u64, 4, 5];
+        let vectors = [3.0, 3.0, 3.0, 4.0, 4.0, 4.0, 5.0, 5.0, 5.0];
+        store.add_batch(&ids, &vectors).unwrap();
+
+        assert_eq!(store.len(), 5);
+        for id in 1..=5u64 {
+            let v = id as f32;
+            assert_eq!(
+                store.get(id).unwrap(),
+                vec![v, v, v],
+                "wrong data for id {id}"
+            );
+        }
+        let results = store.search(&[4.0, 4.0, 4.1], 1).unwrap();
+        assert_eq!(results[0].id, 4);
+    }
 }

--- a/vanedb/tests/hnsw_tests.rs
+++ b/vanedb/tests/hnsw_tests.rs
@@ -237,3 +237,96 @@ fn hnsw_visited_bitmap_epoch_wrap_correctness() {
         assert_eq!(a.id, b.id, "result drifted across epoch wrap");
     }
 }
+
+/// add_batch must produce a graph identical to serial add: same seed means the
+/// level RNG is drawn in the same order, so searches must return identical
+/// results, not merely similar recall.
+#[test]
+fn hnsw_add_batch_matches_serial_add() {
+    let dim = 16;
+    let n = 300;
+
+    let mk = || {
+        HnswIndex::builder(dim, DistanceMetric::L2)
+            .capacity(n)
+            .m(8)
+            .ef_construction(100)
+            .seed(7)
+            .build()
+            .unwrap()
+    };
+    let serial = mk();
+    let batched = mk();
+
+    let mut ids = Vec::with_capacity(n);
+    let mut flat = Vec::with_capacity(n * dim);
+    for i in 0..n {
+        let v: Vec<f32> = (0..dim)
+            .map(|j| ((i * 31 + j * 17) % 97) as f32 / 97.0)
+            .collect();
+        serial.add(i as u64, &v).unwrap();
+        ids.push(i as u64);
+        flat.extend_from_slice(&v);
+    }
+    batched.add_batch(&ids, &flat).unwrap();
+
+    assert_eq!(batched.size(), n);
+    for i in (0..n).step_by(23) {
+        let q: Vec<f32> = (0..dim)
+            .map(|j| ((i * 13 + j * 29) % 89) as f32 / 89.0)
+            .collect();
+        let a = serial.search(&q, 10).unwrap();
+        let b = batched.search(&q, 10).unwrap();
+        assert_eq!(a, b, "query {i} diverged between serial and batch build");
+    }
+}
+
+#[test]
+fn hnsw_add_batch_capacity_exceeded_is_all_or_nothing() {
+    let index = HnswIndex::builder(4, DistanceMetric::L2)
+        .capacity(4)
+        .build()
+        .unwrap();
+    index.add(99, &[0.5; 4]).unwrap();
+
+    let ids: Vec<u64> = (0..4).collect();
+    let flat = vec![1.0f32; 16];
+    let result = index.add_batch(&ids, &flat);
+    assert!(matches!(result, Err(vanedb::VaneError::IndexFull)));
+    assert_eq!(index.size(), 1);
+    assert!(!index.contains(0));
+}
+
+#[test]
+fn hnsw_add_batch_duplicate_is_all_or_nothing() {
+    let index = HnswIndex::builder(2, DistanceMetric::L2)
+        .capacity(10)
+        .build()
+        .unwrap();
+    index.add(5, &[0.1, 0.2]).unwrap();
+
+    let result = index.add_batch(&[4, 5], &[1.0, 2.0, 3.0, 4.0]);
+    assert!(matches!(
+        result,
+        Err(vanedb::VaneError::DuplicateId { id: 5 })
+    ));
+    assert_eq!(index.size(), 1);
+    assert!(!index.contains(4));
+
+    let result = index.add_batch(&[6, 6], &[1.0, 2.0, 3.0, 4.0]);
+    assert!(matches!(
+        result,
+        Err(vanedb::VaneError::DuplicateId { id: 6 })
+    ));
+    assert_eq!(index.size(), 1);
+}
+
+#[test]
+fn hnsw_add_batch_empty_is_noop() {
+    let index = HnswIndex::builder(2, DistanceMetric::L2)
+        .capacity(10)
+        .build()
+        .unwrap();
+    index.add_batch(&[], &[]).unwrap();
+    assert!(index.is_empty());
+}

--- a/vanedb/tests/hnsw_tests.rs
+++ b/vanedb/tests/hnsw_tests.rs
@@ -330,3 +330,67 @@ fn hnsw_add_batch_empty_is_noop() {
     index.add_batch(&[], &[]).unwrap();
     assert!(index.is_empty());
 }
+
+/// Batching onto a NON-EMPTY index must extend the graph exactly as serial
+/// adds would: internal slots continue from the existing count rather than
+/// restarting at zero, so with the same seed searches stay identical and
+/// no pre-existing vector gets overwritten.
+#[test]
+fn hnsw_add_batch_onto_nonempty_matches_serial_add() {
+    let dim = 16;
+    let pre = 100;
+    let n = 300;
+
+    let mk = || {
+        HnswIndex::builder(dim, DistanceMetric::L2)
+            .capacity(n)
+            .m(8)
+            .ef_construction(100)
+            .seed(7)
+            .build()
+            .unwrap()
+    };
+    let serial = mk();
+    let mixed = mk();
+
+    // The first `pre` vectors go in serially on BOTH indexes; the rest
+    // arrive on `mixed` as one batch.
+    let mut ids = Vec::with_capacity(n - pre);
+    let mut flat = Vec::with_capacity((n - pre) * dim);
+    let vec_for = |i: usize| -> Vec<f32> {
+        (0..dim)
+            .map(|j| ((i * 31 + j * 17) % 97) as f32 / 97.0)
+            .collect()
+    };
+    for i in 0..n {
+        let v = vec_for(i);
+        serial.add(i as u64, &v).unwrap();
+        if i < pre {
+            mixed.add(i as u64, &v).unwrap();
+        } else {
+            ids.push(i as u64);
+            flat.extend_from_slice(&v);
+        }
+    }
+    mixed.add_batch(&ids, &flat).unwrap();
+
+    assert_eq!(mixed.size(), n);
+    // Both the pre-existing and the batched ids must still resolve to their
+    // own data — a batch that restarts at slot zero clobbers the former and
+    // misfiles the latter.
+    for i in (0..n).step_by(7) {
+        assert_eq!(
+            mixed.get_vector(i as u64).unwrap(),
+            vec_for(i),
+            "wrong data for id {i}"
+        );
+    }
+    for i in (0..n).step_by(23) {
+        let q: Vec<f32> = (0..dim)
+            .map(|j| ((i * 13 + j * 29) % 89) as f32 / 89.0)
+            .collect();
+        let a = serial.search(&q, 10).unwrap();
+        let b = mixed.search(&q, 10).unwrap();
+        assert_eq!(a, b, "query {i} diverged between serial and mixed build");
+    }
+}


### PR DESCRIPTION
Ships the accumulated `feat/add-batch-core` integration branch to main — everything from the batch stack that isn't in main yet (#28's core already landed as b25b860).

Closes #19, closes #20.

## Contents (net delta vs main, each piece individually reviewed in its own PR)
- **#30** — C ABI `vanedb_rs_{store,hnsw}_add_batch` (null-safe when n==0), regenerated cbindgen header; wasm `add_batch(BigUint64Array, Float32Array)`.
- **#29** — Python numpy/buffer-protocol input on add/search, `add_batch` with GIL released during insert; dtype-independent rank/shape validation (f64 buffers get the same checks and fast path as f32).
- **#31** — README quick start (Rust + Python) and `VectorStore_add_batch_10k` criterion bench.
- **#35** — review follow-ups: mutation-verified tests for add_batch onto a **non-empty** store/index; `vanedb_rs_mmap_build` null-guard for n==0.

Verified locally on the merged tip: `cargo fmt --check`, full workspace test suite with `--features mmap`, and vanedb-py behavior tests (30/30 via maturin develop + pytest). This PR runs full real CI including the new **Check (Python bindings)** job from #36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H