### PR TITLE
fix(release): harden trusted PyPI publishing

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,5 +1,5 @@
-# Codecov configuration for vanedb
-# Documentation: https://docs.codecov.com/docs/codecov-yaml
+# Codecov configuration for the C++ engine.
+# Codecov discovers this file from .github/ at the monorepo root.
 
 coverage:
   precision: 2
@@ -19,13 +19,13 @@ coverage:
         base: auto
 
 ignore:
-  - "tests/**/*"
-  - "benchmarks/**/*"
-  - "examples/**/*"
-  - "python/**/*"
-  - "external/**/*"
-  - "build/**/*"
-  - "**/_deps/**/*"
+  - "cpp/tests"
+  - "cpp/benchmarks"
+  - "cpp/examples"
+  - "cpp/python"
+  - "cpp/external"
+  - "cpp/build"
+  - ".*/_deps/.*"
 
 comment:
   layout: "reach,diff,flags,tree,footer"
@@ -34,9 +34,8 @@ comment:
   require_base: false
   require_head: true
 
-# Scope coverage measurement to library source (excludes tests/python/etc.).
 flags:
   core:
     paths:
-      - src/core/
+      - cpp/src/core/
     carryforward: true

--- a/.github/scripts/validate_python_release.py
+++ b/.github/scripts/validate_python_release.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Validate the identity and coverage of a Python release artifact set."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from email.parser import Parser
+from pathlib import Path
+import tarfile
+import tomllib
+import zipfile
+
+from packaging.utils import canonicalize_name, parse_sdist_filename, parse_wheel_filename
+from packaging.version import Version
+
+
+def expected_count(value: str) -> tuple[str, int]:
+    key, separator, count = value.partition("=")
+    if not separator or not key:
+        raise argparse.ArgumentTypeError("expected KEY=COUNT")
+    try:
+        return key, int(count)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("COUNT must be an integer") from error
+
+
+def package_metadata(path: Path) -> tuple[str, Version]:
+    if path.suffix == ".whl":
+        with zipfile.ZipFile(path) as archive:
+            names = [name for name in archive.namelist() if name.endswith(".dist-info/METADATA")]
+            if len(names) != 1:
+                raise ValueError(f"{path.name}: expected one wheel METADATA file, found {len(names)}")
+            contents = archive.read(names[0]).decode("utf-8")
+    else:
+        with tarfile.open(path, "r:gz") as archive:
+            members = [
+                member
+                for member in archive.getmembers()
+                if member.isfile() and member.name.endswith("/PKG-INFO")
+            ]
+            if len(members) != 1:
+                raise ValueError(f"{path.name}: expected one sdist PKG-INFO file, found {len(members)}")
+            extracted = archive.extractfile(members[0])
+            if extracted is None:
+                raise ValueError(f"{path.name}: could not read PKG-INFO")
+            contents = extracted.read().decode("utf-8")
+
+    metadata = Parser().parsestr(contents)
+    name = metadata.get("Name")
+    version = metadata.get("Version")
+    if not name or not version:
+        raise ValueError(f"{path.name}: package metadata is missing Name or Version")
+    return canonicalize_name(name), Version(version)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--directory", type=Path, required=True)
+    parser.add_argument("--distribution", required=True)
+    parser.add_argument("--pyproject", type=Path, required=True)
+    parser.add_argument("--wheel-count", type=int, required=True)
+    parser.add_argument("--sdist-count", type=int, required=True)
+    parser.add_argument("--python-tag", action="append", type=expected_count, default=[])
+    parser.add_argument("--platform-prefix", action="append", type=expected_count, default=[])
+    args = parser.parse_args()
+
+    expected_name = canonicalize_name(args.distribution)
+    expected_version = Version(
+        tomllib.loads(args.pyproject.read_text(encoding="utf-8"))["project"]["version"]
+    )
+    wheels = sorted(args.directory.glob("*.whl"))
+    sdists = sorted(args.directory.glob("*.tar.gz"))
+    other_files = sorted(
+        path.name
+        for path in args.directory.iterdir()
+        if path.is_file() and path not in {*wheels, *sdists}
+    )
+
+    if len(wheels) != args.wheel_count:
+        raise SystemExit(f"expected {args.wheel_count} wheels, found {len(wheels)}")
+    if len(sdists) != args.sdist_count:
+        raise SystemExit(f"expected {args.sdist_count} sdists, found {len(sdists)}")
+    if other_files:
+        raise SystemExit(f"unexpected release files: {other_files}")
+
+    python_counts: Counter[str] = Counter()
+    platform_counts: Counter[str] = Counter()
+    expected_python = dict(args.python_tag)
+    expected_platform = dict(args.platform_prefix)
+
+    for wheel in wheels:
+        filename_name, filename_version, _build, tags = parse_wheel_filename(wheel.name)
+        if canonicalize_name(filename_name) != expected_name or filename_version != expected_version:
+            raise SystemExit(
+                f"{wheel.name}: filename identity does not match "
+                f"{expected_name} {expected_version}"
+            )
+
+        interpreters = {tag.interpreter for tag in tags} & expected_python.keys()
+        platforms = {
+            prefix
+            for prefix in expected_platform
+            if any(tag.platform.startswith(prefix) for tag in tags)
+        }
+        if len(interpreters) != 1:
+            raise SystemExit(f"{wheel.name}: expected one known Python tag, found {sorted(interpreters)}")
+        if len(platforms) != 1:
+            raise SystemExit(f"{wheel.name}: expected one known platform family, found {sorted(platforms)}")
+        python_counts.update(interpreters)
+        platform_counts.update(platforms)
+
+    for sdist in sdists:
+        filename_name, filename_version = parse_sdist_filename(sdist.name)
+        if canonicalize_name(filename_name) != expected_name or filename_version != expected_version:
+            raise SystemExit(
+                f"{sdist.name}: filename identity does not match "
+                f"{expected_name} {expected_version}"
+            )
+
+    for artifact in [*wheels, *sdists]:
+        metadata_name, metadata_version = package_metadata(artifact)
+        if metadata_name != expected_name or metadata_version != expected_version:
+            raise SystemExit(
+                f"{artifact.name}: embedded metadata is {metadata_name} {metadata_version}, "
+                f"expected {expected_name} {expected_version}"
+            )
+
+    if python_counts != Counter(expected_python):
+        raise SystemExit(f"Python wheel coverage is {dict(python_counts)}, expected {expected_python}")
+    if platform_counts != Counter(expected_platform):
+        raise SystemExit(f"platform wheel coverage is {dict(platform_counts)}, expected {expected_platform}")
+
+    print(
+        f"validated {expected_name} {expected_version}: "
+        f"{len(wheels)} wheels, {len(sdists)} sdist"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/publish-cpp.yml
+++ b/.github/workflows/publish-cpp.yml
@@ -6,12 +6,17 @@ on:
   workflow_dispatch:
     inputs:
       publish:
-        description: 'Publish to PyPI (true/false)'
-        required: false
-        default: 'false'
+        description: Publish the selected vanedb-cpp tag to PyPI
+        type: boolean
+        required: true
+        default: false
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 defaults:
   run:
@@ -19,80 +24,115 @@ defaults:
 
 jobs:
   validate-version:
-    name: Validate product tag
+    name: Validate release identity
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v7
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
 
-    - name: Set up Python
-      uses: actions/setup-python@v7
-      with:
-        python-version: '3.14'
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.14'
 
-    - name: Match tag and package version
-      if: ${{ startsWith(github.ref, 'refs/tags/') }}
-      shell: bash
-      run: |
-        python - <<'PY'
-        import os
-        import tomllib
-        from pathlib import Path
+      - name: Match product tag, package version, and publish request
+        shell: bash
+        env:
+          REQUEST_PUBLISH: ${{ inputs.publish }}
+        run: |
+          python - <<'PY'
+          import os
+          import tomllib
+          from pathlib import Path
 
-        prefix = "vanedb-cpp-v"
-        tag = os.environ["GITHUB_REF_NAME"]
-        expected = tag.removeprefix(prefix)
-        actual = tomllib.loads(Path("pyproject.toml").read_text())["project"]["version"]
-        if not tag.startswith(prefix) or actual != expected:
-            raise SystemExit(f"tag {tag!r} does not match vanedb-cpp {actual}")
-        print(f"validated vanedb-cpp {actual}")
-        PY
+          prefix = "vanedb-cpp-v"
+          version = tomllib.loads(Path("pyproject.toml").read_text())["project"]["version"]
+          is_tag = os.environ["GITHUB_REF_TYPE"] == "tag"
+          tag = os.environ["GITHUB_REF_NAME"]
+
+          if is_tag:
+              if not tag.startswith(prefix):
+                  raise SystemExit(f"unexpected tag: {tag}")
+              expected = tag.removeprefix(prefix)
+              if version != expected:
+                  raise SystemExit(f"tag expects {expected}, package version is {version}")
+
+          publish_requested = os.environ.get("REQUEST_PUBLISH") == "true"
+          if publish_requested and (
+              os.environ["GITHUB_EVENT_NAME"] != "workflow_dispatch"
+              or not is_tag
+              or not tag.startswith(prefix)
+          ):
+              raise SystemExit(
+                  "publishing requires a manual workflow run whose selected ref "
+                  "is the matching vanedb-cpp product tag"
+              )
+          print(f"validated vanedb-cpp {version}")
+          PY
+
+      - name: Require release tag to be on main
+        if: github.ref_type == 'tag'
+        shell: bash
+        run: |
+          git fetch --no-tags origin refs/heads/main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "release tag must point to a commit on main" >&2
+            exit 1
+          fi
 
   build-wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels (${{ matrix.platform }})
     needs: validate-version
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - platform: linux-x86_64
+            runner: ubuntu-latest
+            architecture: x86_64
+          - platform: macos-x86_64
+            runner: macos-15-intel
+            architecture: x86_64
+          - platform: macos-arm64
+            runner: macos-latest
+            architecture: arm64
+          - platform: windows-amd64
+            runner: windows-latest
+            architecture: AMD64
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v7
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-    - name: Set up Python
-      uses: actions/setup-python@v7
-      with:
-        python-version: '3.11'
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.11'
 
-    - name: Install cibuildwheel
-      run: |
-        python -m pip install --upgrade pip
-        pip install cibuildwheel
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install cibuildwheel
 
-    - name: Build wheels
-      run: python -m cibuildwheel --output-dir wheelhouse
-      env:
-        # Build for Python 3.9 through 3.14
-        CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*
-        # Skip 32-bit builds and musllinux
-        CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
-        # Test the wheels
-        CIBW_TEST_REQUIRES: pytest numpy
-        CIBW_TEST_COMMAND: pytest {project}/tests/test_python_bindings.py -v
-        # macOS: Build separate Apple Silicon and Intel wheels
-        CIBW_ARCHS_MACOS: x86_64 arm64
-        # Linux: Build for x86_64
-        CIBW_ARCHS_LINUX: x86_64
-        # Windows: Build for AMD64
-        CIBW_ARCHS_WINDOWS: AMD64
+      - name: Build and test wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*
+          CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
+          CIBW_TEST_REQUIRES: pytest numpy
+          CIBW_TEST_COMMAND: pytest {project}/tests/test_python_bindings.py -v
+          # Each wheel is built and tested on its native architecture.
+          CIBW_ARCHS: ${{ matrix.architecture }}
 
-    - name: Upload wheels
-      uses: actions/upload-artifact@v7
-      with:
-        name: wheels-${{ matrix.os }}
-        path: cpp/wheelhouse/*.whl
+      - name: Upload wheels
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vanedb-cpp-wheels-${{ matrix.platform }}
+          path: cpp/wheelhouse/*.whl
+          if-no-files-found: error
 
   build-sdist:
     name: Build source distribution
@@ -100,45 +140,116 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v7
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-    - name: Set up Python
-      uses: actions/setup-python@v7
-      with:
-        python-version: '3.11'
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.11'
 
-    - name: Install build tools
-      run: |
-        python -m pip install --upgrade pip
-        pip install build
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
 
-    - name: Build sdist
-      run: python -m build --sdist
+      - name: Build sdist
+        run: python -m build --sdist
 
-    - name: Upload sdist
-      uses: actions/upload-artifact@v7
-      with:
-        name: sdist
-        path: cpp/dist/*.tar.gz
+      - name: Upload sdist
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vanedb-cpp-sdist
+          path: cpp/dist/*.tar.gz
+          if-no-files-found: error
+
+  sdist-test:
+    name: Test source distribution
+    needs: build-sdist
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.14'
+      - name: Download sdist
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: vanedb-cpp-sdist
+          path: cpp/dist
+      - name: Build, install, and test sdist
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest numpy
+          python -m pip install --no-deps --force-reinstall dist/*.tar.gz
+          python -m pip check
+          python -m pytest tests/test_python_bindings.py -v
+
+  validate-artifacts:
+    name: Validate release artifacts
+    needs: [build-wheels, sdist-test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.14'
+      - name: Download all artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Validate artifact metadata and coverage
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install packaging twine
+          python -m twine check ../dist/*
+          python ../.github/scripts/validate_python_release.py \
+            --directory ../dist \
+            --distribution vanedb-cpp \
+            --pyproject pyproject.toml \
+            --wheel-count 24 \
+            --sdist-count 1 \
+            --python-tag cp39=4 \
+            --python-tag cp310=4 \
+            --python-tag cp311=4 \
+            --python-tag cp312=4 \
+            --python-tag cp313=4 \
+            --python-tag cp314=4 \
+            --platform-prefix manylinux=6 \
+            --platform-prefix macosx=12 \
+            --platform-prefix win=6
 
   publish:
-    name: Publish to PyPI
-    needs: [build-wheels, build-sdist]
+    name: Publish vanedb-cpp to PyPI
+    needs: validate-artifacts
     runs-on: ubuntu-latest
-    # Product tags build and retain artifacts, but publication remains an
-    # explicit action until the generic x86-64 CPU baseline is safe:
+    # Product tag pushes build and retain artifacts. Publication stays manual
+    # until the generic x86-64 CPU baseline is safe:
     # https://github.com/vanedb/vanedb-cpp/issues/39
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true'
-
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      inputs.publish &&
+      github.ref_type == 'tag' &&
+      startsWith(github.ref, 'refs/tags/vanedb-cpp-v')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/vanedb-cpp
+    permissions:
+      contents: read
+      id-token: write
     steps:
-    - name: Download all artifacts
-      uses: actions/download-artifact@v8
-      with:
-        path: dist
-        merge-multiple: true
+      - name: Download all artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: dist
+          merge-multiple: true
 
-    - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -4,26 +4,26 @@ on:
   push:
     tags: ['vanedb-v*']
   workflow_dispatch:
-    inputs:
-      publish:
-        description: 'Publish to PyPI (true/false)'
-        required: false
-        default: 'false'
 
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   validate-version:
-    name: Validate product tag
+    name: Validate release identity
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.14'
-      - name: Match tag and package versions
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      - name: Match product tag and package versions
         shell: bash
         run: |
           python - <<'PY'
@@ -32,11 +32,6 @@ jobs:
           from pathlib import Path
 
           prefix = "vanedb-v"
-          tag = os.environ["GITHUB_REF_NAME"]
-          if not tag.startswith(prefix):
-              raise SystemExit(f"unexpected tag: {tag}")
-          expected = tag.removeprefix(prefix)
-
           pyproject = tomllib.loads(Path("vanedb-py/pyproject.toml").read_text())
           py_cargo = tomllib.loads(Path("vanedb-py/Cargo.toml").read_text())
           core_cargo = tomllib.loads(Path("vanedb/Cargo.toml").read_text())
@@ -45,23 +40,40 @@ jobs:
               "vanedb-py/Cargo.toml": py_cargo["package"]["version"],
               "vanedb/Cargo.toml": core_cargo["package"]["version"],
           }
-          mismatches = {path: value for path, value in versions.items() if value != expected}
-          if mismatches:
-              raise SystemExit(f"tag expects {expected}, package versions are {mismatches}")
-          print(f"validated vanedb {expected}")
+          if len(set(versions.values())) != 1:
+              raise SystemExit(f"package versions disagree: {versions}")
+
+          version = next(iter(versions.values()))
+          if os.environ["GITHUB_REF_TYPE"] == "tag":
+              tag = os.environ["GITHUB_REF_NAME"]
+              if not tag.startswith(prefix):
+                  raise SystemExit(f"unexpected tag: {tag}")
+              expected = tag.removeprefix(prefix)
+              if version != expected:
+                  raise SystemExit(f"tag expects {expected}, package version is {version}")
+          print(f"validated vanedb {version}")
           PY
+      - name: Require release tag to be on main
+        if: github.ref_type == 'tag'
+        shell: bash
+        run: |
+          git fetch --no-tags origin refs/heads/main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "release tag must point to a commit on main" >&2
+            exit 1
+          fi
 
   linux:
     name: Linux wheels (x86_64, Python 3.9–3.14)
     needs: validate-version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.14'
       - name: Build manylinux wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: x86_64
           manylinux: '2_17'
@@ -70,17 +82,37 @@ jobs:
             --manifest-path vanedb-py/Cargo.toml
             -i python3.9 -i python3.10 -i python3.11
             -i python3.12 -i python3.13 -i python3.14
-      - name: Test Python 3.14 wheel
-        shell: bash
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install --no-index --find-links dist --force-reinstall vanedb
-          python -m pip install pytest numpy
-          python -m pytest vanedb-py/tests -v
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: vanedb-linux-x86_64
           path: dist/*.whl
+          if-no-files-found: error
+
+  linux-test:
+    name: Test Linux wheel (Python ${{ matrix.python-version }})
+    needs: linux
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: vanedb-linux-x86_64
+          path: dist
+      - name: Install and test wheel
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest numpy
+          python -m pip install --no-index --no-deps --find-links dist --force-reinstall vanedb
+          python -m pip check
+          python -m pytest vanedb-py/tests -v
 
   macos:
     name: macOS wheels (${{ matrix.target }}, Python ${{ matrix.python-version }})
@@ -99,12 +131,12 @@ jobs:
           - target: aarch64
             runner: macos-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build wheel
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.target }}
           args: --release --locked --compatibility pypi --out dist --manifest-path vanedb-py/Cargo.toml -i python
@@ -112,13 +144,15 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --no-index --find-links dist --force-reinstall vanedb
+          python -m pip install --no-index --no-deps --find-links dist --force-reinstall vanedb
           python -m pip install pytest numpy
+          python -m pip check
           python -m pytest vanedb-py/tests -v
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: vanedb-macos-${{ matrix.target }}-py${{ matrix.python-version }}
           path: dist/*.whl
+          if-no-files-found: error
 
   windows:
     name: Windows wheels (x64, Python ${{ matrix.python-version }})
@@ -129,12 +163,12 @@ jobs:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build wheel
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: x64
           args: --release --locked --compatibility pypi --out dist --manifest-path vanedb-py/Cargo.toml -i python
@@ -142,42 +176,104 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --no-index --find-links dist --force-reinstall vanedb
+          python -m pip install --no-index --no-deps --find-links dist --force-reinstall vanedb
           python -m pip install pytest numpy
+          python -m pip check
           python -m pytest vanedb-py/tests -v
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: vanedb-windows-x64-py${{ matrix.python-version }}
           path: dist/*.whl
+          if-no-files-found: error
 
   sdist:
     name: Source distribution
     needs: validate-version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build sdist
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           command: sdist
           args: --out dist --manifest-path vanedb-py/Cargo.toml
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: vanedb-sdist
           path: dist/*.tar.gz
+          if-no-files-found: error
 
-  publish:
-    name: Publish vanedb to PyPI
-    needs: [linux, macos, windows, sdist]
+  sdist-test:
+    name: Test source distribution
+    needs: sdist
     runs-on: ubuntu-latest
-    if: >-
-      ${{ startsWith(github.ref, 'refs/tags/vanedb-v') ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true') }}
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.14'
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: vanedb-sdist
+          path: dist
+      - name: Build, install, and test sdist
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest numpy
+          python -m pip install --no-deps --force-reinstall dist/*.tar.gz
+          python -m pip check
+          python -m pytest vanedb-py/tests -v
+
+  validate-artifacts:
+    name: Validate release artifacts
+    needs: [linux-test, macos, windows, sdist-test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.14'
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
           merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Validate artifact metadata and coverage
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install packaging twine
+          python -m twine check dist/*
+          python .github/scripts/validate_python_release.py \
+            --directory dist \
+            --distribution vanedb \
+            --pyproject vanedb-py/pyproject.toml \
+            --wheel-count 24 \
+            --sdist-count 1 \
+            --python-tag cp39=4 \
+            --python-tag cp310=4 \
+            --python-tag cp311=4 \
+            --python-tag cp312=4 \
+            --python-tag cp313=4 \
+            --python-tag cp314=4 \
+            --platform-prefix manylinux=6 \
+            --platform-prefix macosx=12 \
+            --platform-prefix win=6
+
+  publish:
+    name: Publish vanedb to PyPI
+    needs: validate-artifacts
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/vanedb-v')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/vanedb
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1


### PR DESCRIPTION
## Summary

- replace PyPI API-token uploads with environment-scoped OIDC trusted publishing
- pin every action used by the two release workflows to an immutable commit
- require product tags to match package versions and point to commits already on `main`
- make Rust manual runs build-only; keep C++ publication manual, tag-bound, and blocked behind the `pypi` environment
- test every Rust Linux wheel on Python 3.9–3.14 and build/install-test both sdists
- build C++ Intel and Apple Silicon wheels on native runners so every wheel is executed
- validate the complete 24-wheel + 1-sdist artifact sets, including filenames, embedded metadata, Python tags, platform coverage, and `twine check`
- move Codecov configuration to `.github/codecov.yml` and correct its monorepo paths

## Publication safety

This PR does not bump a version, create a tag, dispatch a release workflow, or upload anything.

- Pull-request events do not trigger either publish workflow.
- A manual Rust run can only build and validate artifacts; it cannot publish.
- Rust publication requires a `vanedb-v*` tag push, successful artifact acceptance, and approval of the protected `pypi` environment.
- C++ publication requires a manual run selected from a matching `vanedb-cpp-v*` tag with `publish=true`, successful artifact acceptance, and `pypi` environment approval.
- A normal C++ product-tag push builds and retains artifacts but does not publish them.
- `vanedb-cpp` remains manual-only while the generic x86-64 CPU baseline issue is open: https://github.com/vanedb/vanedb/issues/59

## Validation evidence

- `actionlint` passed for all workflows (with only its stale `macos-15-intel` catalogue warning suppressed)
- Codecov's official YAML validator returned `Valid!`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude vanedb-py --all-targets --features mmap -- -D warnings`
- `cargo test --workspace --exclude vanedb-py --features mmap`
- bench fmt, clippy, and tests with the exact commands from `AGENTS.md`
- CMake release build and CTest: 51/51 passed
- locally built real Rust and C++ wheels and sdists passed the new metadata validator
- locally installed wheels passed `pip check`, 30/30 Rust binding tests, and 28/28 C++ binding tests
- negative validator checks correctly rejected a wrong distribution name and a wrong artifact count

## Post-merge rehearsal

Before creating any release tag, manually dispatch both workflows from `main` (C++ with `publish=false`). These runs exercise the full hosted OS/Python matrices and retain artifacts without making either publish job eligible.
