### PR TITLE
fix(bench): exclude teardown from hnsw_build and refresh the snapshot

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -24,9 +24,8 @@ local `vanedb-capi/` crate, so one commit identifies both engines.
 
 ## Headline snapshot (Apple M4 Pro, 2026-09, monorepo 47f6195)
 
-Criterion medians of three passes on an otherwise idle machine. Inter-pass
-spread was 0.3–6.6%, and under 3% for every row except `l2_sq` at 768d — treat
-differences smaller than that as noise.
+Criterion medians of three passes on an idle machine. Inter-pass spread
+0.3–6.6%; treat smaller differences as noise.
 
 | Op (n=10k, dim=128, L2) | C++ | Rust | rs/cpp |
 |---|---:|---:|---:|
@@ -38,49 +37,25 @@ differences smaller than that as noise.
 | store_search (k=10, n=1k) | 8.10 µs | 8.67 µs | 1.07 |
 | store_search (k=10, n=10k) | 79.0 µs | 92.5 µs | 1.17 |
 
-HNSW recall@10 (100 queries, ef=50): C++ 0.689, Rust 0.700 — quality-comparable.
+HNSW recall@10 (100 queries, ef=50): C++ 0.689, Rust 0.700.
 
-Two corrections make this table not comparable to the 2026-07 snapshot it
-replaces:
-
-1. **The C++ engine was built without `-DNDEBUG`.** A custom
-   `CMAKE_CXX_FLAGS_RELEASE` replaced CMake's defaults instead of extending
-   them, leaving assertions live in the distance kernels. Restoring the
-   standard flags moved hnsw_search by 12.6% and the scan paths by 4–5% — the
-   isolated kernel benchmark was unaffected, so the cost was inlining rather
-   than the branch itself.
-2. **`hnsw_build` used to include teardown.** `hnsw_free` sat inside the
-   measured closure, so every build figure carried the cost of destroying a
-   10k-node graph. It is now excluded, which is why the ratio moved from 0.94
-   to 1.08: teardown was the more expensive half for C++, and removing it from
-   both sides changed which engine leads.
-
-Rust leads on the raw distance kernels and trails on everything that scans:
-17% at n=10k for `store_search` and 22% for `mmap_search` (see vanedb#32).
-`hnsw_search` sits at 1.13 despite the identical kernels, which points at the
-same selection overhead rather than at distance computation.
+Rust leads the distance kernels and trails every path that scans.
+`hnsw_search` at 1.13 with identical kernels points at selection overhead
+rather than distance computation (vanedb#32).
 
 ## Measurement policy
 
-- Both engines run in one process through their C ABIs. Stores and indexes
-  are built interleaved and stay resident together during search benches —
-  the same policy in every criterion suite and the report bin, since
-  residency and construction order are part of what's being compared.
-- The report bin samples the two engines interleaved (cpp, rs, cpp, rs…)
-  after a joint warmup. Block-ordered one-shot timing measured C++ first on
-  colder machine state and flipped the store_search verdict relative to
-  criterion; paired sampling removed the contradiction (2026-08).
-- Criterion is the canonical source for perf claims. The report bin is a
-  quick digestible snapshot and covers only l2_sq, store_search, and
-  hnsw_search + recall; hnsw_build and mmap_search are criterion-only.
-- Every setup return code and handle is asserted, so a failed engine fails
-  the run instead of benchmarking a null handle as infinitely fast.
-- On x86_64 the harness compiles the C++ capi with `-mavx2 -mfma`:
-  vanedb-cpp's own CMake gives those flags to its perf targets but not to
-  `vanedb_cpp_capi`, and C++ gates SIMD at compile time while Rust detects
-  it at runtime — without the flags the harness would compare Rust-AVX2
-  against C++-scalar. The published numbers above are Apple Silicon, where
-  NEON is unconditional on both sides.
+- Both engines run in one process through their C ABIs, built interleaved and
+  resident together during search benches.
+- The report bin samples the engines interleaved (cpp, rs, cpp, rs…) after a
+  joint warmup.
+- Criterion is canonical. The report bin covers l2_sq, store_search, and
+  hnsw_search + recall only; hnsw_build and mmap_search are criterion-only.
+- Every setup return code and handle is asserted, so a failed engine fails the
+  run instead of timing a null handle as infinitely fast.
+- On x86_64 the harness compiles the C++ capi with `-mavx2 -mfma`. C++ gates
+  SIMD at compile time while Rust detects it at runtime, so without those flags
+  the harness would compare Rust-AVX2 against C++-scalar.
 
 ## License
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -22,30 +22,43 @@ Run these commands from the repository root. They require a C++20 toolchain
 and CMake. `build.rs` compiles the local `cpp/` C API, while Cargo links the
 local `vanedb-capi/` crate, so one commit identifies both engines.
 
-## Headline snapshot (Apple Silicon M-series, 2026-07)
+## Headline snapshot (Apple M4 Pro, 2026-09, monorepo 47f6195)
 
-Three rounds of measurement drove three rounds of fixes:
-
-1. **First run** (pre-fix): Rust trailed 1.5× on store/mmap search and 2.5× on
-   HNSW build → vanedb#22 (top-k selection), #23 (build parity), #24 (mmap top-k).
-2. **Second run**: Rust led every op → exposed both engines' distance kernels as
-   latency-bound → vanedb-cpp#31 + vanedb#27 (multi-accumulator SIMD unrolling,
-   kernels now identical at ~37 ns/768d).
-3. **Final run** (vanedb@89f5144, vanedb-cpp@f02bb27): near-parity, honors split —
-   and both engines 30–50% faster than round one on every hot path.
+Criterion medians of three passes on an otherwise idle machine. Inter-pass
+spread was 0.3–6.6%, and under 3% for every row except `l2_sq` at 768d — treat
+differences smaller than that as noise.
 
 | Op (n=10k, dim=128, L2) | C++ | Rust | rs/cpp |
 |---|---:|---:|---:|
-| l2_sq (768d) | 37.1 ns | 37.2 ns | 1.00 |
-| store_search (k=10) | 82.3 µs | 93.4 µs | 1.14 |
-| hnsw_build (M=16, efC=200) | 984 ms | 929 ms | 0.94 |
-| hnsw_search (ef=50) | 24.5 µs | 21.4 µs | 0.87 |
-| mmap_search (k=10) | 81.8 µs | 95.3 µs | 1.17 |
+| l2_sq (128d) | 16.9 ns | 16.5 ns | 0.98 |
+| l2_sq (768d) | 51.3 ns | 48.4 ns | 0.94 |
+| hnsw_build (M=16, efC=200) | 938 ms | 1013 ms | 1.08 |
+| hnsw_search (ef=50) | 18.8 µs | 21.3 µs | 1.13 |
+| mmap_search (k=10) | 78.4 µs | 95.5 µs | 1.22 |
+| store_search (k=10, n=1k) | 8.10 µs | 8.67 µs | 1.07 |
+| store_search (k=10, n=10k) | 79.0 µs | 92.5 µs | 1.17 |
 
 HNSW recall@10 (100 queries, ef=50): C++ 0.689, Rust 0.700 — quality-comparable.
 
-Re-measured 2026-08 under the unified measurement policy below: ratios
-unchanged (store_search 1.14, hnsw_search 0.87).
+Two corrections make this table not comparable to the 2026-07 snapshot it
+replaces:
+
+1. **The C++ engine was built without `-DNDEBUG`.** A custom
+   `CMAKE_CXX_FLAGS_RELEASE` replaced CMake's defaults instead of extending
+   them, leaving assertions live in the distance kernels. Restoring the
+   standard flags moved hnsw_search by 12.6% and the scan paths by 4–5% — the
+   isolated kernel benchmark was unaffected, so the cost was inlining rather
+   than the branch itself.
+2. **`hnsw_build` used to include teardown.** `hnsw_free` sat inside the
+   measured closure, so every build figure carried the cost of destroying a
+   10k-node graph. It is now excluded, which is why the ratio moved from 0.94
+   to 1.08: teardown was the more expensive half for C++, and removing it from
+   both sides changed which engine leads.
+
+Rust leads on the raw distance kernels and trails on everything that scans:
+17% at n=10k for `store_search` and 22% for `mmap_search` (see vanedb#32).
+`hnsw_search` sits at 1.13 despite the identical kernels, which points at the
+same selection overhead rather than at distance computation.
 
 ## Measurement policy
 

--- a/bench/RESULTS.md
+++ b/bench/RESULTS.md
@@ -13,8 +13,5 @@ Covers l2_sq, store_search, and hnsw_search + recall@10 only; hnsw_build and mma
 
 HNSW recall@10: C++ 0.689, Rust 0.700
 
-Criterion is canonical and disagrees with this snapshot on l2_sq (0.98 there
-against 1.26 here). The report bin times l2_sq in batches of 1000 calls, which
-inlines differently from criterion's per-call harness; the batched figure is a
-throughput proxy, not a per-call latency. Prefer the README table for any
-comparison that matters.
+Criterion is canonical; see the README table. This bin times l2_sq in batches
+of 1000 calls, which inlines differently from criterion's per-call harness.

--- a/bench/RESULTS.md
+++ b/bench/RESULTS.md
@@ -1,18 +1,20 @@
 # VaneDB Benchmark Results
 
-> **Historical pre-monorepo snapshot.** The two revisions below identify the
-> former separate repositories. New reports identify both engines with one
-> `VANEDB_MONOREPO_REV` commit.
-
-Engines: vanedb-cpp f02bb27 (CMake Release), vanedb (Rust) 89f5144.
+Engines: vanedb-cpp (CMake Release) and vanedb (Rust), monorepo 47f6195.
 Workload: dim=128, n=10000, k=10, L2. Latencies are medians of 501 interleaved paired samples (one query) after a joint warmup; recall is averaged over 100 queries. Both engines' data stays resident in one process (interleaved construction).
 
 Covers l2_sq, store_search, and hnsw_search + recall@10 only; hnsw_build and mmap_search live in the criterion suite (see README).
 
 | Op | C++ (ns) | Rust (ns) | ratio (rs/cpp) |
 |---|---:|---:|---:|
-| l2_sq | 14 | 17 | 1.17 |
-| store_search | 81917 | 88500 | 1.08 |
-| hnsw_search | 24959 | 21416 | 0.86 |
+| l2_sq | 13 | 17 | 1.26 |
+| store_search | 81833 | 99750 | 1.22 |
+| hnsw_search | 20542 | 22458 | 1.09 |
 
 HNSW recall@10: C++ 0.689, Rust 0.700
+
+Criterion is canonical and disagrees with this snapshot on l2_sq (0.98 there
+against 1.26 here). The report bin times l2_sq in batches of 1000 calls, which
+inlines differently from criterion's per-call harness; the batched figure is a
+throughput proxy, not a per-call latency. Prefer the README table for any
+comparison that matters.

--- a/bench/benches/hnsw.rs
+++ b/bench/benches/hnsw.rs
@@ -1,5 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::hint::black_box;
+use std::time::{Duration, Instant};
 use vanedb_bench::{ffi, workloads};
 
 const DIM: usize = 128;
@@ -18,30 +19,52 @@ fn bench_hnsw(c: &mut Criterion) {
     // Asserts inside the timed loop are symmetric across engines and cost
     // nanoseconds against ~0.1 ms inserts; they turn a failed engine into a
     // loud failure instead of an infinitely fast one.
-    build.bench_function("cpp", |bn| unsafe {
-        bn.iter(|| {
-            let h = ffi::vanedb_cpp_hnsw_new(DIM, 0, N, M, EFC, SEED);
-            assert!(!h.is_null());
-            for i in 0..N {
-                assert_eq!(
-                    ffi::vanedb_cpp_hnsw_add(h, w.ids[i], w.vectors[i * DIM..].as_ptr()),
-                    0
-                );
+    build.bench_function("cpp", |bn| {
+        // Only construction is timed. `hnsw_free` used to sit inside the
+        // measured closure, so every reported build time included teardown of
+        // a 10k-node graph (#62).
+        bn.iter_custom(|iterations| {
+            let mut elapsed = Duration::ZERO;
+            for _ in 0..iterations {
+                let start = Instant::now();
+                let h = unsafe { ffi::vanedb_cpp_hnsw_new(DIM, 0, N, M, EFC, SEED) };
+                assert!(!h.is_null());
+                for i in 0..N {
+                    assert_eq!(
+                        unsafe {
+                            ffi::vanedb_cpp_hnsw_add(h, w.ids[i], w.vectors[i * DIM..].as_ptr())
+                        },
+                        0
+                    );
+                }
+                elapsed += start.elapsed();
+                unsafe { ffi::vanedb_cpp_hnsw_free(black_box(h)) };
             }
-            ffi::vanedb_cpp_hnsw_free(black_box(h));
+            elapsed
         });
     });
-    build.bench_function("rs", |bn| unsafe {
-        bn.iter(|| {
-            let h = ffi::vanedb_rs_hnsw_new(DIM, 0, N, M, EFC, SEED);
-            assert!(!h.is_null());
-            for i in 0..N {
-                assert_eq!(
-                    ffi::vanedb_rs_hnsw_add(h, w.ids[i], w.vectors[i * DIM..].as_ptr()),
-                    0
-                );
+    build.bench_function("rs", |bn| {
+        // Only construction is timed. `hnsw_free` used to sit inside the
+        // measured closure, so every reported build time included teardown of
+        // a 10k-node graph (#62).
+        bn.iter_custom(|iterations| {
+            let mut elapsed = Duration::ZERO;
+            for _ in 0..iterations {
+                let start = Instant::now();
+                let h = unsafe { ffi::vanedb_rs_hnsw_new(DIM, 0, N, M, EFC, SEED) };
+                assert!(!h.is_null());
+                for i in 0..N {
+                    assert_eq!(
+                        unsafe {
+                            ffi::vanedb_rs_hnsw_add(h, w.ids[i], w.vectors[i * DIM..].as_ptr())
+                        },
+                        0
+                    );
+                }
+                elapsed += start.elapsed();
+                unsafe { ffi::vanedb_rs_hnsw_free(black_box(h)) };
             }
-            ffi::vanedb_rs_hnsw_free(black_box(h));
+            elapsed
         });
     });
     build.finish();


### PR DESCRIPTION
## Summary

Closes #62, and refreshes the benchmark documentation that has been stale since the `NDEBUG` fix.

`hnsw_free` sat inside `bn.iter()`, so every reported build time included tearing down a 10k-node graph. `iter_custom` now times construction only, with the free outside the measured interval.

## Why the whole snapshot is re-measured rather than patched

Two independent corrections landed since the published tables were produced, and both change the comparison:

1. **The C++ engine was built without `-DNDEBUG`** — a custom `CMAKE_CXX_FLAGS_RELEASE` replaced CMake's defaults instead of extending them, leaving assertions live in the distance kernels. Fixed in #50. Measured effect: hnsw_search −12.6%, scan paths −4–5%, isolated kernel unchanged — so the cost was blocked inlining, not the branch.
2. **`hnsw_build` included teardown** — this PR.

## Measurement

Criterion medians of three passes on an otherwise idle Apple M4 Pro. **Inter-pass spread 0.3–6.6%, under 3% for every row except `l2_sq` at 768d.** An earlier attempt was discarded because same-code passes differed by up to 31%; that spread is reported here so the table can be read honestly.

| Op (n=10k, dim=128, L2) | C++ | Rust | rs/cpp |
|---|---:|---:|---:|
| l2_sq (128d) | 16.9 ns | 16.5 ns | 0.98 |
| l2_sq (768d) | 51.3 ns | 48.4 ns | 0.94 |
| hnsw_build (M=16, efC=200) | 938 ms | 1013 ms | 1.08 |
| hnsw_search (ef=50) | 18.8 µs | 21.3 µs | 1.13 |
| mmap_search (k=10) | 78.4 µs | 95.5 µs | 1.22 |
| store_search (n=1k) | 8.10 µs | 8.67 µs | 1.07 |
| store_search (n=10k) | 79.0 µs | 92.5 µs | 1.17 |

Recall@10 unchanged: C++ 0.689, Rust 0.700.

`hnsw_build` moving from 0.94 to 1.08 is the teardown fix, not a regression: teardown was the more expensive half for C++, so removing it from both sides changed which engine leads.

## Note on the two tables

`RESULTS.md` and the README table disagree on `l2_sq` (1.26 vs 0.98). That is not an error in either: the report bin times `l2_sq` in batches of 1000 calls, which inlines differently from criterion's per-call harness. `RESULTS.md` now says so explicitly and points at criterion as canonical, rather than leaving two numbers that quietly contradict each other.

## Impact on #32

The scan gap is **17% at n=10k and 22% for mmap_search**, not the ~15% in the issue title. `hnsw_search` at 1.13 with identical kernels points at the same selection overhead. Commented on the issue separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H
