### PR TITLE
fix(persistence): require id_map to be a bijection over live slots

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -36,6 +36,26 @@ itself. Finite inputs therefore never produce a non-finite cosine distance.
 by `vanedb/tests/cosine_conformance.rs` and
 `cpp/tests/test_cosine_conformance.cpp`.
 
+## Persisted identity
+
+A loaded HNSW index must carry an exact one-to-one relationship between live
+slots and external ids:
+
+```
+id_map.len() == count      and      id_map[ext_ids[i]] == i   for every live i
+```
+
+Those two conditions together force a bijection, so one pass rejects
+key/value mismatches, duplicate external ids, duplicated internal ids, missing
+entries and out-of-range values. Checking only the length and the value range
+accepted files in which an external id resolved to a different slot — reads
+returned well-formed data under the wrong identity, which is worse than a
+refusal to load.
+
+`hnsw_id_map_consistency.tsv` pins these cases for both engines and is consumed
+by `vanedb/tests/hnsw_id_map_conformance.rs` and
+`cpp/tests/test_hnsw_id_map_conformance.cpp`.
+
 ## Universal persistence
 
 The first public persistence format is **VNDB v1**. Existing Rust and C++

--- a/conformance/hnsw_id_map_consistency.tsv
+++ b/conformance/hnsw_id_map_consistency.tsv
@@ -1,0 +1,19 @@
+# Shared HNSW id_map integrity cases. A persisted index must carry an exact
+# one-to-one relationship between live slots and external ids:
+#
+#   id_map.len() == count   and   id_map[ext_ids[i]] == i   for every live i
+#
+# Checking only length and value range accepted files where an external id
+# resolved to another slot's vector, so reads returned the right bytes under
+# the wrong identity.
+#
+# `ext_ids` and `id_map` describe the `count` live slots. `id_map` entries are
+# `key:value` pairs; an empty list is written as `-`.
+# name	count	ext_ids	id_map	expect
+consistent	2	10,20	10:0,20:1	accept
+key_mismatch	1	10	20:0	reject
+duplicate_external_id	2	10,10	10:0,99:1	reject
+duplicated_internal_id	2	10,20	10:0,20:0	reject
+missing_entry	2	10,20	10:0	reject
+out_of_range_internal	1	10	10:5	reject
+empty_map_for_live_slots	1	10	-	reject

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -120,6 +120,17 @@ target_compile_options(test_distance_strategy PRIVATE
 )
 target_link_options(test_distance_strategy PRIVATE ${COVERAGE_LINK_FLAGS})
 
+add_executable(test_hnsw_id_map_conformance tests/test_hnsw_id_map_conformance.cpp)
+target_link_libraries(test_hnsw_id_map_conformance PRIVATE vanedb Catch2::Catch2WithMain)
+target_compile_definitions(test_hnsw_id_map_conformance PRIVATE
+  VANEDB_CONFORMANCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../conformance"
+)
+target_compile_options(test_hnsw_id_map_conformance PRIVATE
+  $<$<CXX_COMPILER_ID:MSVC>:/W4>
+  ${COVERAGE_COMPILE_FLAGS}
+)
+target_link_options(test_hnsw_id_map_conformance PRIVATE ${COVERAGE_LINK_FLAGS})
+
 add_executable(test_cosine_conformance tests/test_cosine_conformance.cpp)
 target_link_libraries(test_cosine_conformance PRIVATE vanedb Catch2::Catch2WithMain)
 target_compile_definitions(test_cosine_conformance PRIVATE
@@ -171,6 +182,7 @@ catch_discover_tests(test_hnsw_index)
 catch_discover_tests(test_distance_strategy)
 catch_discover_tests(test_mmap_vector_store)
 catch_discover_tests(test_cosine_conformance)
+catch_discover_tests(test_hnsw_id_map_conformance)
 catch_discover_tests(test_non_finite_conformance)
 catch_discover_tests(test_hnsw_derived_size_conformance)
 endif() # VANEDB_BUILD_TESTS

--- a/cpp/src/core/hnsw_index.h
+++ b/cpp/src/core/hnsw_index.h
@@ -372,6 +372,19 @@ public:
       if (v >= cnt) throw std::runtime_error("Corrupted file: invalid internal index in id_map");
       idx->id_map_[k] = v;
     }
+    // Every live slot must be reachable by its own external id. Combined with
+    // a size equal to the live count this forces a bijection, rejecting
+    // key/value mismatches, duplicate external ids, duplicated internal ids,
+    // and missing entries. Checking only size <= count and value range
+    // accepted a file whose external id resolved to another slot's vector
+    // (vanedb#42 / vanedb-cpp#38).
+    if (idx->id_map_.size() != cnt)
+      throw std::runtime_error("Corrupted file: id_map size does not match count");
+    for (size_t i = 0; i < cnt; ++i) {
+      auto entry = idx->id_map_.find(idx->ext_ids_[i]);
+      if (entry == idx->id_map_.end() || entry->second != i)
+        throw std::runtime_error("Corrupted file: id_map is not consistent with ext_ids");
+    }
 
     size_t nsz;
     detail::read_bin(f, nsz);

--- a/cpp/tests/test_hnsw_id_map_conformance.cpp
+++ b/cpp/tests/test_hnsw_id_map_conformance.cpp
@@ -1,0 +1,157 @@
+// Cross-engine HNSW id_map cases from conformance/hnsw_id_map_consistency.tsv.
+//
+// The loader accepted an id_map whose size was <= count and whose values were
+// in range, without checking that each key mapped back to its own slot. A file
+// could therefore resolve an external id to another slot's vector — the right
+// bytes under the wrong identity (vanedb#42 / vanedb-cpp#38).
+
+#include "core/hnsw_index.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct Case {
+  std::string name;
+  size_t count;
+  std::vector<uint64_t> ext_ids;
+  std::vector<std::pair<uint64_t, size_t>> id_map;
+  bool accept;
+};
+
+std::vector<std::string> split(const std::string& line, char sep) {
+  std::vector<std::string> out;
+  size_t start = 0;
+  for (;;) {
+    const size_t at = line.find(sep, start);
+    out.push_back(line.substr(start, at - start));
+    if (at == std::string::npos) return out;
+    start = at + 1;
+  }
+}
+
+std::vector<Case> cases() {
+  std::ifstream fixture(std::string(VANEDB_CONFORMANCE_DIR) + "/hnsw_id_map_consistency.tsv");
+  REQUIRE(fixture.is_open());
+
+  std::vector<Case> result;
+  for (std::string line; std::getline(fixture, line);) {
+    if (line.empty() || line[0] == '#') continue;
+    const auto fields = split(line, '\t');
+    REQUIRE(fields.size() == 5);
+
+    Case test_case;
+    test_case.name = fields[0];
+    test_case.count = static_cast<size_t>(std::stoull(fields[1]));
+    for (const auto& id : split(fields[2], ',')) test_case.ext_ids.push_back(std::stoull(id));
+    if (fields[3] != "-") {
+      for (const auto& pair : split(fields[3], ',')) {
+        const auto kv = split(pair, ':');
+        REQUIRE(kv.size() == 2);
+        test_case.id_map.emplace_back(std::stoull(kv[0]), static_cast<size_t>(std::stoull(kv[1])));
+      }
+    }
+    test_case.accept = fields[4] == "accept";
+    result.push_back(std::move(test_case));
+  }
+  REQUIRE(result.size() >= 6);
+  return result;
+}
+
+// Byte offset of the id_map block in a v3 file, derived from the field order
+// in save(): three uint32, seven size_t, one double, one int, then the three
+// length-prefixed arrays.
+size_t id_map_offset(size_t count, size_t dim) {
+  const size_t header = 3 * sizeof(uint32_t) + 7 * sizeof(size_t) + sizeof(double) + sizeof(int);
+  const size_t vectors = sizeof(size_t) + count * dim * sizeof(float);
+  const size_t ext_ids = sizeof(size_t) + count * sizeof(uint64_t);
+  const size_t levels = sizeof(size_t) + count * sizeof(int);
+  return header + vectors + ext_ids + levels;
+}
+
+template <typename T>
+void append(std::vector<char>& out, const T& value) {
+  const char* raw = reinterpret_cast<const char*>(&value);
+  out.insert(out.end(), raw, raw + sizeof(T));
+}
+
+std::vector<char> read_all(const std::filesystem::path& path) {
+  std::ifstream in(path, std::ios::binary);
+  REQUIRE(in.is_open());
+  return {std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>()};
+}
+
+/// Save a genuine index, then replace only its id_map block with the crafted
+/// one. Everything else stays exactly what the real writer produced.
+std::filesystem::path craft(const std::filesystem::path& dir, const Case& test_case, size_t dim) {
+  const auto valid = dir / (test_case.name + "-valid.idx");
+  {
+    vanedb::HNSWIndex index(dim, vanedb::DistanceMetric::L2, std::max<size_t>(test_case.count, 1), 2, 10);
+    for (size_t i = 0; i < test_case.count; ++i) {
+      const std::vector<float> vector(dim, static_cast<float>(i));
+      // Placeholder ids only: the crafted ext_ids are written over these
+      // below, and a fixture case may deliberately repeat an external id.
+      index.add(1000 + i, vector.data());
+    }
+    index.save(valid.string());
+  }
+
+  auto bytes = read_all(valid);
+  const size_t offset = id_map_offset(test_case.count, dim);
+  REQUIRE(bytes.size() > offset + sizeof(size_t));
+
+  size_t existing = 0;
+  std::memcpy(&existing, bytes.data() + offset, sizeof(size_t));
+  const size_t block = sizeof(size_t) + existing * (sizeof(uint64_t) + sizeof(size_t));
+  REQUIRE(bytes.size() >= offset + block);
+
+  std::vector<char> crafted(bytes.begin(), bytes.begin() + static_cast<long>(offset));
+  append(crafted, test_case.id_map.size());
+  for (const auto& [key, value] : test_case.id_map) {
+    append(crafted, key);
+    append(crafted, value);
+  }
+  // Overwrite the live ext_ids so the crafted map is evaluated against the
+  // identifiers the fixture names.
+  const size_t ext_ids_at = 3 * sizeof(uint32_t) + 7 * sizeof(size_t) + sizeof(double) + sizeof(int)
+                            + sizeof(size_t) + test_case.count * dim * sizeof(float) + sizeof(size_t);
+  for (size_t i = 0; i < test_case.count; ++i) {
+    std::memcpy(crafted.data() + ext_ids_at + i * sizeof(uint64_t), &test_case.ext_ids[i],
+                sizeof(uint64_t));
+  }
+  crafted.insert(crafted.end(), bytes.begin() + static_cast<long>(offset + block), bytes.end());
+
+  const auto path = dir / (test_case.name + ".idx");
+  std::ofstream out(path, std::ios::binary);
+  out.write(crafted.data(), static_cast<long>(crafted.size()));
+  out.close();
+  return path;
+}
+
+}  // namespace
+
+TEST_CASE("HNSW loader enforces the shared id_map contract", "[conformance][persistence]") {
+  const auto dir = std::filesystem::temp_directory_path() / "vanedb-id-map-conformance";
+  std::filesystem::remove_all(dir);
+  std::filesystem::create_directories(dir);
+  constexpr size_t DIM = 2;
+
+  for (const auto& test_case : cases()) {
+    const auto path = craft(dir, test_case, DIM);
+    INFO("case=" << test_case.name);
+    if (test_case.accept) {
+      REQUIRE_NOTHROW(vanedb::HNSWIndex::load(path.string()));
+    } else {
+      REQUIRE_THROWS_AS(vanedb::HNSWIndex::load(path.string()), std::runtime_error);
+    }
+  }
+
+  std::filesystem::remove_all(dir);
+}

--- a/vanedb/src/hnsw/persistence.rs
+++ b/vanedb/src/hnsw/persistence.rs
@@ -192,6 +192,27 @@ impl HnswIndex {
                 data.count
             )));
         }
+        // Every live slot must be reachable by its own external id. Combined
+        // with the length check above this forces a bijection, which rejects
+        // key/value mismatches, duplicate external ids, duplicated internal
+        // ids, and missing entries in one pass. The previous length-and-range
+        // check accepted `ext_ids[0] = 10` alongside `id_map = {20: 0}`, so a
+        // lookup of 20 returned slot 0's vector under the wrong identity (#42).
+        for (index, &ext_id) in data.ext_ids.iter().take(data.count).enumerate() {
+            match data.id_map.get(&ext_id) {
+                Some(&mapped) if mapped == index => {}
+                Some(&mapped) => {
+                    return Err(VaneError::Io(format!(
+                        "corrupted file: id_map[{ext_id}] is {mapped}, expected {index}"
+                    )))
+                }
+                None => {
+                    return Err(VaneError::Io(format!(
+                        "corrupted file: id_map has no entry for external id {ext_id}"
+                    )))
+                }
+            }
+        }
         for &iid in data.id_map.values() {
             if iid >= data.count {
                 return Err(VaneError::Io(

--- a/vanedb/tests/hnsw_id_map_conformance.rs
+++ b/vanedb/tests/hnsw_id_map_conformance.rs
@@ -1,0 +1,154 @@
+//! Cross-engine HNSW id_map cases from `conformance/hnsw_id_map_consistency.tsv`.
+//!
+//! The loader validated only `id_map.len() == count` and that each internal
+//! index was in range, so a file could map an external id onto another slot.
+//! Reads then returned the right bytes under the wrong identity (#42).
+
+use std::collections::HashMap;
+use std::fs;
+use std::io::Write;
+
+use vanedb::HnswIndex;
+
+const HNSW_MAGIC: u32 = u32::from_le_bytes(*b"HNSW");
+const HNSW_VERSION: u32 = 2;
+const DIM: usize = 2;
+
+/// Field-order mirror of the private `HnswData` in `src/hnsw/persistence.rs`.
+/// bincode encodes by field order, so this serializes identically.
+#[derive(serde::Serialize)]
+struct HnswDataMirror {
+    dim: usize,
+    metric: u32,
+    max_elements: usize,
+    m: usize,
+    m_max: usize,
+    m_max0: usize,
+    ef_construction: usize,
+    ef_search: usize,
+    mult: f64,
+    seed: u64,
+    count: usize,
+    entry_point: Option<usize>,
+    max_level: i32,
+    vectors: Vec<f32>,
+    ext_ids: Vec<u64>,
+    levels: Vec<i32>,
+    neighbors: Vec<Vec<Vec<usize>>>,
+    id_map: HashMap<u64, usize>,
+}
+
+struct Case {
+    name: String,
+    count: usize,
+    ext_ids: Vec<u64>,
+    id_map: HashMap<u64, usize>,
+    accept: bool,
+}
+
+fn cases() -> Vec<Case> {
+    include_str!("../../conformance/hnsw_id_map_consistency.tsv")
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(|line| {
+            let f: Vec<&str> = line.split('\t').collect();
+            assert_eq!(f.len(), 5, "valid id_map fixture row: {line}");
+            let id_map = if f[3] == "-" {
+                HashMap::new()
+            } else {
+                f[3].split(',')
+                    .map(|pair| {
+                        let (k, v) = pair.split_once(':').expect("key:value pair");
+                        (k.parse().unwrap(), v.parse().unwrap())
+                    })
+                    .collect()
+            };
+            Case {
+                name: f[0].to_string(),
+                count: f[1].parse().unwrap(),
+                ext_ids: f[2].split(',').map(|v| v.parse().unwrap()).collect(),
+                id_map,
+                accept: match f[4] {
+                    "accept" => true,
+                    "reject" => false,
+                    other => panic!("unknown expectation: {other}"),
+                },
+            }
+        })
+        .collect()
+}
+
+fn payload(case: &Case) -> HnswDataMirror {
+    HnswDataMirror {
+        dim: DIM,
+        metric: 0,
+        max_elements: case.count.max(1),
+        m: 2,
+        m_max: 2,
+        m_max0: 4,
+        ef_construction: 10,
+        ef_search: 10,
+        mult: 1.0,
+        seed: 7,
+        count: case.count,
+        entry_point: Some(0),
+        max_level: 0,
+        // Distinguishable per slot, so a mis-mapped id returns detectably
+        // wrong data rather than the same bytes.
+        vectors: (0..case.count).flat_map(|i| [i as f32, 0.0]).collect(),
+        ext_ids: case.ext_ids.clone(),
+        levels: vec![0; case.count],
+        neighbors: vec![vec![vec![]]; case.count],
+        id_map: case.id_map.clone(),
+    }
+}
+
+fn write_case(dir: &std::path::Path, case: &Case) -> std::path::PathBuf {
+    let mut bytes = HNSW_MAGIC.to_le_bytes().to_vec();
+    bytes.extend_from_slice(&HNSW_VERSION.to_le_bytes());
+    bytes.extend_from_slice(
+        &bincode::serde::encode_to_vec(payload(case), bincode::config::legacy()).unwrap(),
+    );
+    let path = dir.join(format!("{}.idx", case.name));
+    let mut f = fs::File::create(&path).unwrap();
+    f.write_all(&bytes).unwrap();
+    path
+}
+
+#[test]
+fn loader_enforces_the_shared_id_map_contract() {
+    let dir = std::env::temp_dir().join(format!("vanedb-issue-42-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+
+    let all = cases();
+    assert!(all.len() >= 6, "fixture should cover every invalid shape");
+
+    for case in &all {
+        let path = write_case(&dir, case);
+        let result = HnswIndex::load(&path);
+        if case.accept {
+            let index =
+                result.unwrap_or_else(|e| panic!("{}: expected load to succeed: {e}", case.name));
+            assert_eq!(index.size(), case.count, "{}", case.name);
+            for (i, &ext_id) in case.ext_ids.iter().enumerate() {
+                assert!(index.contains(ext_id), "{}: {ext_id} not found", case.name);
+                assert_eq!(
+                    index.get_vector(ext_id).unwrap(),
+                    vec![i as f32, 0.0],
+                    "{}: external id {ext_id} resolved to the wrong slot",
+                    case.name
+                );
+            }
+        } else {
+            assert!(
+                result.is_err(),
+                "{}: expected the loader to reject this file",
+                case.name
+            );
+        }
+    }
+
+    let _ = fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## Summary

Closes #42, the last of the three paired correctness bugs (#40 and #41 landed in #55 and #53).

The HNSW loader checked only that `id_map` had one entry per live slot and that every internal index was in range. It never checked that a key mapped back to *its own* slot, so this file loaded cleanly:

```
count   = 1
ext_ids = [10]
id_map  = { 20: 0 }
```

`get_vector(20)` then returned slot 0's vector. That is well-formed data under the wrong identity — worse than a refusal to load, because nothing downstream can detect it.

## Fix

Both loaders now require `id_map[ext_ids[i]] == i` for every live slot. Combined with the size check that forces a bijection, so one pass rejects key/value mismatches, duplicate external ids, duplicated internal ids, missing entries, and out-of-range values.

**The C++ loader was additionally weaker than the Rust one**: it accepted `id_map.size() < count` where Rust required equality. It now requires equality too — worth noting as exactly the kind of silent divergence the shared fixtures exist to catch.

No persistence format change; valid v1/v2/v3 files load as before.

## Conformance

`conformance/hnsw_id_map_consistency.tsv` pins seven shapes — one valid, six invalid — consumed by `vanedb/tests/hnsw_id_map_conformance.rs` and `cpp/tests/test_hnsw_id_map_conformance.cpp`.

The two engines craft files differently, deliberately. Rust builds payloads through the field-order mirror already used by the corruption suite. C++ **saves a genuine index and splices in only the crafted `id_map` block**, so every other byte is what the real writer produced rather than a hand-rolled approximation of it.

The accept case asserts identity rather than mere loading: each slot's vector is distinct, so a mis-mapped id returns detectably wrong data. An earlier version of that assertion used `search()` and failed against a deliberately disconnected test graph — `contains` and `get_vector` test the thing the bug was actually about.

## Validation

Both sides confirmed failing before the fix:

- Rust: `key_mismatch: expected the loader to reject this file`
- C++: 1 of 26 assertions failed with the fix reverted

After:

- `cargo fmt --all -- --check` — pass
- `cargo clippy --workspace --exclude vanedb-py --all-targets --features mmap --locked -- -D warnings` — pass
- `cargo test --workspace --exclude vanedb-py --features mmap --locked` — 18 suites pass
- CMake Release + `ctest` — **66/66**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H
