### PR TITLE
Restore build fidelity across C++ and Rust CI

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -29,13 +29,13 @@ jobs:
       # libtest harness (which doesn't accept --save-baseline) regardless
       # of Cargo.toml settings on either branch.
       - name: Benchmark (PR branch)
-        run: cargo bench --bench distance_bench --bench store_bench --bench hnsw_bench -- --save-baseline pr
+        run: cargo bench --locked --bench distance_bench --bench store_bench --bench hnsw_bench -- --save-baseline pr
 
       - name: Checkout main
         run: git checkout origin/main
 
       - name: Benchmark (main baseline)
-        run: cargo bench --bench distance_bench --bench store_bench --bench hnsw_bench -- --save-baseline main
+        run: cargo bench --locked --bench distance_bench --bench store_bench --bench hnsw_bench -- --save-baseline main
 
       - name: Compare benchmarks
         run: |

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -96,6 +96,6 @@ jobs:
         with:
           ndk-version: r26b
       - name: Install cargo-ndk
-        run: cargo install cargo-ndk --locked
+        run: cargo install cargo-ndk --version 4.1.2 --locked
       - name: Cross-compile core for Android
         run: cargo ndk -t arm64-v8a -t x86_64 build -p vanedb --features mmap --release --locked

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           components: clippy, rustfmt
       - run: cargo fmt --all -- --check
-      - run: cargo clippy --workspace --exclude vanedb-py --all-targets --features mmap -- -D warnings
+      - run: cargo clippy --workspace --exclude vanedb-py --all-targets --features mmap --locked -- -D warnings
 
   check-py:
     name: Check (Python bindings)
@@ -32,7 +32,7 @@ jobs:
       # maturin), but `cargo check` needs only a Python interpreter, so the
       # crate at least compiling is verified on every PR. Full behavior tests
       # still run locally via maturin develop + pytest.
-      - run: cargo check -p vanedb-py
+      - run: cargo check -p vanedb-py --locked
 
   test-linux:
     name: Test (Linux x86_64)
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo test --workspace --exclude vanedb-py --features mmap
+      - run: cargo test --workspace --exclude vanedb-py --features mmap --locked
 
   test-macos:
     name: Test (macOS ARM)
@@ -48,7 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo test --workspace --exclude vanedb-py --features mmap,gpu-metal
+      - run: cargo test --workspace --exclude vanedb-py --features mmap,gpu-metal --locked
 
   test-windows:
     name: Test (Windows x86_64)
@@ -56,7 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo test --workspace --exclude vanedb-py --features mmap
+      - run: cargo test --workspace --exclude vanedb-py --features mmap --locked
 
   test-wasm:
     name: Test (WASM)
@@ -69,7 +69,7 @@ jobs:
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Test WASM
-        run: cd vanedb-wasm && wasm-pack test --node
+        run: cd vanedb-wasm && wasm-pack test --node --locked
 
   build-ios:
     name: Build (iOS arm64)
@@ -81,7 +81,7 @@ jobs:
           targets: aarch64-apple-ios
       # Cross-compile only: there is no iOS test runner, mirroring the
       # build-only verification the C++ repo uses for mobile.
-      - run: cargo build -p vanedb --target aarch64-apple-ios --features mmap --release
+      - run: cargo build -p vanedb --target aarch64-apple-ios --features mmap --release --locked
 
   build-android:
     name: Build (Android arm64-v8a, x86_64)
@@ -98,4 +98,4 @@ jobs:
       - name: Install cargo-ndk
         run: cargo install cargo-ndk --locked
       - name: Cross-compile core for Android
-        run: cargo ndk -t arm64-v8a -t x86_64 build -p vanedb --features mmap --release
+        run: cargo ndk -t arm64-v8a -t x86_64 build -p vanedb --features mmap --release --locked

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -16,16 +16,6 @@ else()
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-# Configuration-specific flags
-if(NOT MSVC)
-  set(CMAKE_CXX_FLAGS_RELEASE "-O3")
-  set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
-  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
-  set(CMAKE_C_FLAGS_RELEASE "-O3")
-  set(CMAKE_C_FLAGS_DEBUG "-O0 -g")
-  set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -g")
-endif()
-
 # Detect x86_64 for AVX2 support
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|amd64")
   set(VANEDB_X86_64 TRUE)


### PR DESCRIPTION
## Summary

- stop replacing CMake's canonical configuration flags on non-MSVC builds
- restore `-DNDEBUG` to Release and RelWithDebInfo C++ builds
- enforce the committed Cargo lockfile in every dependency-resolving Rust CI build and test command
- pin the Android CI build tool to the version verified by this PR

## Why

The custom `CMAKE_*_FLAGS_<CONFIG>` assignments replaced CMake's defaults rather than extending them. Release still used `-O3`, but lost `-DNDEBUG` on Linux and macOS while MSVC retained it. The cross-engine C++ C API therefore kept three distance-kernel assertions in the measured path, making the Rust/C++ benchmark configuration asymmetric and causing Google Benchmark to report that the C++ binaries were built as DEBUG.

The repository now commits `Cargo.lock`, but the reusable Rust CI workflow did not use `--locked`. CI could therefore resolve a dependency graph different from the committed release graph.

## Acceptance evidence

### Build configuration

- cross-engine C++ C API compile flags: `-O3 -DNDEBUG`
- `nm -u libvanedb_cpp_capi.a`: no `assert` reference after the rebuild
- Google Benchmark DEBUG warning: removed
- C++ CTest: 51/51 passed

### Rust and workflow validation

- `cargo fmt --all -- --check`
- locked Clippy and Python-binding checks
- locked Rust workspace tests: 111 passed
- locked WASM tests: 9/9 passed; output confirms `cargo test ... --locked`
- locked iOS arm64 release cross-build passed
- Android CI passed with the now-pinned `cargo-ndk` 4.1.2
- actionlint v1.7.12 passed
- cross-engine harness tests: 2/2 passed

### Packaging

- rebuilt the C++ wheel from this branch in an isolated PEP 517 environment
- installed it into a clean Python 3.13 virtual environment
- vector-store, HNSW save/load, and mmap smoke tests passed
- packaged Python binding suite: 28/28 passed

### Benchmark validation

- the full local Criterion suite completed successfully
- the GitHub performance-regression job measured both the PR and `main` and passed
- both benchmark revisions now resolve strictly from their committed lockfiles

No directional performance claim is made from the local snapshot. The existing benchmark tables are stale and remain unchanged pending a controlled dedicated-hardware rerun.

## Scope

This PR intentionally does not change the separate local macOS wheel deployment-target behavior.
