### PR TITLE
ci(bench): smoke-run the report binary and anchor RESULTS.md to the crate

### DIFF
--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -10,8 +10,8 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  benchmark-harness:
-    name: Build and test both C ABIs
+  harness-lint:
+    name: Lint the shared harness
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -21,7 +21,41 @@ jobs:
         run: cargo fmt --manifest-path bench/Cargo.toml --all -- --check
       - name: Lint shared harness
         run: cargo clippy --manifest-path bench/Cargo.toml --all-targets --locked -- -D warnings
+
+  harness:
+    name: Build and test both C ABIs (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # ubuntu covers the cmake/link glue; macos is the platform the README
+        # snapshot is captured on.
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
       - name: Test shared harness
         run: cargo test --manifest-path bench/Cargo.toml --locked
       - name: Compile all cross-engine benchmarks
         run: cargo bench --manifest-path bench/Cargo.toml --locked --no-run
+      # End-to-end proof that the report path still executes, at sizes that
+      # finish in under a second. Shared-runner timings are meaningless, so
+      # nothing here asserts one; recall is a correctness signal and the binary
+      # asserts it against its own sanity floor.
+      - name: Smoke-run the report binary
+        env:
+          VANEDB_BENCH_N: 500
+          VANEDB_BENCH_DIM: 32
+          VANEDB_BENCH_QUERIES: 5
+          VANEDB_BENCH_OUT: ${{ runner.temp }}/RESULTS.md
+        run: |
+          cargo run --release --manifest-path bench/Cargo.toml --locked --bin report
+          grep -q 'HNSW recall@10' "$VANEDB_BENCH_OUT"
+      - name: The harness must not write into the source tree
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git status --porcelain
+            echo "the harness left files in the working tree"
+            exit 1
+          fi

--- a/bench/README.md
+++ b/bench/README.md
@@ -22,6 +22,11 @@ Run these commands from the repository root. They require a C++20 toolchain
 and CMake. `build.rs` compiles the local `cpp/` C API, while Cargo links the
 local `vanedb-capi/` crate, so one commit identifies both engines.
 
+`report` writes [`RESULTS.md`](RESULTS.md) beside this README whatever the
+working directory. `VANEDB_BENCH_DIM`, `_N`, `_K`, `_QUERIES` and `_OUT`
+override the workload and destination; CI runs it at n=500, dim=32 as an
+end-to-end smoke check and asserts recall, never a timing.
+
 ## Headline snapshot (Apple M4 Pro, 2026-09, monorepo 47f6195)
 
 Criterion medians of three passes on an idle machine. Inter-pass spread

--- a/bench/src/bin/report.rs
+++ b/bench/src/bin/report.rs
@@ -1,10 +1,13 @@
 use std::hint::black_box;
+use std::process::ExitCode;
 use std::time::Instant;
+use vanedb_bench::config::ReportConfig;
 use vanedb_bench::{ffi, ground_truth, workloads};
 
-const DIM: usize = 128;
-const N: usize = 10_000;
-const K: usize = 10;
+/// Sanity floor, not a performance assertion: a healthy graph recalls ~0.7 at
+/// these settings and a broken one collapses to near zero. It exists so the
+/// smoke run fails on a graph that builds but does not retrieve.
+const MIN_RECALL: f32 = 0.5;
 
 /// Median one-call latency for two engines, sampled interleaved (a, b, a, b…)
 /// after a joint warmup. Interleaving makes frequency ramp, core migration,
@@ -33,42 +36,55 @@ fn median_pair_ns(mut a: impl FnMut(), mut b: impl FnMut()) -> (u128, u128) {
     (ta[SAMPLES / 2], tb[SAMPLES / 2])
 }
 
-const N_QUERIES: usize = 100;
+fn main() -> ExitCode {
+    let cfg = match ReportConfig::from_env() {
+        Ok(cfg) => cfg,
+        Err(err) => {
+            eprintln!("invalid configuration: {err}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let ReportConfig {
+        dim,
+        n,
+        k,
+        queries,
+        out,
+    } = cfg;
 
-fn main() {
-    let w = workloads::generate(99, DIM, N, N_QUERIES);
-    let q = &w.queries[0..DIM];
-    let mut out = String::from("# VaneDB Benchmark Results\n\n");
-    out.push_str(&format!(
+    let w = workloads::generate(99, dim, n, queries);
+    let q = &w.queries[0..dim];
+    let mut md = String::from("# VaneDB Benchmark Results\n\n");
+    md.push_str(&format!(
         "Engines: vanedb-cpp (CMake Release) and vanedb (Rust), monorepo {}.\n",
         env!("VANEDB_MONOREPO_REV"),
     ));
-    out.push_str(&format!(
-        "Workload: dim={DIM}, n={N}, k={K}, L2. Latencies are medians of 501 \
+    md.push_str(&format!(
+        "Workload: dim={dim}, n={n}, k={k}, L2. Latencies are medians of 501 \
          interleaved paired samples (one query) after a joint warmup; recall is \
-         averaged over {N_QUERIES} queries. Both engines' data stays resident \
+         averaged over {queries} queries. Both engines' data stays resident \
          in one process (interleaved construction).\n\n"
     ));
-    out.push_str(&format!(
-        "Covers l2_sq, store_search, and hnsw_search + recall@{K} only; \
+    md.push_str(&format!(
+        "Covers l2_sq, store_search, and hnsw_search + recall@{k} only; \
          hnsw_build and mmap_search live in the criterion suite (see README).\n\n"
     ));
-    out.push_str("| Op | C++ (ns) | Rust (ns) | ratio (rs/cpp) |\n|---|---:|---:|---:|\n");
+    md.push_str("| Op | C++ (ns) | Rust (ns) | ratio (rs/cpp) |\n|---|---:|---:|---:|\n");
 
     unsafe {
         // Distance — timed in batches of 1000: a single ~10 ns call is below
         // Instant::now() resolution.
-        let a = &w.vectors[0..DIM];
-        let b = &w.vectors[DIM..2 * DIM];
+        let a = &w.vectors[0..dim];
+        let b = &w.vectors[dim..2 * dim];
         let (cpp, rs) = median_pair_ns(
             || {
                 for _ in 0..1000 {
-                    black_box(ffi::vanedb_cpp_l2_sq(a.as_ptr(), b.as_ptr(), DIM));
+                    black_box(ffi::vanedb_cpp_l2_sq(a.as_ptr(), b.as_ptr(), dim));
                 }
             },
             || {
                 for _ in 0..1000 {
-                    black_box(ffi::vanedb_rs_l2_sq(a.as_ptr(), b.as_ptr(), DIM));
+                    black_box(ffi::vanedb_rs_l2_sq(a.as_ptr(), b.as_ptr(), dim));
                 }
             },
         );
@@ -76,41 +92,41 @@ fn main() {
         // truncates ~13.9 vs ~15.0 into 13 vs 15 and distorts the ratio.
         let ratio = rs as f64 / cpp as f64;
         let (cpp, rs) = (cpp / 1000, rs / 1000);
-        out.push_str(&format!("| l2_sq | {cpp} | {rs} | {ratio:.2} |\n"));
+        md.push_str(&format!("| l2_sq | {cpp} | {rs} | {ratio:.2} |\n"));
 
         // Store search. Setup asserts keep a failed engine from benchmarking
         // as infinitely fast.
-        let sc = ffi::vanedb_cpp_store_new(DIM, 0);
-        let sr = ffi::vanedb_rs_store_new(DIM, 0);
+        let sc = ffi::vanedb_cpp_store_new(dim, 0);
+        let sr = ffi::vanedb_rs_store_new(dim, 0);
         assert!(!sc.is_null() && !sr.is_null(), "store_new failed");
-        for i in 0..N {
+        for i in 0..n {
             assert_eq!(
-                ffi::vanedb_cpp_store_add(sc, w.ids[i], w.vectors[i * DIM..].as_ptr()),
+                ffi::vanedb_cpp_store_add(sc, w.ids[i], w.vectors[i * dim..].as_ptr()),
                 0
             );
             assert_eq!(
-                ffi::vanedb_rs_store_add(sr, w.ids[i], w.vectors[i * DIM..].as_ptr()),
+                ffi::vanedb_rs_store_add(sr, w.ids[i], w.vectors[i * dim..].as_ptr()),
                 0
             );
         }
-        let mut ids_c = [0u64; K];
-        let mut ds_c = [0f32; K];
-        let mut ids_r = [0u64; K];
-        let mut ds_r = [0f32; K];
+        let mut ids_c = vec![0u64; k];
+        let mut ds_c = vec![0f32; k];
+        let mut ids_r = vec![0u64; k];
+        let mut ds_r = vec![0f32; k];
         assert_eq!(
-            ffi::vanedb_cpp_store_search(sc, q.as_ptr(), K, ids_c.as_mut_ptr(), ds_c.as_mut_ptr()),
-            K
+            ffi::vanedb_cpp_store_search(sc, q.as_ptr(), k, ids_c.as_mut_ptr(), ds_c.as_mut_ptr()),
+            k
         );
         assert_eq!(
-            ffi::vanedb_rs_store_search(sr, q.as_ptr(), K, ids_r.as_mut_ptr(), ds_r.as_mut_ptr()),
-            K
+            ffi::vanedb_rs_store_search(sr, q.as_ptr(), k, ids_r.as_mut_ptr(), ds_r.as_mut_ptr()),
+            k
         );
         let (cpp, rs) = median_pair_ns(
             || {
                 ffi::vanedb_cpp_store_search(
                     sc,
                     q.as_ptr(),
-                    K,
+                    k,
                     ids_c.as_mut_ptr(),
                     ds_c.as_mut_ptr(),
                 );
@@ -119,13 +135,13 @@ fn main() {
                 ffi::vanedb_rs_store_search(
                     sr,
                     q.as_ptr(),
-                    K,
+                    k,
                     ids_r.as_mut_ptr(),
                     ds_r.as_mut_ptr(),
                 );
             },
         );
-        out.push_str(&format!(
+        md.push_str(&format!(
             "| store_search | {cpp} | {rs} | {:.2} |\n",
             rs as f64 / cpp as f64
         ));
@@ -133,31 +149,31 @@ fn main() {
         ffi::vanedb_rs_store_free(sr);
 
         // HNSW search + recall@k vs brute-force truth, averaged over all queries
-        let hc = ffi::vanedb_cpp_hnsw_new(DIM, 0, N, 16, 200, 7);
-        let hr = ffi::vanedb_rs_hnsw_new(DIM, 0, N, 16, 200, 7);
+        let hc = ffi::vanedb_cpp_hnsw_new(dim, 0, n, 16, 200, 7);
+        let hr = ffi::vanedb_rs_hnsw_new(dim, 0, n, 16, 200, 7);
         assert!(!hc.is_null() && !hr.is_null(), "hnsw_new failed");
-        for i in 0..N {
+        for i in 0..n {
             assert_eq!(
-                ffi::vanedb_cpp_hnsw_add(hc, w.ids[i], w.vectors[i * DIM..].as_ptr()),
+                ffi::vanedb_cpp_hnsw_add(hc, w.ids[i], w.vectors[i * dim..].as_ptr()),
                 0
             );
             assert_eq!(
-                ffi::vanedb_rs_hnsw_add(hr, w.ids[i], w.vectors[i * DIM..].as_ptr()),
+                ffi::vanedb_rs_hnsw_add(hr, w.ids[i], w.vectors[i * dim..].as_ptr()),
                 0
             );
         }
-        let mut ic = [0u64; K];
-        let mut dc = [0f32; K];
-        let mut ir = [0u64; K];
-        let mut dr = [0f32; K];
+        let mut ic = vec![0u64; k];
+        let mut dc = vec![0f32; k];
+        let mut ir = vec![0u64; k];
+        let mut dr = vec![0f32; k];
         let (mut rec_c, mut rec_r) = (0.0f32, 0.0f32);
-        for qi in 0..N_QUERIES {
-            let query = &w.queries[qi * DIM..(qi + 1) * DIM];
-            let truth = ground_truth::brute_force_topk(&w.vectors, &w.ids, DIM, query, K);
+        for qi in 0..queries {
+            let query = &w.queries[qi * dim..(qi + 1) * dim];
+            let truth = ground_truth::brute_force_topk(&w.vectors, &w.ids, dim, query, k);
             let nc = ffi::vanedb_cpp_hnsw_search(
                 hc,
                 query.as_ptr(),
-                K,
+                k,
                 50,
                 ic.as_mut_ptr(),
                 dc.as_mut_ptr(),
@@ -165,44 +181,51 @@ fn main() {
             let nr = ffi::vanedb_rs_hnsw_search(
                 hr,
                 query.as_ptr(),
-                K,
+                k,
                 50,
                 ir.as_mut_ptr(),
                 dr.as_mut_ptr(),
             );
-            assert_eq!(nc, K, "cpp hnsw_search returned short at query {qi}");
-            assert_eq!(nr, K, "rs hnsw_search returned short at query {qi}");
+            assert_eq!(nc, k, "cpp hnsw_search returned short at query {qi}");
+            assert_eq!(nr, k, "rs hnsw_search returned short at query {qi}");
             rec_c += ground_truth::recall_at_k(&ic[..nc], &truth);
             rec_r += ground_truth::recall_at_k(&ir[..nr], &truth);
         }
-        let rec_c = rec_c / N_QUERIES as f32;
-        let rec_r = rec_r / N_QUERIES as f32;
+        let rec_c = rec_c / queries as f32;
+        let rec_r = rec_r / queries as f32;
         let (cpp, rs) = median_pair_ns(
             || {
                 ffi::vanedb_cpp_hnsw_search(
                     hc,
                     q.as_ptr(),
-                    K,
+                    k,
                     50,
                     ic.as_mut_ptr(),
                     dc.as_mut_ptr(),
                 );
             },
             || {
-                ffi::vanedb_rs_hnsw_search(hr, q.as_ptr(), K, 50, ir.as_mut_ptr(), dr.as_mut_ptr());
+                ffi::vanedb_rs_hnsw_search(hr, q.as_ptr(), k, 50, ir.as_mut_ptr(), dr.as_mut_ptr());
             },
         );
-        out.push_str(&format!(
+        md.push_str(&format!(
             "| hnsw_search | {cpp} | {rs} | {:.2} |\n",
             rs as f64 / cpp as f64
         ));
         ffi::vanedb_cpp_hnsw_free(hc);
         ffi::vanedb_rs_hnsw_free(hr);
-        out.push_str(&format!(
-            "\nHNSW recall@{K}: C++ {rec_c:.3}, Rust {rec_r:.3}\n"
+        md.push_str(&format!(
+            "\nHNSW recall@{k}: C++ {rec_c:.3}, Rust {rec_r:.3}\n"
         ));
+
+        assert!(
+            rec_c >= MIN_RECALL && rec_r >= MIN_RECALL,
+            "recall@{k} below the {MIN_RECALL} sanity floor: C++ {rec_c:.3}, Rust {rec_r:.3}"
+        );
     }
 
-    std::fs::write("RESULTS.md", &out).unwrap();
-    print!("{out}");
+    std::fs::write(&out, &md).unwrap_or_else(|e| panic!("writing {}: {e}", out.display()));
+    print!("{md}");
+    eprintln!("written to {}", out.display());
+    ExitCode::SUCCESS
 }

--- a/bench/src/config.rs
+++ b/bench/src/config.rs
@@ -1,0 +1,166 @@
+//! Runtime configuration for the `report` binary.
+//!
+//! The defaults reproduce the published snapshot. The environment overrides
+//! exist so CI can execute the same code path at sizes that finish in seconds
+//! (see `.github/workflows/integration-ci.yml`).
+
+use std::path::PathBuf;
+
+/// Workload and output settings for one `report` run.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReportConfig {
+    pub dim: usize,
+    pub n: usize,
+    pub k: usize,
+    pub queries: usize,
+    pub out: PathBuf,
+}
+
+impl ReportConfig {
+    /// Reads the `VANEDB_BENCH_*` variables from the process environment.
+    pub fn from_env() -> Result<Self, String> {
+        Self::from_lookup(|name| std::env::var(name).ok())
+    }
+
+    /// Same, against an arbitrary lookup — the process environment is global
+    /// mutable state, so tests supply their own.
+    pub fn from_lookup(lookup: impl Fn(&str) -> Option<String>) -> Result<Self, String> {
+        let dim = size(&lookup, "VANEDB_BENCH_DIM", 128)?;
+        let n = size(&lookup, "VANEDB_BENCH_N", 10_000)?;
+        let k = size(&lookup, "VANEDB_BENCH_K", 10)?;
+        let queries = size(&lookup, "VANEDB_BENCH_QUERIES", 100)?;
+
+        // The distance comparison comes from the first two corpus vectors.
+        if n < 2 {
+            return Err(format!("VANEDB_BENCH_N: must be at least 2, got {n}"));
+        }
+        if k > n {
+            return Err(format!(
+                "VANEDB_BENCH_K: {k} exceeds VANEDB_BENCH_N ({n}); no engine can return that many neighbours"
+            ));
+        }
+
+        // Anchored to the crate, not the cwd: the snapshot belongs beside the
+        // README that quotes it however the binary was invoked.
+        let out = lookup("VANEDB_BENCH_OUT")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("RESULTS.md"));
+
+        Ok(Self {
+            dim,
+            n,
+            k,
+            queries,
+            out,
+        })
+    }
+}
+
+fn size(
+    lookup: &impl Fn(&str) -> Option<String>,
+    name: &str,
+    default: usize,
+) -> Result<usize, String> {
+    let Some(raw) = lookup(name) else {
+        return Ok(default);
+    };
+    let value: usize = raw
+        .trim()
+        .parse()
+        .map_err(|_| format!("{name}: expected a positive integer, got {raw:?}"))?;
+    if value == 0 {
+        return Err(format!("{name}: must be at least 1"));
+    }
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(vars: &[(&str, &str)]) -> Result<ReportConfig, String> {
+        ReportConfig::from_lookup(|name| {
+            vars.iter()
+                .find(|(key, _)| *key == name)
+                .map(|(_, value)| (*value).to_string())
+        })
+    }
+
+    #[test]
+    fn defaults_reproduce_the_published_snapshot() {
+        let cfg = config(&[]).unwrap();
+        assert_eq!(cfg.dim, 128);
+        assert_eq!(cfg.n, 10_000);
+        assert_eq!(cfg.k, 10);
+        assert_eq!(cfg.queries, 100);
+    }
+
+    #[test]
+    fn results_default_beside_the_crate_not_the_working_directory() {
+        let cfg = config(&[]).unwrap();
+        assert_eq!(
+            cfg.out,
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("RESULTS.md")
+        );
+        assert!(
+            cfg.out.is_absolute(),
+            "{} must not depend on the cwd",
+            cfg.out.display()
+        );
+    }
+
+    #[test]
+    fn every_dimension_is_overridable() {
+        let cfg = config(&[
+            ("VANEDB_BENCH_DIM", "32"),
+            ("VANEDB_BENCH_N", "500"),
+            ("VANEDB_BENCH_K", "5"),
+            ("VANEDB_BENCH_QUERIES", "3"),
+            ("VANEDB_BENCH_OUT", "/tmp/smoke.md"),
+        ])
+        .unwrap();
+        assert_eq!(
+            cfg,
+            ReportConfig {
+                dim: 32,
+                n: 500,
+                k: 5,
+                queries: 3,
+                out: PathBuf::from("/tmp/smoke.md"),
+            }
+        );
+    }
+
+    #[test]
+    fn a_non_numeric_value_names_the_variable_it_came_from() {
+        let err = config(&[("VANEDB_BENCH_N", "ten thousand")]).unwrap_err();
+        assert!(err.contains("VANEDB_BENCH_N"), "unhelpful message: {err}");
+    }
+
+    #[test]
+    fn zero_sized_workloads_are_rejected() {
+        for var in [
+            "VANEDB_BENCH_DIM",
+            "VANEDB_BENCH_N",
+            "VANEDB_BENCH_K",
+            "VANEDB_BENCH_QUERIES",
+        ] {
+            let err = config(&[(var, "0")]).unwrap_err();
+            assert!(err.contains(var), "unhelpful message for {var}: {err}");
+        }
+    }
+
+    #[test]
+    fn k_may_not_exceed_the_corpus() {
+        // Otherwise the search asserts deep inside the run: every engine
+        // returns fewer than k neighbours and the failure names neither.
+        let err = config(&[("VANEDB_BENCH_N", "8"), ("VANEDB_BENCH_K", "10")]).unwrap_err();
+        assert!(err.contains("VANEDB_BENCH_K"), "unhelpful message: {err}");
+    }
+
+    #[test]
+    fn the_corpus_holds_the_two_vectors_the_distance_bench_needs() {
+        let err = config(&[("VANEDB_BENCH_N", "1"), ("VANEDB_BENCH_K", "1")]).unwrap_err();
+        assert!(err.contains("VANEDB_BENCH_N"), "unhelpful message: {err}");
+    }
+}

--- a/bench/src/lib.rs
+++ b/bench/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod config;
 pub mod ffi;
 pub mod ground_truth;
 pub mod workloads;


### PR DESCRIPTION
Closes #61.

Integration CI built, linted and tested the harness but never executed it. An end-to-end break in the report path — a broken FFI decl, a graph that builds but does not retrieve — reached main unchallenged.

## What changed

**The report binary takes its workload from the environment.** `VANEDB_BENCH_DIM`, `_N`, `_K`, `_QUERIES` and `_OUT`, defaulting to the published snapshot's shape. CI drives the same code path at n=500, dim=32, 5 queries — 0.3 s locally.

**Sizes are validated up front.** `k > n` and `n < 2` (the distance comparison needs two corpus vectors) previously failed deep inside the run with a message naming neither.

**Recall is asserted, timings are not.** A 0.5 sanity floor: a healthy graph returns ~0.7 at these settings, a broken one collapses to near zero. Verified by falsification — temporarily raising the floor to 1.1 fails the run with `recall@10 below the 1.1 sanity floor: C++ 1.000, Rust 1.000` (exit 101). No perf assertion anywhere; shared-runner timings are meaningless.

**RESULTS.md is anchored to the crate.** It was written relative to the working directory, so the README's own documented invocation from the repository root dropped a duplicate there rather than updating `bench/RESULTS.md`. (There was one sitting untracked in my checkout.) CI now fails if the harness leaves anything in the tree.

**The matrix gains macos-latest**, the platform the published snapshot is captured on. Lint moves to its own ubuntu job rather than running twice.

## Verification

Every step of the new workflow replayed locally on the commit:

| Step | Result |
|---|---|
| `cargo fmt --check` / `clippy -D warnings` | clean |
| `cargo test` (bench crate) | 9 passed (7 new) |
| `cargo bench --no-run` | all four benches compile |
| Smoke run at n=500, dim=32 | recall@10 1.000 both engines, exit 0, 0.32 s |
| Tree-cleanliness check | clean |
| `actionlint` (pinned 1.7.12, all workflows) | clean |

The config tests were written first and watched fail (7 failures on `not implemented`) before the parser existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H