### PR TITLE
chore(release): raise the Python floor to 3.11

### DIFF
--- a/.github/requirements-release.txt
+++ b/.github/requirements-release.txt
@@ -4,6 +4,5 @@
 build==1.6.0
 cibuildwheel==4.2.0
 packaging==26.3
-pip==25.3; python_version == "3.9"
-pip==26.2.1; python_version >= "3.10"
+pip==26.2.1
 twine==7.0.0

--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -136,7 +136,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
 
     steps:
     - name: Checkout code

--- a/.github/workflows/publish-cpp.yml
+++ b/.github/workflows/publish-cpp.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Build and test wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*
+          CIBW_BUILD: cp311-* cp312-* cp313-* cp314-*
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {project}/tests/test_python_bindings.py -v
@@ -216,17 +216,15 @@ jobs:
             --directory ../dist \
             --distribution vanedb-cpp \
             --pyproject pyproject.toml \
-            --wheel-count 24 \
+            --wheel-count 16 \
             --sdist-count 1 \
-            --python-tag cp39=4 \
-            --python-tag cp310=4 \
             --python-tag cp311=4 \
             --python-tag cp312=4 \
             --python-tag cp313=4 \
             --python-tag cp314=4 \
-            --platform-prefix manylinux=6 \
-            --platform-prefix macosx=12 \
-            --platform-prefix win=6
+            --platform-prefix manylinux=4 \
+            --platform-prefix macosx=8 \
+            --platform-prefix win=4
 
   publish:
     name: Publish vanedb-cpp to PyPI

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -78,7 +78,7 @@ jobs:
           fi
 
   linux:
-    name: Linux wheels (x86_64, Python 3.9–3.14)
+    name: Linux wheels (x86_64, Python 3.11–3.14)
     needs: validate-version
     runs-on: ubuntu-latest
     steps:
@@ -94,8 +94,7 @@ jobs:
           args: >-
             --release --locked --compatibility pypi --out dist
             --manifest-path vanedb-py/Cargo.toml
-            -i python3.9 -i python3.10 -i python3.11
-            -i python3.12 -i python3.13 -i python3.14
+            -i python3.11 -i python3.12 -i python3.13 -i python3.14
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: vanedb-linux-x86_64
@@ -109,7 +108,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -138,7 +137,7 @@ jobs:
         target:
           - x86_64
           - aarch64
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
         include:
           - target: x86_64
             runner: macos-15-intel
@@ -175,7 +174,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -265,17 +264,15 @@ jobs:
             --directory dist \
             --distribution vanedb \
             --pyproject vanedb-py/pyproject.toml \
-            --wheel-count 24 \
+            --wheel-count 16 \
             --sdist-count 1 \
-            --python-tag cp39=4 \
-            --python-tag cp310=4 \
             --python-tag cp311=4 \
             --python-tag cp312=4 \
             --python-tag cp313=4 \
             --python-tag cp314=4 \
-            --platform-prefix manylinux=6 \
-            --platform-prefix macosx=12 \
-            --platform-prefix win=6
+            --platform-prefix manylinux=4 \
+            --platform-prefix macosx=8 \
+            --platform-prefix win=4
 
   publish-testpypi:
     name: Publish vanedb to TestPyPI

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -8,7 +8,7 @@
 [![codecov](https://codecov.io/gh/vanedb/vanedb/branch/main/graph/badge.svg)](https://codecov.io/gh/vanedb/vanedb)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![C++20](https://img.shields.io/badge/C%2B%2B-20-00599C.svg)](https://en.cppreference.com/w/cpp/20)
-[![Python 3.9+](https://img.shields.io/badge/Python-3.9%2B-3776AB.svg)](https://www.python.org/)
+[![Python 3.11+](https://img.shields.io/badge/Python-3.11%2B-3776AB.svg)](https://www.python.org/)
 
 </div>
 

--- a/cpp/pyproject.toml
+++ b/cpp/pyproject.toml
@@ -3,7 +3,7 @@ name = "vanedb-cpp"
 version = "0.1.0"
 description = "Supplementary C++ Python bindings for VaneDB"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 license = {text = "MIT"}
 authors = [
     {name = "Anton Tsvetkov"}
@@ -15,8 +15,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/vanedb-py/pyproject.toml
+++ b/vanedb-py/pyproject.toml
@@ -6,13 +6,11 @@ build-backend = "maturin"
 name = "vanedb"
 version = "0.1.0"
 description = "Embeddable vector database for edge AI"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 license = "MIT"
 keywords = ["vector", "database", "embeddings", "similarity-search"]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
## Summary

Raises the Python floor to 3.11 across both products and resolves Dependabot alert #4 (#58).

## Why 3.11, not 3.12

3.9 reached end of life in October 2025; 3.10 reaches it this month. Dropping both is free.

The real question is 3.11 vs 3.12, and it turns on the audience. **Debian 12 — current stable — ships 3.11**, and an embeddable vector database for edge AI meets older LTS bases far more often than a typical library does. Ubuntu 24.04 ships 3.12, so a 3.12 floor would cut out Debian stable for no practical gain. 3.11 is supported until October 2027.

## Why this closes the Dependabot alert

The alert could not be fixed by bumping the pin. pip 26.0.1 is the last release that supports 3.9, and the advisory is fixed in 26.2.0, which requires 3.10 — so no patched pip exists for 3.9. Removing 3.9 removes the constraint, and `.github/requirements-release.txt` collapses to a single unconditional `pip==26.2.1`.

## Changes

| File | Change |
|---|---|
| `publish-rust.yml` | matrix and `-i` flags → 3.11–3.14; validators → 16 wheels, 4/8/4 platform split |
| `publish-cpp.yml` | `CIBW_BUILD` → `cp311-*`…`cp314-*`; same validator changes |
| `cpp-ci.yml` | Python Bindings Tests matrix 18 jobs → 12 |
| `requires-release.txt` | single `pip==26.2.1`, no marker |
| both `pyproject.toml` | `requires-python = ">=3.11"`, classifiers trimmed |
| `cpp/README.md` | badge |

The validator counts (`--wheel-count`, `--python-tag`, `--platform-prefix`) are a deliberate tripwire and move in lockstep — 4 interpreters × 4 platforms = 16, split 4 manylinux / 8 macosx / 4 win.

## Follow-up worth considering separately

With a 3.11 floor, the Rust extension becomes eligible for **`abi3-py311`**: one wheel per platform covering 3.11, 3.12, 3.13, 3.14 and every future release. That would take the Rust matrix from 16 wheels to 4 and remove the per-version matrix entirely rather than shrinking it — the macOS leg alone goes from 8 jobs to 2. The limited-API cost is negligible here because the hot path is Rust rather than Python calls. It does not apply to the C++ wheel, which is why `cp39-abi3` was removed in cpp#41. Deliberately not bundled: it changes wheel naming and the validator's tag model, and deserves its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H
