### PR TITLE
fix: temp-path collisions, builder overflow, and wasm id narrowing

### DIFF
--- a/vanedb-wasm/src/lib.rs
+++ b/vanedb-wasm/src/lib.rs
@@ -2,7 +2,47 @@ use wasm_bindgen::prelude::*;
 
 use vanedb::distance::DistanceMetric;
 use vanedb::hnsw::HnswIndex;
-use vanedb::store::VectorStore;
+use vanedb::store::{SearchResult, VectorStore};
+
+/// Search results with lossless 64-bit ids.
+#[wasm_bindgen]
+pub struct WasmSearchResults {
+    ids: Vec<u64>,
+    distances: Vec<f32>,
+}
+
+#[wasm_bindgen]
+impl WasmSearchResults {
+    /// Matched ids, in rank order, as a `BigUint64Array`.
+    #[wasm_bindgen(getter)]
+    pub fn ids(&self) -> Vec<u64> {
+        self.ids.clone()
+    }
+
+    /// Distances, parallel to `ids`, as a `Float32Array`.
+    #[wasm_bindgen(getter)]
+    pub fn distances(&self) -> Vec<f32> {
+        self.distances.clone()
+    }
+
+    /// Number of matches returned.
+    #[wasm_bindgen(getter)]
+    pub fn length(&self) -> usize {
+        self.ids.len()
+    }
+}
+
+impl From<Vec<SearchResult>> for WasmSearchResults {
+    fn from(results: Vec<SearchResult>) -> Self {
+        let mut ids = Vec::with_capacity(results.len());
+        let mut distances = Vec::with_capacity(results.len());
+        for result in results {
+            ids.push(result.id);
+            distances.push(result.distance);
+        }
+        Self { ids, distances }
+    }
+}
 
 fn to_jserr(e: vanedb::VaneError) -> JsError {
     JsError::new(&e.to_string())
@@ -50,15 +90,15 @@ impl WasmVectorStore {
         self.inner.add_batch(ids, vectors).map_err(to_jserr)
     }
 
-    /// Search for k nearest neighbors. Returns flat array: [id0, dist0, id1, dist1, ...].
-    pub fn search(&self, query: &[f32], k: usize) -> Result<Vec<f32>, JsError> {
+    /// Search for k nearest neighbors.
+    ///
+    /// Ids come back as a `BigUint64Array` and distances as a `Float32Array`,
+    /// parallel by index. Ids are never narrowed to `f32`: values at or above
+    /// 2^24 are not exactly representable, so distinct records collided and
+    /// callers could act on the wrong record (#39).
+    pub fn search(&self, query: &[f32], k: usize) -> Result<WasmSearchResults, JsError> {
         let results = self.inner.search(query, k).map_err(to_jserr)?;
-        let mut flat = Vec::with_capacity(results.len() * 2);
-        for r in results {
-            flat.push(r.id as f32);
-            flat.push(r.distance);
-        }
-        Ok(flat)
+        Ok(WasmSearchResults::from(results))
     }
 
     pub fn get(&self, id: u64) -> Result<Vec<f32>, JsError> {
@@ -120,15 +160,15 @@ impl WasmHnswIndex {
         self.inner.add_batch(ids, vectors).map_err(to_jserr)
     }
 
-    /// Search for k nearest neighbors. Returns flat array: [id0, dist0, id1, dist1, ...].
-    pub fn search(&self, query: &[f32], k: usize) -> Result<Vec<f32>, JsError> {
+    /// Search for k nearest neighbors.
+    ///
+    /// Ids come back as a `BigUint64Array` and distances as a `Float32Array`,
+    /// parallel by index. Ids are never narrowed to `f32`: values at or above
+    /// 2^24 are not exactly representable, so distinct records collided and
+    /// callers could act on the wrong record (#39).
+    pub fn search(&self, query: &[f32], k: usize) -> Result<WasmSearchResults, JsError> {
         let results = self.inner.search(query, k).map_err(to_jserr)?;
-        let mut flat = Vec::with_capacity(results.len() * 2);
-        for r in results {
-            flat.push(r.id as f32);
-            flat.push(r.distance);
-        }
-        Ok(flat)
+        Ok(WasmSearchResults::from(results))
     }
 
     pub fn contains(&self, id: u64) -> bool {

--- a/vanedb-wasm/tests/web.rs
+++ b/vanedb-wasm/tests/web.rs
@@ -24,9 +24,10 @@ fn test_vector_store_search() {
     store.add(2, &[1.0, 0.0]).unwrap();
     store.add(3, &[10.0, 10.0]).unwrap();
 
-    let flat = store.search(&[0.0, 0.1], 2).unwrap();
-    assert_eq!(flat.len(), 4); // [id0, dist0, id1, dist1]
-    assert_eq!(flat[0] as u64, 1); // closest
+    let hits = store.search(&[0.0, 0.1], 2).unwrap();
+    assert_eq!(hits.length(), 2);
+    assert_eq!(hits.distances().len(), 2);
+    assert_eq!(hits.ids()[0], 1); // closest
 }
 
 #[wasm_bindgen_test]
@@ -44,8 +45,8 @@ fn test_hnsw_search() {
     idx.add(1, &[0.0, 0.0, 0.0]).unwrap();
     idx.add(2, &[10.0, 10.0, 10.0]).unwrap();
 
-    let flat = idx.search(&[0.0, 0.0, 0.0], 1).unwrap();
-    assert_eq!(flat[0] as u64, 1);
+    let hits = idx.search(&[0.0, 0.0, 0.0], 1).unwrap();
+    assert_eq!(hits.ids()[0], 1);
 }
 
 #[wasm_bindgen_test]
@@ -53,8 +54,8 @@ fn test_cosine_metric() {
     let store = WasmVectorStore::new(2, "cosine").unwrap();
     store.add(1, &[1.0, 0.0]).unwrap();
     store.add(2, &[0.0, 1.0]).unwrap();
-    let flat = store.search(&[0.9, 0.1], 1).unwrap();
-    assert_eq!(flat[0] as u64, 1);
+    let hits = store.search(&[0.9, 0.1], 1).unwrap();
+    assert_eq!(hits.ids()[0], 1);
 }
 
 #[wasm_bindgen_test]
@@ -71,7 +72,7 @@ fn test_store_add_batch() {
     store.add_batch(&ids, &flat).unwrap();
     assert_eq!(store.size(), 3);
     let results = store.search(&[0.9, 0.9], 1).unwrap();
-    assert_eq!(results[0] as u64, 2);
+    assert_eq!(results.ids()[0], 2);
 
     // duplicate -> Err, all-or-nothing
     assert!(store.add_batch(&[4, 1], &flat[..4]).is_err());
@@ -87,5 +88,35 @@ fn test_hnsw_add_batch() {
     index.add_batch(&ids, &flat).unwrap();
     assert_eq!(index.size(), 2);
     let results = index.search(&[0.1, 0.1], 1).unwrap();
-    assert_eq!(results[0] as u64, 10);
+    assert_eq!(results.ids()[0], 10);
+}
+
+// --- #39: ids must survive the JS boundary without f32 narrowing ---
+
+const PRECISION_IDS: [u64; 4] = [1 << 24, (1 << 24) + 1, 1 << 53, u64::MAX];
+
+#[wasm_bindgen_test]
+fn store_search_round_trips_ids_beyond_f32_precision() {
+    let store = WasmVectorStore::new(2, "l2").unwrap();
+    for (i, id) in PRECISION_IDS.iter().enumerate() {
+        store.add(*id, &[i as f32, 0.0]).unwrap();
+    }
+    let mut got = store.search(&[0.0, 0.0], 4).unwrap().ids();
+    got.sort_unstable();
+    let mut want = PRECISION_IDS.to_vec();
+    want.sort_unstable();
+    assert_eq!(got, want);
+}
+
+#[wasm_bindgen_test]
+fn hnsw_search_round_trips_ids_beyond_f32_precision() {
+    let index = WasmHnswIndex::new(2, "l2", 16, 16, 100).unwrap();
+    for (i, id) in PRECISION_IDS.iter().enumerate() {
+        index.add(*id, &[i as f32, 0.0]).unwrap();
+    }
+    let mut got = index.search(&[0.0, 0.0], 4).unwrap().ids();
+    got.sort_unstable();
+    let mut want = PRECISION_IDS.to_vec();
+    want.sort_unstable();
+    assert_eq!(got, want);
 }

--- a/vanedb/src/atomic_write.rs
+++ b/vanedb/src/atomic_write.rs
@@ -1,0 +1,89 @@
+//! Atomic file replacement.
+//!
+//! A save writes to a temporary sibling of its destination and renames it into
+//! place, so a crash mid-write cannot leave a half-written file behind. The
+//! temporary name must be unique per destination *and* per concurrent writer:
+//! deriving it with `Path::with_extension("tmp")` made `index.bin` and
+//! `index.idx` collide on `index.tmp`, so two unrelated saves truncated,
+//! replaced, or renamed each other's work (#38).
+
+use std::ffi::{OsStr, OsString};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::error::{Result, VaneError};
+
+static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+/// A temporary file that is removed when dropped, unless it was committed.
+pub(crate) struct AtomicFile {
+    temp: PathBuf,
+    committed: bool,
+}
+
+impl AtomicFile {
+    /// Reserve a temporary path beside `dest`. Staying in the destination
+    /// directory keeps the final rename on one filesystem, and therefore
+    /// atomic.
+    pub(crate) fn new(dest: &Path) -> Self {
+        let mut name = OsString::from(".");
+        name.push(dest.file_name().unwrap_or_else(|| OsStr::new("vanedb")));
+        name.push(format!(
+            ".{}.{}.tmp",
+            std::process::id(),
+            SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        Self {
+            temp: dest.with_file_name(name),
+            committed: false,
+        }
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.temp
+    }
+
+    /// Publish the finished temporary file at `dest`.
+    pub(crate) fn commit(mut self, dest: &Path) -> Result<()> {
+        fs::rename(&self.temp, dest).map_err(|e| VaneError::Io(format!("rename: {e}")))?;
+        self.committed = true;
+        Ok(())
+    }
+}
+
+impl Drop for AtomicFile {
+    fn drop(&mut self) {
+        if !self.committed {
+            // Best effort: a failed save must not leave an orphan behind, but
+            // there is nothing useful to do if the cleanup itself fails.
+            let _ = fs::remove_file(&self.temp);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn destinations_sharing_a_stem_get_distinct_temp_paths() {
+        let bin = AtomicFile::new(Path::new("/tmp/index.bin"));
+        let idx = AtomicFile::new(Path::new("/tmp/index.idx"));
+        assert_ne!(bin.path(), idx.path());
+    }
+
+    #[test]
+    fn concurrent_saves_to_one_destination_get_distinct_temp_paths() {
+        let first = AtomicFile::new(Path::new("/tmp/index.bin"));
+        let second = AtomicFile::new(Path::new("/tmp/index.bin"));
+        assert_ne!(first.path(), second.path());
+    }
+
+    #[test]
+    fn temp_file_stays_in_the_destination_directory() {
+        let dest = Path::new("/tmp/nested/index.bin");
+        let temp = AtomicFile::new(dest);
+        assert_eq!(temp.path().parent(), dest.parent());
+    }
+}

--- a/vanedb/src/hnsw/mod.rs
+++ b/vanedb/src/hnsw/mod.rs
@@ -599,6 +599,26 @@ impl HnswIndexBuilder {
         } else {
             1.0
         };
+        // Derived sizes are checked before any allocation: unchecked `m * 2`
+        // and `capacity * dim` panicked on overflow, which a fallible builder
+        // must not do — and which aborts the host process when the C ABI calls
+        // it (#43).
+        let m_max0 = self
+            .m
+            .checked_mul(2)
+            .ok_or(VaneError::InvalidParameter("M * 2 overflows usize"))?;
+        let vector_len = self
+            .capacity
+            .checked_mul(self.dim)
+            .ok_or(VaneError::InvalidParameter(
+                "capacity * dim overflows usize",
+            ))?;
+        let mut vectors: Vec<f32> = Vec::new();
+        vectors
+            .try_reserve_exact(vector_len)
+            .map_err(|_| VaneError::InvalidParameter("capacity is too large to allocate"))?;
+        vectors.resize(vector_len, 0.0);
+
         Ok(HnswIndex {
             dim: self.dim,
             metric: self.metric,
@@ -606,13 +626,13 @@ impl HnswIndexBuilder {
             max_elements: self.capacity,
             m: self.m,
             m_max: self.m,
-            m_max0: self.m * 2,
+            m_max0,
             ef_construction,
             ef_search: AtomicUsize::new(50),
             mult,
             seed: self.seed,
             inner: RwLock::new(Inner {
-                vectors: vec![0.0; self.capacity * self.dim],
+                vectors,
                 ext_ids: vec![0; self.capacity],
                 id_map: HashMap::new(),
                 levels: vec![0; self.capacity],

--- a/vanedb/src/hnsw/persistence.rs
+++ b/vanedb/src/hnsw/persistence.rs
@@ -100,8 +100,9 @@ impl HnswIndex {
             .map_err(|e| VaneError::Io(format!("serialize: {e}")))?;
 
         let path = path.as_ref();
-        let tmp = path.with_extension("tmp");
-        let mut f = fs::File::create(&tmp).map_err(|e| VaneError::Io(format!("create: {e}")))?;
+        let temp = crate::atomic_write::AtomicFile::new(path);
+        let mut f =
+            fs::File::create(temp.path()).map_err(|e| VaneError::Io(format!("create: {e}")))?;
         f.write_all(&MAGIC.to_le_bytes())
             .map_err(|e| VaneError::Io(format!("write: {e}")))?;
         f.write_all(&VERSION.to_le_bytes())
@@ -115,8 +116,7 @@ impl HnswIndex {
             .map_err(|e| VaneError::Io(format!("sync: {e}")))?;
         drop(f);
 
-        fs::rename(&tmp, path).map_err(|e| VaneError::Io(format!("rename: {e}")))?;
-        Ok(())
+        temp.commit(path)
     }
 
     pub fn load(path: impl AsRef<Path>) -> Result<Self> {

--- a/vanedb/src/lib.rs
+++ b/vanedb/src/lib.rs
@@ -1,3 +1,4 @@
+mod atomic_write;
 pub mod distance;
 pub mod error;
 #[cfg(any(feature = "gpu-metal", feature = "gpu-cuda"))]

--- a/vanedb/src/mmap.rs
+++ b/vanedb/src/mmap.rs
@@ -74,8 +74,9 @@ impl MmapVectorStoreBuilder {
 
     pub fn save(&self, path: impl AsRef<Path>) -> Result<()> {
         let path = path.as_ref();
-        let tmp = path.with_extension("tmp");
-        let mut f = fs::File::create(&tmp).map_err(|e| VaneError::Io(format!("create: {e}")))?;
+        let temp = crate::atomic_write::AtomicFile::new(path);
+        let mut f =
+            fs::File::create(temp.path()).map_err(|e| VaneError::Io(format!("create: {e}")))?;
 
         // Header
         f.write_all(&MAGIC.to_le_bytes())
@@ -112,8 +113,7 @@ impl MmapVectorStoreBuilder {
             .map_err(|e| VaneError::Io(format!("sync: {e}")))?;
         drop(f);
 
-        fs::rename(&tmp, path).map_err(|e| VaneError::Io(format!("rename: {e}")))?;
-        Ok(())
+        temp.commit(path)
     }
 }
 

--- a/vanedb/tests/atomic_save_tests.rs
+++ b/vanedb/tests/atomic_save_tests.rs
@@ -1,0 +1,110 @@
+//! Regression coverage for #38: two saves whose destinations share a stem must
+//! not fight over a single temporary file.
+#![cfg(feature = "mmap")]
+
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+use vanedb::{DistanceMetric, HnswIndex, MmapVectorStore, MmapVectorStoreBuilder};
+
+const DIM: usize = 4;
+const N: u64 = 64;
+const ROUNDS: usize = 25;
+
+fn vector(i: u64) -> Vec<f32> {
+    vec![i as f32, 1.0, 2.0, 3.0]
+}
+
+/// `index.bin` and `index.idx` share the stem `index`, so deriving the
+/// temporary path with `with_extension("tmp")` made both writers target
+/// `index.tmp`.
+#[test]
+fn concurrent_saves_sharing_a_stem_both_succeed() {
+    let dir = std::env::temp_dir().join(format!("vanedb-issue-38-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let store_path = dir.join("index.bin");
+    let index_path = dir.join("index.idx");
+
+    for round in 0..ROUNDS {
+        let mut builder = MmapVectorStoreBuilder::new(DIM, DistanceMetric::L2).unwrap();
+        let index = HnswIndex::builder(DIM, DistanceMetric::L2)
+            .capacity(N as usize)
+            .build()
+            .unwrap();
+        for i in 0..N {
+            builder.add(i, &vector(i)).unwrap();
+            index.add(i, &vector(i)).unwrap();
+        }
+
+        let barrier = Arc::new(Barrier::new(2));
+        let (store_barrier, index_barrier) = (Arc::clone(&barrier), Arc::clone(&barrier));
+        let (store_dest, index_dest) = (store_path.clone(), index_path.clone());
+
+        let store_writer = thread::spawn(move || {
+            store_barrier.wait();
+            builder.save(&store_dest)
+        });
+        let index_writer = thread::spawn(move || {
+            index_barrier.wait();
+            index.save(&index_dest)
+        });
+
+        if let Err(e) = store_writer.join().unwrap() {
+            panic!("round {round}: store save failed: {e}");
+        }
+        if let Err(e) = index_writer.join().unwrap() {
+            panic!("round {round}: index save failed: {e}");
+        }
+
+        let store = MmapVectorStore::open(&store_path)
+            .unwrap_or_else(|e| panic!("round {round}: store reload failed: {e}"));
+        assert_eq!(store.size(), N as usize, "round {round}");
+        assert_eq!(
+            store.search(&vector(7), 1).unwrap()[0].id,
+            7,
+            "round {round}"
+        );
+
+        let reloaded = HnswIndex::load(&index_path)
+            .unwrap_or_else(|e| panic!("round {round}: index reload failed: {e}"));
+        assert_eq!(
+            reloaded.search(&vector(7), 1).unwrap()[0].id,
+            7,
+            "round {round}"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// A failed save must not leave its temporary file behind for the next writer
+/// to trip over — unique temp names make orphans accumulate otherwise.
+#[test]
+fn failed_save_leaves_no_temporary_file() {
+    let dir = std::env::temp_dir().join(format!("vanedb-issue-38-cleanup-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let mut builder = MmapVectorStoreBuilder::new(DIM, DistanceMetric::L2).unwrap();
+    builder.add(1, &vector(1)).unwrap();
+
+    // A directory as the destination makes the final rename fail.
+    let dest = dir.join("occupied.bin");
+    std::fs::create_dir(&dest).unwrap();
+    assert!(builder.save(&dest).is_err());
+
+    let leftovers: Vec<_> = std::fs::read_dir(&dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|name| name.ends_with(".tmp"))
+        .collect();
+    assert!(
+        leftovers.is_empty(),
+        "temporary files left behind: {leftovers:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/vanedb/tests/hnsw_tests.rs
+++ b/vanedb/tests/hnsw_tests.rs
@@ -394,3 +394,53 @@ fn hnsw_add_batch_onto_nonempty_matches_serial_add() {
         assert_eq!(a, b, "query {i} diverged between serial and mixed build");
     }
 }
+
+// --- #43: derived sizes must be checked, not left to overflow/abort ---
+
+/// `capacity * dim` overflowed `usize` and panicked before the fallible
+/// builder could return an error.
+#[test]
+fn builder_rejects_capacity_times_dim_overflow() {
+    let result = vanedb::HnswIndex::builder(2, vanedb::DistanceMetric::L2)
+        .capacity(usize::MAX)
+        .build();
+    let Err(err) = result else {
+        panic!("expected the builder to reject these sizes");
+    };
+    assert!(
+        matches!(err, vanedb::VaneError::InvalidParameter(_)),
+        "expected InvalidParameter, got {err:?}"
+    );
+}
+
+/// `m * 2` (the layer-0 link budget) had the same problem.
+#[test]
+fn builder_rejects_m_doubling_overflow() {
+    let result = vanedb::HnswIndex::builder(2, vanedb::DistanceMetric::L2)
+        .capacity(1)
+        .m(usize::MAX / 2 + 1)
+        .build();
+    let Err(err) = result else {
+        panic!("expected the builder to reject these sizes");
+    };
+    assert!(
+        matches!(err, vanedb::VaneError::InvalidParameter(_)),
+        "expected InvalidParameter, got {err:?}"
+    );
+}
+
+/// Sizes that fit in `usize` but cannot be allocated must also return an error
+/// rather than aborting the process through the allocator.
+#[test]
+fn builder_rejects_unallocatable_capacity() {
+    let result = vanedb::HnswIndex::builder(1024, vanedb::DistanceMetric::L2)
+        .capacity(usize::MAX / 4096)
+        .build();
+    let Err(err) = result else {
+        panic!("expected the builder to reject these sizes");
+    };
+    assert!(
+        matches!(err, vanedb::VaneError::InvalidParameter(_)),
+        "expected InvalidParameter, got {err:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Three independent correctness fixes, one per commit, each with a regression test written before the fix and confirmed to fail against unfixed `main`.

- **#38** — `MmapVectorStoreBuilder::save` and `HnswIndex::save` both derived their temporary file with `path.with_extension("tmp")`, so `index.bin` and `index.idx` — the natural pairing when an application persists a store and its graph together — resolved to the same `index.tmp` and overwrote each other. Temporary names are now `.<file name>.<pid>.<seq>.tmp` beside the destination, keeping the publish rename same-filesystem and atomic. `AtomicFile` removes the temporary on drop unless committed, because unique names would otherwise let failed saves accumulate orphans instead of overwriting one stale file.
- **#43** — `m * 2` and `capacity * dim` were unchecked, so type-valid builder inputs panicked before the fallible builder could return `Err`, and that panic aborts the host process when it crosses the C ABI. Both products are now checked before allocation, and the vector arena uses `try_reserve_exact` so unallocatable-but-representable sizes also return an error instead of aborting through the allocator.
- **#39** — both wasm search paths flattened results into `Vec<f32>`, casting every `u64` id through a 24-bit mantissa. Ids at or above 2^24 collided silently, so callers could act on the wrong record while the API advertised 64-bit ids. Search now returns `WasmSearchResults` with ids as a `BigUint64Array` and distances as a parallel `Float32Array`. **Breaking change** for wasm consumers of the previous flat array; consistent with `add_batch`, which already takes `BigUint64Array`.

Existing `VaneError` variants are reused throughout, so this does not conflict with #53's `error.rs` change.

## Validation

- `cargo fmt --all -- --check` — pass
- `cargo clippy --workspace --exclude vanedb-py --all-targets --features mmap --locked -- -D warnings` — pass
- `cargo test --workspace --exclude vanedb-py --features mmap --locked` — 119 passed
- `wasm-pack test --node` — 11 passed, including both new id round-trip cases

Falsification against unfixed `main`:

- `concurrent_saves_sharing_a_stem_both_succeed` fails on round 0 with `rename: No such file or directory` — the issue's exact mechanism
- `failed_save_leaves_no_temporary_file` fails
- `builder_rejects_capacity_times_dim_overflow` and `builder_rejects_m_doubling_overflow` fail with `attempt to multiply with overflow` at `hnsw/mod.rs:609`
- `builder_rejects_unallocatable_capacity` fails
- #39's cases cannot be expressed against the old `Vec<f32>` signature; the collision is arithmetic (f32 carries 24 mantissa bits)

## Cross-engine assessment

Per `AGENTS.md`, both engines were checked rather than assumed:

- **#38 — not shared.** C++ builds its temporary as `filename + ".tmp"` (append, not replace), so distinct destinations do not collide. A narrower same-destination concurrent-save race does exist there and is worth its own issue.
- **#39 — not applicable.** wasm bindings are Rust-only.
- **#43 — the C++ engine has a more severe counterpart, reported separately.** `HNSWIndex` performs the same unchecked `max_elements * dim` in its constructor (`cpp/src/core/hnsw_index.h:78`) and load path (`:305`). Unsigned overflow wraps silently in C++ rather than panicking, so the result is an under-allocation rather than an abort — and in the loader both operands are read from the file with no bounds validation, while the length check uses the same wrapped product. That deserves its own fix and is out of scope here.

## Scope

No persistence format, publish workflow, or benchmark documentation changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H
