### PR TITLE
fix(cpp): validate HNSW derived sizes

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -14,6 +14,10 @@ both issue trackers:
   boundary, persisted stores containing non-finite vectors fail to load, and
   defensive result ordering always places finite distances first. The shared
   input cases live in `non_finite_vectors.tsv`;
+- HNSW construction in both engines rejects overflow in
+  capacity-times-dimension and doubled-`M` derived sizes before allocation;
+  the C++ legacy-format loader applies the same cases as corruption checks.
+  The architecture-neutral symbolic cases live in `hnsw_derived_sizes.tsv`;
 - HNSW persistence with inconsistent external-id maps.
 
 ## Distance semantics

--- a/conformance/hnsw_derived_sizes.tsv
+++ b/conformance/hnsw_derived_sizes.tsv
@@ -1,0 +1,6 @@
+# Shared symbolic cases for fallible HNSW derived-size validation. Symbols are
+# resolved against each engine's native index type (`usize` / `size_t`) so the
+# same contract applies on both 32-bit and 64-bit targets.
+# name	dimension	max_elements	M	overflow
+capacity_times_dimension	2	SIZE_MAX	2	capacity_times_dimension
+m_times_two	2	1	HALF_SIZE_MAX_PLUS_ONE	m_times_two

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -151,6 +151,17 @@ target_compile_options(test_non_finite_conformance PRIVATE
 )
 target_link_options(test_non_finite_conformance PRIVATE ${COVERAGE_LINK_FLAGS})
 
+add_executable(test_hnsw_derived_size_conformance tests/test_hnsw_derived_size_conformance.cpp)
+target_link_libraries(test_hnsw_derived_size_conformance PRIVATE vanedb Catch2::Catch2WithMain)
+target_compile_definitions(test_hnsw_derived_size_conformance PRIVATE
+  VANEDB_CONFORMANCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../conformance"
+)
+target_compile_options(test_hnsw_derived_size_conformance PRIVATE
+  $<$<CXX_COMPILER_ID:MSVC>:/W4>
+  ${COVERAGE_COMPILE_FLAGS}
+)
+target_link_options(test_hnsw_derived_size_conformance PRIVATE ${COVERAGE_LINK_FLAGS})
+
 include(CTest)
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
 include(Catch)
@@ -161,6 +172,7 @@ catch_discover_tests(test_distance_strategy)
 catch_discover_tests(test_mmap_vector_store)
 catch_discover_tests(test_cosine_conformance)
 catch_discover_tests(test_non_finite_conformance)
+catch_discover_tests(test_hnsw_derived_size_conformance)
 endif() # VANEDB_BUILD_TESTS
 
 # Examples

--- a/cpp/src/core/hnsw_index.h
+++ b/cpp/src/core/hnsw_index.h
@@ -316,9 +316,9 @@ public:
     size_t cnt, ep_val;
     int max_level_val;
     detail::read_bin(f, cnt);
-    if (cnt > max_el) throw std::runtime_error("Corrupted file: count exceeds max_elements");
     const size_t live_vector_count =
         checked_persisted_product(cnt, dim, "count * dimension");
+    if (cnt > max_el) throw std::runtime_error("Corrupted file: count exceeds max_elements");
     detail::read_bin(f, ep_val);
     detail::read_bin(f, max_level_val);
     // Validate ep_ and max_level_

--- a/cpp/src/core/hnsw_index.h
+++ b/cpp/src/core/hnsw_index.h
@@ -64,6 +64,51 @@ struct HNSWSearchResult {
 };
 
 class HNSWIndex {
+  struct DerivedSizes {
+    size_t vector_count;
+    size_t m_max0;
+  };
+
+  static DerivedSizes checked_direct_sizes(size_t dimension, size_t max_elements, size_t M) {
+    if (dimension == 0) throw std::invalid_argument("Dimension must be > 0");
+    if (max_elements == 0) throw std::invalid_argument("max_elements must be > 0");
+    if (M < 2) throw std::invalid_argument("M must be >= 2");
+    if (max_elements > std::numeric_limits<size_t>::max() / dimension)
+      throw std::invalid_argument("max_elements * dimension overflow");
+    if (M > std::numeric_limits<size_t>::max() / 2)
+      throw std::invalid_argument("M * 2 overflow");
+    return {max_elements * dimension, M * 2};
+  }
+
+  static DerivedSizes checked_persisted_sizes(size_t dimension, size_t max_elements, size_t M) {
+    if (dimension == 0) throw std::runtime_error("Corrupted file: invalid dimension");
+    if (max_elements == 0) throw std::runtime_error("Corrupted file: invalid max_elements");
+    if (M < 2) throw std::runtime_error("Corrupted file: invalid M");
+    if (max_elements > std::numeric_limits<size_t>::max() / dimension)
+      throw std::runtime_error("Corrupted file: max_elements * dimension overflow");
+    if (M > std::numeric_limits<size_t>::max() / 2)
+      throw std::runtime_error("Corrupted file: M * 2 overflow");
+    return {max_elements * dimension, M * 2};
+  }
+
+  static size_t checked_persisted_product(size_t left, size_t right, const char* name) {
+    if (right != 0 && left > std::numeric_limits<size_t>::max() / right)
+      throw std::runtime_error(std::string("Corrupted file: ") + name + " overflow");
+    return left * right;
+  }
+
+  HNSWIndex(size_t dimension, DistanceMetric metric, size_t max_elements, size_t M,
+            size_t ef_construction, uint32_t seed, DerivedSizes sizes)
+      : dim_(dimension), metric_(metric), dist_(metric, dimension),
+        max_elements_(max_elements), M_(M), M_max_(M),
+        M_max0_(sizes.m_max0), ef_construction_(std::max(ef_construction, M)), ef_search_(50),
+        mult_(M > 1 ? 1.0 / std::log(static_cast<double>(M)) : 1.0), level_gen_(seed) {
+    vectors_.resize(sizes.vector_count);
+    ext_ids_.resize(max_elements);
+    levels_.resize(max_elements, 0);
+    neighbors_.resize(max_elements);
+  }
+
 public:
   static constexpr uint32_t MAGIC = 0x51565244;  // "QVRD" (legacy QuiverDB magic, retained for on-disk compat)
   static constexpr uint32_t VERSION = 3;  // v3: compact arrays, count-sized (issue #24); v2 added RNG state
@@ -72,19 +117,8 @@ public:
 
   explicit HNSWIndex(size_t dimension, DistanceMetric metric = DistanceMetric::L2,
       size_t max_elements = 100000, size_t M = 16, size_t ef_construction = 200, uint32_t seed = 42)
-      : dim_(dimension), metric_(metric), dist_(metric, dimension),
-        max_elements_(max_elements), M_(M), M_max_(M),
-        M_max0_(M * 2), ef_construction_(std::max(ef_construction, M)), ef_search_(50),
-        mult_(M > 1 ? 1.0 / std::log(static_cast<double>(M)) : 1.0), level_gen_(seed) {
-    if (dimension == 0) throw std::invalid_argument("Dimension must be > 0");
-    if (max_elements == 0) throw std::invalid_argument("max_elements must be > 0");
-    if (M < 2) throw std::invalid_argument("M must be >= 2");
-    if (max_elements > SIZE_MAX / dim_) throw std::invalid_argument("max_elements * dimension overflow");
-    vectors_.resize(max_elements * dim_);
-    ext_ids_.resize(max_elements);
-    levels_.resize(max_elements, 0);
-    neighbors_.resize(max_elements);
-  }
+      : HNSWIndex(dimension, metric, max_elements, M, ef_construction, seed,
+                  checked_direct_sizes(dimension, max_elements, M)) {}
 
   // Thread-safety: global_mtx_ is the single sync point. add() holds it
   // exclusive; readers (search/size/contains/get_vector/save) hold it shared.
@@ -274,15 +308,17 @@ public:
     detail::read_bin(f, ef_s);
     detail::read_bin(f, mult);
 
-    auto idx = std::make_unique<HNSWIndex>(dim, static_cast<DistanceMetric>(met), max_el, M, ef_con);
-    idx->ef_search_.store(ef_s);
-    idx->mult_ = mult;
+    // Validate every derived allocation size while this input is still just a
+    // file header. Passing the products into the private constructor keeps the
+    // checks ahead of allocation and avoids recomputing them unchecked.
+    const DerivedSizes sizes = checked_persisted_sizes(dim, max_el, M);
 
     size_t cnt, ep_val;
     int max_level_val;
     detail::read_bin(f, cnt);
     if (cnt > max_el) throw std::runtime_error("Corrupted file: count exceeds max_elements");
-    idx->count_.store(cnt);
+    const size_t live_vector_count =
+        checked_persisted_product(cnt, dim, "count * dimension");
     detail::read_bin(f, ep_val);
     detail::read_bin(f, max_level_val);
     // Validate ep_ and max_level_
@@ -295,17 +331,25 @@ public:
       if (ep_val != INVALID_ID)
         throw std::runtime_error("Corrupted file: non-empty entry point for empty index");
     }
+    // Array lengths are version-specific: v1/v2 stored full pre-allocated
+    // arrays, v3 stores only the `cnt` live entries.
+    const size_t stored = ver >= 3 ? cnt : max_el;
+    const size_t stored_vector_count =
+        ver >= 3 ? live_vector_count : sizes.vector_count;
+
+    auto idx = std::unique_ptr<HNSWIndex>(
+        new HNSWIndex(dim, static_cast<DistanceMetric>(met), max_el, M, ef_con, 42, sizes));
+    idx->ef_search_.store(ef_s);
+    idx->mult_ = mult;
+    idx->count_.store(cnt);
     idx->ep_.store(ep_val);
     idx->max_level_.store(max_level_val);
     detail::read_vec(f, idx->vectors_);
     detail::read_vec(f, idx->ext_ids_);
     detail::read_vec(f, idx->levels_);
-    // Array lengths are version-specific: v1/v2 stored full pre-allocated
-    // arrays, v3 stores only the `cnt` live entries.
-    const size_t stored = ver >= 3 ? cnt : max_el;
-    if (idx->vectors_.size() != stored * dim)
+    if (idx->vectors_.size() != stored_vector_count)
       throw std::runtime_error("Corrupted file: vectors length mismatch");
-    for (size_t i = 0; i < cnt * dim; ++i) {
+    for (size_t i = 0; i < live_vector_count; ++i) {
       if (!std::isfinite(idx->vectors_[i]))
         throw std::runtime_error("Corrupted file: vector values must be finite");
     }
@@ -313,7 +357,7 @@ public:
       throw std::runtime_error("Corrupted file: ext_ids/levels length mismatch");
     // Re-expand to the pre-allocated capacity layout the index expects
     // (no-ops for v1/v2).
-    idx->vectors_.resize(max_el * dim);
+    idx->vectors_.resize(sizes.vector_count);
     idx->ext_ids_.resize(max_el);
     idx->levels_.resize(max_el);
 

--- a/cpp/tests/test_hnsw_derived_size_conformance.cpp
+++ b/cpp/tests/test_hnsw_derived_size_conformance.cpp
@@ -1,0 +1,106 @@
+// Cross-engine HNSW size cases from conformance/hnsw_derived_sizes.tsv.
+#include "core/hnsw_index.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct Case {
+  std::string name;
+  size_t dimension;
+  size_t max_elements;
+  size_t M;
+  std::string overflow;
+};
+
+size_t parse_size(const std::string& value) {
+  if (value == "SIZE_MAX") return std::numeric_limits<size_t>::max();
+  if (value == "HALF_SIZE_MAX_PLUS_ONE")
+    return std::numeric_limits<size_t>::max() / 2 + 1;
+  return static_cast<size_t>(std::stoull(value));
+}
+
+std::vector<Case> cases() {
+  std::ifstream fixture(std::string(VANEDB_CONFORMANCE_DIR) + "/hnsw_derived_sizes.tsv");
+  REQUIRE(fixture.is_open());
+
+  std::vector<Case> result;
+  for (std::string line; std::getline(fixture, line);) {
+    if (line.empty() || line[0] == '#') continue;
+    std::vector<std::string> fields;
+    size_t start = 0;
+    for (size_t tab = line.find('\t');; tab = line.find('\t', start)) {
+      fields.push_back(line.substr(start, tab - start));
+      if (tab == std::string::npos) break;
+      start = tab + 1;
+    }
+    REQUIRE(fields.size() == 5);
+    result.push_back(
+        {fields[0], parse_size(fields[1]), parse_size(fields[2]), parse_size(fields[3]), fields[4]});
+  }
+  return result;
+}
+
+std::string direct_error(const Case& test_case) {
+  if (test_case.overflow == "capacity_times_dimension")
+    return "max_elements * dimension overflow";
+  if (test_case.overflow == "m_times_two") return "M * 2 overflow";
+  FAIL("Unknown overflow kind: " << test_case.overflow);
+}
+
+std::string load_error(const Case& test_case) {
+  return "Corrupted file: " + direct_error(test_case);
+}
+
+void write_overflowing_header(const std::filesystem::path& path, const Case& test_case) {
+  std::ofstream file(path, std::ios::binary);
+  REQUIRE(file.is_open());
+  vanedb::detail::write_bin(file, vanedb::HNSWIndex::MAGIC);
+  vanedb::detail::write_bin(file, vanedb::HNSWIndex::VERSION);
+  vanedb::detail::write_bin(file, test_case.dimension);
+  vanedb::detail::write_bin(file, uint32_t{0});
+  vanedb::detail::write_bin(file, test_case.max_elements);
+  vanedb::detail::write_bin(file, test_case.M);
+  vanedb::detail::write_bin(file, size_t{200});
+  vanedb::detail::write_bin(file, size_t{50});
+  vanedb::detail::write_bin(file, double{1.0});
+}
+
+}  // namespace
+
+TEST_CASE("HNSW construction rejects shared derived-size overflows",
+          "[conformance][hnsw][sizes]") {
+  const auto fixture_cases = cases();
+  REQUIRE(fixture_cases.size() == 2);
+  for (const auto& test_case : fixture_cases) {
+    CAPTURE(test_case.name);
+    REQUIRE_THROWS_AS(
+        vanedb::HNSWIndex(test_case.dimension, vanedb::DistanceMetric::L2,
+                         test_case.max_elements, test_case.M),
+        std::invalid_argument);
+    REQUIRE_THROWS_WITH(
+        vanedb::HNSWIndex(test_case.dimension, vanedb::DistanceMetric::L2,
+                         test_case.max_elements, test_case.M),
+        direct_error(test_case));
+  }
+}
+
+TEST_CASE("HNSW load rejects derived-size overflows before allocation",
+          "[conformance][hnsw][sizes][persistence]") {
+  for (const auto& test_case : cases()) {
+    CAPTURE(test_case.name);
+    const auto path = std::filesystem::path("test_hnsw_" + test_case.name + ".bin");
+    write_overflowing_header(path, test_case);
+    REQUIRE_THROWS_AS(vanedb::HNSWIndex::load(path.string()), std::runtime_error);
+    REQUIRE_THROWS_WITH(vanedb::HNSWIndex::load(path.string()), load_error(test_case));
+    std::filesystem::remove(path);
+  }
+}

--- a/cpp/tests/test_hnsw_derived_size_conformance.cpp
+++ b/cpp/tests/test_hnsw_derived_size_conformance.cpp
@@ -60,7 +60,7 @@ std::string load_error(const Case& test_case) {
   return "Corrupted file: " + direct_error(test_case);
 }
 
-void write_overflowing_header(const std::filesystem::path& path, const Case& test_case) {
+void write_header(const std::filesystem::path& path, const Case& test_case) {
   std::ofstream file(path, std::ios::binary);
   REQUIRE(file.is_open());
   vanedb::detail::write_bin(file, vanedb::HNSWIndex::MAGIC);
@@ -72,6 +72,12 @@ void write_overflowing_header(const std::filesystem::path& path, const Case& tes
   vanedb::detail::write_bin(file, size_t{200});
   vanedb::detail::write_bin(file, size_t{50});
   vanedb::detail::write_bin(file, double{1.0});
+}
+
+void append_count(const std::filesystem::path& path, size_t count) {
+  std::ofstream file(path, std::ios::binary | std::ios::app);
+  REQUIRE(file.is_open());
+  vanedb::detail::write_bin(file, count);
 }
 
 }  // namespace
@@ -98,9 +104,22 @@ TEST_CASE("HNSW load rejects derived-size overflows before allocation",
   for (const auto& test_case : cases()) {
     CAPTURE(test_case.name);
     const auto path = std::filesystem::path("test_hnsw_" + test_case.name + ".bin");
-    write_overflowing_header(path, test_case);
+    write_header(path, test_case);
     REQUIRE_THROWS_AS(vanedb::HNSWIndex::load(path.string()), std::runtime_error);
     REQUIRE_THROWS_WITH(vanedb::HNSWIndex::load(path.string()), load_error(test_case));
     std::filesystem::remove(path);
   }
+}
+
+TEST_CASE("HNSW load rejects live-vector size overflow before allocation",
+          "[conformance][hnsw][sizes][persistence]") {
+  const auto path = std::filesystem::path("test_hnsw_count_times_dimension.bin");
+  const Case safe_header{"count_times_dimension", 2, 1, 2, "count_times_dimension"};
+  write_header(path, safe_header);
+  append_count(path, std::numeric_limits<size_t>::max());
+
+  REQUIRE_THROWS_AS(vanedb::HNSWIndex::load(path.string()), std::runtime_error);
+  REQUIRE_THROWS_WITH(vanedb::HNSWIndex::load(path.string()),
+                      "Corrupted file: count * dimension overflow");
+  std::filesystem::remove(path);
 }

--- a/vanedb/tests/hnsw_derived_size_conformance.rs
+++ b/vanedb/tests/hnsw_derived_size_conformance.rs
@@ -1,0 +1,67 @@
+//! Cross-engine HNSW size cases from `conformance/hnsw_derived_sizes.tsv`.
+
+use vanedb::{DistanceMetric, HnswIndex, VaneError};
+
+#[derive(Debug)]
+struct Case<'a> {
+    name: &'a str,
+    dimension: usize,
+    max_elements: usize,
+    m: usize,
+    overflow: &'a str,
+}
+
+fn parse_size(value: &str) -> usize {
+    match value {
+        "SIZE_MAX" => usize::MAX,
+        "HALF_SIZE_MAX_PLUS_ONE" => usize::MAX / 2 + 1,
+        value => value.parse().expect("valid symbolic size"),
+    }
+}
+
+fn cases() -> Vec<Case<'static>> {
+    include_str!("../../conformance/hnsw_derived_sizes.tsv")
+        .lines()
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(|line| {
+            let fields: Vec<_> = line.split('\t').collect();
+            assert_eq!(fields.len(), 5, "valid HNSW derived-size fixture row");
+            Case {
+                name: fields[0],
+                dimension: parse_size(fields[1]),
+                max_elements: parse_size(fields[2]),
+                m: parse_size(fields[3]),
+                overflow: fields[4],
+            }
+        })
+        .collect()
+}
+
+#[test]
+fn builder_rejects_shared_derived_size_overflows() {
+    let cases = cases();
+    assert_eq!(cases.len(), 2);
+
+    for case in cases {
+        let result = HnswIndex::builder(case.dimension, DistanceMetric::L2)
+            .capacity(case.max_elements)
+            .m(case.m)
+            .build();
+        let Err(error) = result else {
+            panic!("{}: expected derived-size overflow", case.name);
+        };
+        assert!(
+            matches!(error, VaneError::InvalidParameter(_)),
+            "{}: expected InvalidParameter, got {error:?}",
+            case.name
+        );
+        let message = error.to_string();
+        match case.overflow {
+            "capacity_times_dimension" => {
+                assert!(message.contains("capacity * dim overflows usize"));
+            }
+            "m_times_two" => assert!(message.contains("M * 2 overflows usize")),
+            other => panic!("{}: unknown overflow kind {other}", case.name),
+        }
+    }
+}

--- a/vanedb/tests/hnsw_tests.rs
+++ b/vanedb/tests/hnsw_tests.rs
@@ -395,42 +395,8 @@ fn hnsw_add_batch_onto_nonempty_matches_serial_add() {
     }
 }
 
-// --- #43: derived sizes must be checked, not left to overflow/abort ---
-
-/// `capacity * dim` overflowed `usize` and panicked before the fallible
-/// builder could return an error.
-#[test]
-fn builder_rejects_capacity_times_dim_overflow() {
-    let result = vanedb::HnswIndex::builder(2, vanedb::DistanceMetric::L2)
-        .capacity(usize::MAX)
-        .build();
-    let Err(err) = result else {
-        panic!("expected the builder to reject these sizes");
-    };
-    assert!(
-        matches!(err, vanedb::VaneError::InvalidParameter(_)),
-        "expected InvalidParameter, got {err:?}"
-    );
-}
-
-/// `m * 2` (the layer-0 link budget) had the same problem.
-#[test]
-fn builder_rejects_m_doubling_overflow() {
-    let result = vanedb::HnswIndex::builder(2, vanedb::DistanceMetric::L2)
-        .capacity(1)
-        .m(usize::MAX / 2 + 1)
-        .build();
-    let Err(err) = result else {
-        panic!("expected the builder to reject these sizes");
-    };
-    assert!(
-        matches!(err, vanedb::VaneError::InvalidParameter(_)),
-        "expected InvalidParameter, got {err:?}"
-    );
-}
-
-/// Sizes that fit in `usize` but cannot be allocated must also return an error
-/// rather than aborting the process through the allocator.
+// Unlike integer overflow, allocation failure is Rust-engine-specific: its
+// fallible builder promises to translate reserve failure into VaneError.
 #[test]
 fn builder_rejects_unallocatable_capacity() {
     let result = vanedb::HnswIndex::builder(1024, vanedb::DistanceMetric::L2)


### PR DESCRIPTION
## Summary

- reject overflow in the C++ HNSW level-0 reverse-link capacity (`M * 2`) for both direct construction and persisted-file loading
- validate and reuse all derived HNSW sizes before allocation or payload reads
- report invalid persisted size metadata consistently as `std::runtime_error("Corrupted file: ...")`
- add a shared, native-width conformance fixture consumed by both the Rust and C++ test suites

## Audit correction for #56

The issue's reported `max_elements * dimension` wraparound/OOB path was already guarded by the C++ constructor and could not be reproduced. The pre-fix behavior was:

```text
capacity_times_dim=invalid_argument:max_elements * dimension overflow
m_times_two=accepted
loader_capacity_times_dim=invalid_argument:max_elements * dimension overflow
```

The audit did uncover a related gap: `M * 2` could wrap in both direct construction and loading. After this change:

```text
capacity_times_dim=invalid_argument:max_elements * dimension overflow
m_times_two=rejected:M * 2 overflow
loader_capacity_times_dim=runtime_error:Corrupted file: max_elements * dimension overflow
```

The exact safe boundary (`M == SIZE_MAX / 2`) remains accepted; the first overflowing value is rejected. The C API returns `NULL` rather than allowing either invalid configuration through.

## Compatibility and scope

- no persistence-format, magic, version, ABI, or valid-file behavior changes
- a valid C++ v3 file produced before and after the patch was byte-identical (7,044 bytes)
- legacy v1/v2 and current v3 round trips still pass
- resource exhaustion from very large but non-overflowing allocations remains outside this patch and is already documented as out of scope in `cpp/SECURITY.md`

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude vanedb-py --all-targets --features mmap --locked -- -D warnings`
- `cargo test --workspace --exclude vanedb-py --features mmap --locked` (134 tests)
- `cargo fmt --manifest-path bench/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path bench/Cargo.toml --all-targets --locked -- -D warnings`
- `cargo test --manifest-path bench/Cargo.toml --locked`
- CMake Release build and `ctest --test-dir cpp/build --output-on-failure` (66/66)
- independent acceptance run with ASan+UBSan (65/65)
- independent direct-construction, malformed-loader, C API, safe-boundary, and valid-file byte-identity probes

Closes #56
