### PR TITLE
fix(distance): make cosine scale-invariant in both engines

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -13,6 +13,22 @@ both issue trackers:
 - non-finite distances in top-k ordering;
 - HNSW persistence with inconsistent external-id maps.
 
+## Distance semantics
+
+**Cosine.** The distance depends only on direction, so it must not change when
+both inputs are rescaled. Normalisation divides by `sqrt(norm_a) * sqrt(norm_b)`
+rather than `sqrt(norm_a * norm_b)`: the product grows with the fourth power of
+magnitude, which previously classified ordinary small vectors as zero and
+overflowed to infinity for large ones.
+
+A vector with no usable direction — a zero vector, or one whose squared norm
+overflows `f32` — is defined to be `1.0` away from everything, including
+itself. Finite inputs therefore never produce a non-finite cosine distance.
+
+`cosine_scale_invariance.tsv` pins these cases for both engines and is consumed
+by `vanedb/tests/cosine_conformance.rs` and
+`cpp/tests/test_cosine_conformance.cpp`.
+
 ## Universal persistence
 
 The first public persistence format is **VNDB v1**. Existing Rust and C++

--- a/conformance/cosine_scale_invariance.tsv
+++ b/conformance/cosine_scale_invariance.tsv
@@ -1,0 +1,33 @@
+# Shared cosine cases. Cosine distance depends only on direction, so `expected`
+# is identical at every scale. Each row builds two 2-D vectors from `scale`:
+#   identical    a = ( s, 2s)   b = ( s, 2s)   -> 0.0
+#   opposite     a = ( s, 2s)   b = (-s,-2s)   -> 2.0
+#   orthogonal   a = ( s,  0)   b = ( 0,  s)   -> 1.0
+#   zero         a = ( 0,  0)   b = ( s, 2s)   -> 1.0  (a has no direction)
+# Scales stay inside the f32 normal range at both ends so the cases test the
+# distance policy rather than subnormal arithmetic.
+# scale	relation	expected
+1e-18	identical	0.0
+1e-18	opposite	2.0
+1e-18	orthogonal	1.0
+1e-9	identical	0.0
+1e-9	opposite	2.0
+1e-9	orthogonal	1.0
+1e-4	identical	0.0
+1e-4	opposite	2.0
+1e-4	orthogonal	1.0
+1.0	identical	0.0
+1.0	opposite	2.0
+1.0	orthogonal	1.0
+1e4	identical	0.0
+1e4	opposite	2.0
+1e4	orthogonal	1.0
+1e9	identical	0.0
+1e9	opposite	2.0
+1e9	orthogonal	1.0
+1e18	identical	0.0
+1e18	opposite	2.0
+1e18	orthogonal	1.0
+1.0	zero	1.0
+1e-18	zero	1.0
+1e18	zero	1.0

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -120,6 +120,18 @@ target_compile_options(test_distance_strategy PRIVATE
 )
 target_link_options(test_distance_strategy PRIVATE ${COVERAGE_LINK_FLAGS})
 
+add_executable(test_cosine_conformance tests/test_cosine_conformance.cpp)
+target_link_libraries(test_cosine_conformance PRIVATE vanedb Catch2::Catch2WithMain)
+target_compile_definitions(test_cosine_conformance PRIVATE
+  VANEDB_CONFORMANCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../conformance"
+)
+target_compile_options(test_cosine_conformance PRIVATE
+  $<$<CXX_COMPILER_ID:MSVC>:/W4 /arch:AVX2>
+  $<$<AND:$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>,$<BOOL:${VANEDB_X86_64}>>:-mavx2 -mfma>
+  ${COVERAGE_COMPILE_FLAGS}
+)
+target_link_options(test_cosine_conformance PRIVATE ${COVERAGE_LINK_FLAGS})
+
 add_executable(test_mmap_vector_store tests/test_mmap_vector_store.cpp)
 target_link_libraries(test_mmap_vector_store PRIVATE vanedb Catch2::Catch2WithMain)
 target_compile_options(test_mmap_vector_store PRIVATE
@@ -136,6 +148,7 @@ catch_discover_tests(test_vector_store)
 catch_discover_tests(test_hnsw_index)
 catch_discover_tests(test_distance_strategy)
 catch_discover_tests(test_mmap_vector_store)
+catch_discover_tests(test_cosine_conformance)
 endif() # VANEDB_BUILD_TESTS
 
 # Examples

--- a/cpp/src/core/distance.h
+++ b/cpp/src/core/distance.h
@@ -22,7 +22,6 @@
 namespace vanedb {
 
 // Below this denominator (||a|| · ||b||) the vectors are treated as orthogonal.
-inline constexpr float COSINE_EPSILON = 1e-12f;
 
 #ifdef VANE_ARM_NEON
 [[nodiscard]] inline float hsum(float32x4_t v) noexcept {
@@ -184,9 +183,21 @@ inline constexpr float COSINE_EPSILON = 1e-12f;
     nb += b[i] * b[i];
   }
 
-  float denom = na * nb;
-  if (denom < COSINE_EPSILON) return 1.0f;
-  float sim = dot / sqrtf(denom);
+  // Normalise by each vector's own norm. `na * nb` grows with the fourth
+  // power of magnitude, so a fixed epsilon on that product classified ordinary
+  // small vectors as zero and overflowed to infinity for large ones — both
+  // returned 1.0 for identical inputs (vanedb#40 / vanedb-cpp#36).
+  //
+  // Zero-vector policy, shared with the Rust engine: a vector is zero only
+  // when its own squared norm is zero. It has no direction, so its cosine
+  // distance to anything, including itself, is 1.0.
+  // Multiplying the roots rather than rooting the product keeps the
+  // denominator in range for both tiny and huge vectors. A vector with no
+  // usable direction — zero, or a squared norm that overflowed float — is
+  // 1.0 away from everything, including itself.
+  float denom = sqrtf(na) * sqrtf(nb);
+  if (!(denom > 0.0f && std::isfinite(denom))) return 1.0f;
+  float sim = dot / denom;
   return 1.0f - std::clamp(sim, -1.0f, 1.0f);
 }
 

--- a/cpp/src/core/gpu/cuda_distance.cuh
+++ b/cpp/src/core/gpu/cuda_distance.cuh
@@ -57,8 +57,8 @@ __global__ void cos_k(const float4* __restrict__ q, const float4* __restrict__ v
     nv.x += b.x*b.x; nv.y += b.y*b.y; nv.z += b.z*b.z; nv.w += b.w*b.w;
   }
   float dot = d.x+d.y+d.z+d.w, na = nq.x+nq.y+nq.z+nq.w, nb = nv.x+nv.y+nv.z+nv.w;
-  float dn = na * nb;
-  float sim = (dn < 1e-12f) ? 0.0f : dot * rsqrtf(dn);
+  float dn = sqrtf(na) * sqrtf(nb);
+  float sim = (dn > 0.0f && isfinite(dn)) ? dot / dn : 0.0f;
   r[i] = 1.0f - fminf(fmaxf(sim, -1.0f), 1.0f);
 }
 

--- a/cpp/src/core/gpu/metal_distance.h
+++ b/cpp/src/core/gpu/metal_distance.h
@@ -86,7 +86,7 @@ kernel void cs(device const float4* q[[buffer(0)]], device const float4* v[[buff
   float4 d=0,nq=0,nv=0; uint o=i*d4;
   for(uint j=0;j<d4;++j){float4 a=q[j],b=v[o+j];d+=a*b;nq+=a*a;nv+=b*b;}
   float dot=d.x+d.y+d.z+d.w,na=nq.x+nq.y+nq.z+nq.w,nb=nv.x+nv.y+nv.z+nv.w;
-  float dn=na*nb; r[i]=1.0f-clamp((dn<1e-12f)?0.0f:dot*rsqrt(dn),-1.0f,1.0f);
+  float dn=sqrt(na)*sqrt(nb); float sim=(dn>0.0f&&isfinite(dn))?dot/dn:0.0f; r[i]=1.0f-clamp(sim,-1.0f,1.0f);
 }
       )";
       id<MTLLibrary> lib = [dev_ newLibraryWithSource:src options:nil error:&err];

--- a/cpp/tests/test_cosine_conformance.cpp
+++ b/cpp/tests/test_cosine_conformance.cpp
@@ -1,0 +1,82 @@
+// Cross-engine cosine cases from conformance/cosine_scale_invariance.tsv.
+//
+// The zero-vector guard compared `na * nb` against a fixed epsilon. That
+// product grows with the fourth power of magnitude, so ordinary small vectors
+// were classified as zero and large ones overflowed the product to infinity —
+// both returned 1.0 for identical inputs (vanedb-cpp#36 / vanedb#40).
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cmath>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "core/distance.h"
+
+namespace {
+
+constexpr float TOLERANCE = 1e-5f;
+
+struct Case {
+  float scale;
+  std::string relation;
+  float expected;
+};
+
+std::vector<Case> load_cases() {
+  const std::string path = std::string(VANEDB_CONFORMANCE_DIR) + "/cosine_scale_invariance.tsv";
+  std::ifstream in(path);
+  REQUIRE(in.is_open());
+
+  std::vector<Case> cases;
+  std::string line;
+  while (std::getline(in, line)) {
+    if (line.empty() || line[0] == '#') continue;
+    std::istringstream fields(line);
+    std::string scale, relation, expected;
+    std::getline(fields, scale, '\t');
+    std::getline(fields, relation, '\t');
+    std::getline(fields, expected, '\t');
+    cases.push_back({std::stof(scale), relation, std::stof(expected)});
+  }
+  REQUIRE_FALSE(cases.empty());
+  return cases;
+}
+
+std::pair<std::vector<float>, std::vector<float>> vectors(float s, const std::string& relation) {
+  if (relation == "identical") return {{s, 2.0f * s}, {s, 2.0f * s}};
+  if (relation == "opposite") return {{s, 2.0f * s}, {-s, -2.0f * s}};
+  if (relation == "orthogonal") return {{s, 0.0f}, {0.0f, s}};
+  if (relation == "zero") return {{0.0f, 0.0f}, {s, 2.0f * s}};
+  FAIL("unknown relation: " << relation);
+  return {};
+}
+
+}  // namespace
+
+TEST_CASE("cosine distance matches the shared cases", "[conformance][distance]") {
+  for (const auto& c : load_cases()) {
+    auto [a, b] = vectors(c.scale, c.relation);
+    const float got = vanedb::cosine_distance(a.data(), b.data(), a.size());
+    INFO("scale=" << c.scale << " relation=" << c.relation);
+    REQUIRE(std::fabs(got - c.expected) <= TOLERANCE);
+  }
+}
+
+TEST_CASE("cosine is scale invariant across SIMD-width vectors", "[conformance][distance]") {
+  for (float scale : {1e-18f, 1e-4f, 1.0f, 1e4f, 1e15f}) {
+    std::vector<float> a(128);
+    for (size_t i = 0; i < a.size(); ++i) a[i] = (static_cast<float>(i) + 1.0f) * scale;
+    INFO("scale=" << scale);
+    REQUIRE(std::fabs(vanedb::cosine_distance(a.data(), a.data(), a.size())) <= TOLERANCE);
+  }
+}
+
+TEST_CASE("cosine returns one when norms overflow rather than NaN", "[conformance][distance]") {
+  const std::vector<float> a(128, 1e20f);
+  const float got = vanedb::cosine_distance(a.data(), a.data(), a.size());
+  REQUIRE(std::isfinite(got));
+  REQUIRE(std::fabs(got - 1.0f) <= TOLERANCE);
+}

--- a/vanedb/src/distance/avx2.rs
+++ b/vanedb/src/distance/avx2.rs
@@ -1,8 +1,6 @@
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
 
-use crate::distance::COSINE_EPSILON;
-
 /// Horizontal sum of 8 floats in a 256-bit register.
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2")]
@@ -121,11 +119,15 @@ pub unsafe fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
         i += 1;
     }
 
-    let denom = norm_a * norm_b;
-    if denom < COSINE_EPSILON {
+    // Zero-vector policy and per-norm normalisation must stay identical to
+    // `scalar::cosine_distance`, the reference implementation (#40).
+    // Multiplying the roots rather than rooting the product keeps the
+    // denominator in range for both tiny and huge vectors.
+    let denom = norm_a.sqrt() * norm_b.sqrt();
+    if !(denom > 0.0 && denom.is_finite()) {
         return 1.0;
     }
-    let sim = dot / denom.sqrt();
+    let sim = dot / denom;
     1.0 - sim.clamp(-1.0, 1.0)
 }
 

--- a/vanedb/src/distance/mod.rs
+++ b/vanedb/src/distance/mod.rs
@@ -18,9 +18,6 @@ pub enum DistanceMetric {
 /// Function type for distance computation.
 pub type DistanceFn = fn(&[f32], &[f32]) -> f32;
 
-/// Zero-norm threshold for cosine distance.
-pub const COSINE_EPSILON: f32 = 1e-12;
-
 /// Returns the distance function for the given metric.
 /// Automatically selects SIMD implementation when available.
 pub fn distance_fn(metric: DistanceMetric) -> DistanceFn {

--- a/vanedb/src/distance/neon.rs
+++ b/vanedb/src/distance/neon.rs
@@ -1,8 +1,6 @@
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 
-use crate::distance::COSINE_EPSILON;
-
 #[cfg(target_arch = "aarch64")]
 pub fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
     debug_assert_eq!(a.len(), b.len());
@@ -101,11 +99,15 @@ pub fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
         i += 1;
     }
 
-    let denom = norm_a * norm_b;
-    if denom < COSINE_EPSILON {
+    // Zero-vector policy and per-norm normalisation must stay identical to
+    // `scalar::cosine_distance`, the reference implementation (#40).
+    // Multiplying the roots rather than rooting the product keeps the
+    // denominator in range for both tiny and huge vectors.
+    let denom = norm_a.sqrt() * norm_b.sqrt();
+    if !(denom > 0.0 && denom.is_finite()) {
         return 1.0;
     }
-    let sim = dot / denom.sqrt();
+    let sim = dot / denom;
     1.0 - sim.clamp(-1.0, 1.0)
 }
 

--- a/vanedb/src/distance/scalar.rs
+++ b/vanedb/src/distance/scalar.rs
@@ -1,5 +1,3 @@
-use crate::distance::COSINE_EPSILON;
-
 pub fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
     debug_assert_eq!(a.len(), b.len());
     a.iter()
@@ -21,11 +19,21 @@ pub fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
         norm_a += x * x;
         norm_b += y * y;
     }
-    let denom = norm_a * norm_b;
-    if denom < COSINE_EPSILON {
+    // Normalise by each vector's own norm. `norm_a * norm_b` grows with the
+    // fourth power of magnitude, so a fixed epsilon on that product classified
+    // ordinary small vectors as zero, and the product overflowed to infinity
+    // for large ones — both returned 1.0 for identical inputs (#40).
+    //
+    // Policy, shared with vanedb-cpp: a vector with no usable direction —
+    // a zero vector, or one whose squared norm overflowed f32 — is 1.0 away
+    // from everything, including itself. Finite inputs never yield NaN.
+    // Multiplying the roots rather than rooting the product keeps the
+    // denominator in range for both tiny and huge vectors.
+    let denom = norm_a.sqrt() * norm_b.sqrt();
+    if !(denom > 0.0 && denom.is_finite()) {
         return 1.0;
     }
-    let sim = dot / denom.sqrt();
+    let sim = dot / denom;
     1.0 - sim.clamp(-1.0, 1.0)
 }
 

--- a/vanedb/src/gpu/metal.rs
+++ b/vanedb/src/gpu/metal.rs
@@ -60,8 +60,9 @@ kernel void cs(
     float dot = d.x + d.y + d.z + d.w;
     float na = nq.x + nq.y + nq.z + nq.w;
     float nb = nv.x + nv.y + nv.z + nv.w;
-    float dn = na * nb;
-    r[i] = 1.0f - clamp((dn < 1e-12f) ? 0.0f : dot * rsqrt(dn), -1.0f, 1.0f);
+    float dn = sqrt(na) * sqrt(nb);
+    float sim = (dn > 0.0f && isfinite(dn)) ? dot / dn : 0.0f;
+    r[i] = 1.0f - clamp(sim, -1.0f, 1.0f);
 }
 "#;
 

--- a/vanedb/tests/cosine_conformance.rs
+++ b/vanedb/tests/cosine_conformance.rs
@@ -1,0 +1,100 @@
+//! Cross-engine cosine cases from `conformance/cosine_scale_invariance.tsv`.
+//!
+//! Cosine distance is scale-invariant, but the zero-vector guard compared
+//! `norm_a * norm_b` against a fixed epsilon. That product scales with the
+//! fourth power of magnitude, so ordinary small vectors were classified as
+//! zero (returning 1.0 for identical inputs) and large ones overflowed the
+//! product to infinity, returning 1.0 as well (#40).
+
+use vanedb::distance::{distance_fn, DistanceMetric};
+
+const TOLERANCE: f32 = 1e-5;
+
+fn cases() -> Vec<(f32, String, f32)> {
+    let raw = include_str!("../../conformance/cosine_scale_invariance.tsv");
+    raw.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(|line| {
+            let mut field = line.split('\t');
+            let scale: f32 = field.next().unwrap().parse().unwrap();
+            let relation = field.next().unwrap().to_string();
+            let expected: f32 = field.next().unwrap().parse().unwrap();
+            (scale, relation, expected)
+        })
+        .collect()
+}
+
+fn vectors(scale: f32, relation: &str) -> (Vec<f32>, Vec<f32>) {
+    match relation {
+        "identical" => (vec![scale, 2.0 * scale], vec![scale, 2.0 * scale]),
+        "opposite" => (vec![scale, 2.0 * scale], vec![-scale, -2.0 * scale]),
+        "orthogonal" => (vec![scale, 0.0], vec![0.0, scale]),
+        "zero" => (vec![0.0, 0.0], vec![scale, 2.0 * scale]),
+        other => panic!("unknown relation: {other}"),
+    }
+}
+
+#[test]
+fn cosine_distance_matches_the_shared_cases() {
+    let cosine = distance_fn(DistanceMetric::Cosine);
+    let mut failures = Vec::new();
+
+    for (scale, relation, expected) in cases() {
+        let (a, b) = vectors(scale, &relation);
+        let got = cosine(&a, &b);
+        if (got - expected).abs() > TOLERANCE {
+            failures.push(format!(
+                "scale={scale:e} {relation}: expected {expected}, got {got}"
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "cosine cases failed:\n{}",
+        failures.join("\n")
+    );
+}
+
+/// The dispatcher picks a SIMD path at runtime; the scalar reference defines
+/// the contract, so the two must agree on every shared case.
+#[test]
+fn dispatched_cosine_agrees_with_the_scalar_reference() {
+    let cosine = distance_fn(DistanceMetric::Cosine);
+    for (scale, relation, _) in cases() {
+        let (a, b) = vectors(scale, &relation);
+        let dispatched = cosine(&a, &b);
+        let scalar = vanedb::distance::scalar::cosine_distance(&a, &b);
+        assert!(
+            (dispatched - scalar).abs() <= TOLERANCE,
+            "scale={scale:e} {relation}: dispatched {dispatched} vs scalar {scalar}"
+        );
+    }
+}
+
+/// Wider vectors exercise the SIMD body rather than only the scalar tail.
+#[test]
+fn cosine_is_scale_invariant_for_simd_width_vectors() {
+    let cosine = distance_fn(DistanceMetric::Cosine);
+    for scale in [1e-18f32, 1e-4, 1.0, 1e4, 1e15] {
+        let a: Vec<f32> = (0..128).map(|i| (i as f32 + 1.0) * scale).collect();
+        let got = cosine(&a, &a);
+        assert!(
+            got.abs() <= TOLERANCE,
+            "identical 128-d vectors at scale {scale:e} gave {got}, expected 0"
+        );
+    }
+}
+
+/// A finite input whose squared norm overflows f32 has no usable direction.
+/// The documented answer is 1.0 — never NaN, which would otherwise leak a
+/// non-finite distance into top-k ordering.
+#[test]
+fn cosine_returns_one_when_norms_overflow_rather_than_nan() {
+    let cosine = distance_fn(DistanceMetric::Cosine);
+    let a: Vec<f32> = vec![1e20; 128];
+    let got = cosine(&a, &a);
+    assert!(got.is_finite(), "expected a finite distance, got {got}");
+    assert!((got - 1.0).abs() <= TOLERANCE, "expected 1.0, got {got}");
+}


### PR DESCRIPTION
## Summary

Fixes #40 and its C++ twin `vanedb-cpp#36` in one change, with a shared fixture consumed by both engines.

The zero-vector guard compared `norm_a * norm_b` against a fixed `1e-12`. That product grows with the **fourth** power of magnitude, so it failed at both ends:

- `cosine([1e-4], [1e-4])` returned `1.0` — identical vectors reported as maximally distant, the case in the issue;
- at large magnitudes the product overflows to infinity and returns `1.0` as well. **This half was not in the issue** — the fixture caught it at scale `1e18`.

Cosine distance therefore was not scale-invariant, and results changed under harmless rescaling.

## Fix

Normalise by `sqrt(norm_a) * sqrt(norm_b)` instead of `sqrt(norm_a * norm_b)`, and test that denominator directly. Multiplying the roots keeps the denominator in range at both extremes.

**Zero-vector policy, now explicit and shared:** a vector with no usable direction — zero, or a squared norm that overflowed the float type — is `1.0` away from everything, including itself. A consequence worth stating: finite inputs can no longer produce a non-finite cosine distance, so this cannot leak a NaN into top-k ordering (the concern behind #41).

Applied identically to all eight implementations — Rust scalar, NEON, AVX2, Metal shader; C++ scalar/AVX2, Metal, CUDA. `COSINE_EPSILON` is removed from both engines because it encoded the wrong policy; this is a breaking change for anyone importing that public constant.

## Conformance

`conformance/cosine_scale_invariance.tsv` — identical / opposite / orthogonal at seven magnitudes from `1e-18` to `1e18`, plus zero-vector cases. Scales stay inside the f32 normal range at both ends so the cases test the distance policy rather than subnormal arithmetic. Consumed by `vanedb/tests/cosine_conformance.rs` and `cpp/tests/test_cosine_conformance.cpp`.

The policy is documented in `conformance/README.md` under a new "Distance semantics" section.

## Validation

Written test-first and confirmed failing before the fix:

```
scale=1e-18 identical: expected 0, got 1
scale=1e-9  identical: expected 0, got 1
scale=1e-4  identical: expected 0, got 1
scale=1e18  identical: expected 0, got 1   (and the matching `opposite` rows)
```

After:

- `cargo fmt --all -- --check` — pass
- `cargo clippy --workspace --exclude vanedb-py --all-targets --features mmap --locked -- -D warnings` — pass
- `cargo test --workspace --exclude vanedb-py --features mmap --locked` — all suites pass
- `wasm-pack test --node` — 11 passed
- CMake Release + `ctest` — **54/54 passed**, including the three new C++ conformance cases

GPU paths (Metal, CUDA) received the same policy but are not exercised by this run; the Metal job in CI covers the Rust shader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H
