### PR TITLE
Add safe TestPyPI OIDC rehearsal

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags: ['vanedb-v*']
   workflow_dispatch:
+    inputs:
+      publish_testpypi:
+        description: Publish validated vanedb artifacts to TestPyPI
+        type: boolean
+        required: true
+        default: false
 
 permissions:
   contents: read
@@ -53,6 +59,14 @@ jobs:
                   raise SystemExit(f"tag expects {expected}, package version is {version}")
           print(f"validated vanedb {version}")
           PY
+      - name: Require TestPyPI rehearsals to run from main
+        if: github.event_name == 'workflow_dispatch' && inputs.publish_testpypi
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "TestPyPI publication must be dispatched from main" >&2
+            exit 1
+          fi
       - name: Require release tag to be on main
         if: github.ref_type == 'tag'
         shell: bash
@@ -262,6 +276,30 @@ jobs:
             --platform-prefix manylinux=6 \
             --platform-prefix macosx=12 \
             --platform-prefix win=6
+
+  publish-testpypi:
+    name: Publish vanedb to TestPyPI
+    needs: validate-artifacts
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      inputs.publish_testpypi &&
+      github.ref == 'refs/heads/main'
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/vanedb
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
 
   publish:
     name: Publish vanedb to PyPI


### PR DESCRIPTION
## Summary

- add an explicit `publish_testpypi` boolean to the manual Rust release rehearsal
- publish validated artifacts to TestPyPI through the dedicated `testpypi` GitHub environment and OIDC
- require TestPyPI publication to be dispatched from `main`
- leave production PyPI publication restricted to `vanedb-v*` tag pushes

## Safety contract

| Event | Input/ref | TestPyPI | PyPI |
|---|---|---:|---:|
| Manual dispatch | `publish_testpypi: false` | skipped | skipped |
| Manual dispatch | `publish_testpypi: true`, `main` | enabled after environment approval | skipped |
| Manual dispatch | `publish_testpypi: true`, non-`main` | validation fails | skipped |
| `vanedb-v*` tag push | matching version on `main` | skipped | existing production path |

The TestPyPI job receives `id-token: write` only at job scope, uses no long-lived secret, and targets `https://test.pypi.org/legacy/` explicitly. It still depends on the existing artifact validation gate.

## Validation

- actionlint v1.7.12 passed for all workflows
- `git diff --check` passed
- all actions remain pinned to immutable commit SHAs
- production `publish` condition remains tag-push-only

## Post-merge acceptance

After merge, manually dispatch **Publish vanedb** from `main` with `publish_testpypi` enabled, approve the `testpypi` environment, then verify the OIDC upload and install `vanedb==0.1.0` from TestPyPI in a clean virtual environment.

This PR itself does not publish to either package index.
