### PR TITLE
ci(release): pin tooling and gate workflow lint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,7 @@ updates:
     directory: "/cpp"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/.github"
+    schedule:
+      interval: "weekly"

--- a/.github/requirements-release.txt
+++ b/.github/requirements-release.txt
@@ -1,0 +1,9 @@
+# Reproducible tooling for Python release workflows. Dependabot updates this
+# file deliberately; build and test dependencies remain governed by each
+# package's supported dependency ranges.
+build==1.6.0
+cibuildwheel==4.2.0
+packaging==26.3
+pip==25.3; python_version == "3.9"
+pip==26.2.1; python_version >= "3.10"
+twine==7.0.0

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -39,8 +39,8 @@ jobs:
 
       - name: Compare benchmarks
         run: |
-          echo "## Benchmark Comparison (main vs PR)" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          critcmp main pr >> $GITHUB_STEP_SUMMARY 2>&1 || true
-          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "## Benchmark Comparison (main vs PR)" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          critcmp main pr >> "$GITHUB_STEP_SUMMARY" 2>&1 || true
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
           critcmp main pr --threshold 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       cpp: ${{ steps.filter.outputs.cpp }}
       integration: ${{ steps.filter.outputs.integration }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - id: filter
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         with:
@@ -34,9 +34,11 @@ jobs:
               - 'vanedb-capi/**'
               - 'vanedb-py/**'
               - 'vanedb-wasm/**'
+              - '.github/requirements-release.txt'
               - '.github/workflows/**'
             cpp:
               - 'cpp/**'
+              - '.github/requirements-release.txt'
               - '.github/workflows/**'
             integration:
               - 'Cargo.toml'
@@ -47,6 +49,29 @@ jobs:
               - 'bench/**'
               - 'conformance/**'
               - '.github/workflows/**'
+
+  workflow-lint:
+    name: Workflow lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install actionlint
+        shell: bash
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          set -euo pipefail
+          archive="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          path="$RUNNER_TEMP/$archive"
+          curl --fail --silent --show-error --location \
+            --output "$path" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${archive}"
+          echo "$ACTIONLINT_SHA256  $path" | sha256sum --check --status
+          tar --extract --gzip --file "$path" --directory "$RUNNER_TEMP" actionlint
+          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
+      - name: Lint GitHub Actions workflows
+        run: actionlint -color
 
   rust:
     name: Rust component
@@ -73,13 +98,14 @@ jobs:
   gate:
     name: Required CI Gate
     if: ${{ always() }}
-    needs: [changes, rust, cpp, integration]
+    needs: [changes, workflow-lint, rust, cpp, integration]
     runs-on: ubuntu-latest
     steps:
       - name: Verify every affected component passed
         shell: bash
         env:
           CHANGES_RESULT: ${{ needs.changes.result }}
+          WORKFLOW_LINT_RESULT: ${{ needs.workflow-lint.result }}
           RUST_CHANGED: ${{ needs.changes.outputs.rust }}
           RUST_RESULT: ${{ needs.rust.result }}
           CPP_CHANGED: ${{ needs.changes.outputs.cpp }}
@@ -91,6 +117,10 @@ jobs:
 
           if [[ "$CHANGES_RESULT" != "success" ]]; then
             echo "Change detection did not succeed: $CHANGES_RESULT"
+            exit 1
+          fi
+          if [[ "$WORKFLOW_LINT_RESULT" != "success" ]]; then
+            echo "Workflow lint did not succeed: $WORKFLOW_LINT_RESULT"
             exit 1
           fi
 

--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -57,11 +57,11 @@ jobs:
       shell: bash
       run: |
         if [ "${{ matrix.compiler }}" = "gcc" ]; then
-          echo "CC=gcc" >> $GITHUB_ENV
-          echo "CXX=g++" >> $GITHUB_ENV
+          echo "CC=gcc" >> "$GITHUB_ENV"
+          echo "CXX=g++" >> "$GITHUB_ENV"
         else
-          echo "CC=clang" >> $GITHUB_ENV
-          echo "CXX=clang++" >> $GITHUB_ENV
+          echo "CC=clang" >> "$GITHUB_ENV"
+          echo "CXX=clang++" >> "$GITHUB_ENV"
         fi
 
     - name: Configure CMake
@@ -87,6 +87,7 @@ jobs:
 
     - name: Run benchmarks (Windows)
       if: runner.os == 'Windows'
+      shell: pwsh
       run: |
         cd build
         .\${{ matrix.build_type }}\bench_distance.exe --benchmark_min_time=0.05s --benchmark_filter=BM_L2/768 --benchmark_format=json > bench_distance.json
@@ -376,12 +377,12 @@ jobs:
     - name: Install NDK
       run: |
         sdkmanager --install "ndk;26.1.10909125"
-        echo "ANDROID_NDK=$ANDROID_HOME/ndk/26.1.10909125" >> $GITHUB_ENV
+        echo "ANDROID_NDK=$ANDROID_HOME/ndk/26.1.10909125" >> "$GITHUB_ENV"
 
     - name: Configure CMake for Android
       run: |
         cmake -B build-android \
-          -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
+          -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK/build/cmake/android.toolchain.cmake" \
           -DANDROID_ABI=arm64-v8a \
           -DANDROID_PLATFORM=android-24 \
           -DANDROID_STL=c++_shared \
@@ -416,12 +417,12 @@ jobs:
     - name: Install NDK
       run: |
         sdkmanager --install "ndk;26.1.10909125"
-        echo "ANDROID_NDK=$ANDROID_HOME/ndk/26.1.10909125" >> $GITHUB_ENV
+        echo "ANDROID_NDK=$ANDROID_HOME/ndk/26.1.10909125" >> "$GITHUB_ENV"
 
     - name: Configure CMake for Android x86_64
       run: |
         cmake -B build-android-x86_64 \
-          -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
+          -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK/build/cmake/android.toolchain.cmake" \
           -DANDROID_ABI=x86_64 \
           -DANDROID_PLATFORM=android-24 \
           -DANDROID_STL=c++_shared \

--- a/.github/workflows/publish-cpp.yml
+++ b/.github/workflows/publish-cpp.yml
@@ -114,8 +114,8 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install cibuildwheel
+          python -m pip install --upgrade --constraint "${{ github.workspace }}/.github/requirements-release.txt" pip
+          python -m pip install --constraint "${{ github.workspace }}/.github/requirements-release.txt" cibuildwheel
 
       - name: Build and test wheels
         run: python -m cibuildwheel --output-dir wheelhouse
@@ -150,8 +150,8 @@ jobs:
 
       - name: Install build tools
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install build
+          python -m pip install --upgrade --constraint "${{ github.workspace }}/.github/requirements-release.txt" pip
+          python -m pip install --constraint "${{ github.workspace }}/.github/requirements-release.txt" build
 
       - name: Build sdist
         run: python -m build --sdist
@@ -182,7 +182,7 @@ jobs:
       - name: Build, install, and test sdist
         shell: bash
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade --constraint "${{ github.workspace }}/.github/requirements-release.txt" pip
           python -m pip install pytest numpy
           python -m pip install --no-deps --force-reinstall dist/*.tar.gz
           python -m pip check
@@ -207,9 +207,11 @@ jobs:
       - name: Validate artifact metadata and coverage
         shell: bash
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install packaging twine
+          python -m pip install --upgrade --constraint "${{ github.workspace }}/.github/requirements-release.txt" pip
+          python -m pip install --constraint "${{ github.workspace }}/.github/requirements-release.txt" packaging twine
           python -m twine check ../dist/*
+          # Matrix contract: 4 native platforms x 6 CPython versions = 24
+          # wheels. Keep these tripwires aligned with build-wheels above.
           python ../.github/scripts/validate_python_release.py \
             --directory ../dist \
             --distribution vanedb-cpp \

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Install and test wheel
         shell: bash
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade --constraint "${{ github.workspace }}/.github/requirements-release.txt" pip
           python -m pip install pytest numpy
           python -m pip install --no-index --no-deps --find-links dist --force-reinstall vanedb
           python -m pip check
@@ -143,7 +143,7 @@ jobs:
       - name: Test wheel
         shell: bash
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade --constraint "${{ github.workspace }}/.github/requirements-release.txt" pip
           python -m pip install --no-index --no-deps --find-links dist --force-reinstall vanedb
           python -m pip install pytest numpy
           python -m pip check
@@ -175,7 +175,7 @@ jobs:
       - name: Test wheel
         shell: bash
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade --constraint "${{ github.workspace }}/.github/requirements-release.txt" pip
           python -m pip install --no-index --no-deps --find-links dist --force-reinstall vanedb
           python -m pip install pytest numpy
           python -m pip check
@@ -219,7 +219,7 @@ jobs:
       - name: Build, install, and test sdist
         shell: bash
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade --constraint "${{ github.workspace }}/.github/requirements-release.txt" pip
           python -m pip install pytest numpy
           python -m pip install --no-deps --force-reinstall dist/*.tar.gz
           python -m pip check
@@ -241,9 +241,12 @@ jobs:
       - name: Validate artifact metadata and coverage
         shell: bash
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install packaging twine
+          python -m pip install --upgrade --constraint "${{ github.workspace }}/.github/requirements-release.txt" pip
+          python -m pip install --constraint "${{ github.workspace }}/.github/requirements-release.txt" packaging twine
           python -m twine check dist/*
+          # Matrix contract: 6 Linux + (2 macOS architectures x 6) +
+          # 6 Windows wheels = 24. Keep these tripwires aligned with the
+          # linux, macos, and windows build matrices above.
           python .github/scripts/validate_python_release.py \
             --directory dist \
             --distribution vanedb \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ benchmark harness, and the shared conformance contract.
 These are exactly what CI runs — use the same invocations:
 
 ```bash
+actionlint
 cargo fmt --all -- --check
 cargo clippy --workspace --exclude vanedb-py --all-targets --features mmap -- -D warnings
 cargo test --workspace --exclude vanedb-py --features mmap


### PR DESCRIPTION
## Summary

- centralize exact Python release-tool pins for `pip`, `cibuildwheel`, `build`, `packaging`, and `twine`
- keep pip deterministic across the supported interpreter range with a Python 3.9-specific pin
- add checksum-verified actionlint 1.7.12 to CI and make the required aggregate gate depend on it
- document how each 24-wheel artifact-count tripwire maps to its build matrix
- let Dependabot maintain the release-tool requirements

The existing `actions/checkout` use in the required change-detection job is also pinned to the already-used v7.0.1 commit.

## Validation

- `actionlint -color` passes across all workflows using actionlint 1.7.12 with ShellCheck 0.11.0 enabled
- the release constraints resolve together in a clean Python 3.13 virtual environment
- installed versions: build 1.6.0, cibuildwheel 4.2.0, packaging 26.3, pip 26.2.1, twine 7.0.0
- `pip check` reports no broken requirements
- `git diff --check` passes
- PyPI metadata confirms pip 25.3 supports Python 3.9 and pip 26.2.1 is used for Python 3.10+

The first CI run proved the new gate was active by catching existing unquoted workflow variables and a Windows step whose shell was implicit. Commit `1b1842f` fixes those findings; the same actionlint/ShellCheck combination now passes locally.

## Safety

This PR does not create a tag, dispatch a release workflow, or publish a package. After merge, both product workflows will be manually rehearsed in build-only mode from `main` before any release tag is created.

Intel macOS runner lifecycle follow-up: #47
