### PR TITLE
feat(bench): measure the whole approved scope and check the claim mechanically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ vanedb-wasm/pkg/
 __pycache__/
 *.py[cod]
 *.pyo
+
+# Benchmark scratch files: the benches run from the repository root and build
+# their mmap stores on a real filesystem (see bench/benches/mmap.rs).
+*.mmap
+*.bin

--- a/bench/README.md
+++ b/bench/README.md
@@ -6,9 +6,9 @@ implementations in this repository: C++ in [`../cpp`](../cpp) and Rust in
 
 ## Status
 
-**Implemented.** Criterion benches for distance, VectorStore, HNSW, and mmap,
-plus a `report` binary that writes a [`RESULTS.md`](RESULTS.md) snapshot with
-HNSW recall@10 averaged over 100 queries. Design spec:
+**Implemented.** Criterion benches covering every operation the design spec
+promises, plus a `report` binary that writes a [`RESULTS.md`](RESULTS.md)
+snapshot with HNSW recall@10 averaged over 100 queries. Design spec:
 [`docs/superpowers/specs/2026-05-28-vanedb-bench-design.md`](docs/superpowers/specs/2026-05-28-vanedb-bench-design.md).
 
 ## Running
@@ -27,10 +27,31 @@ working directory. `VANEDB_BENCH_DIM`, `_N`, `_K`, `_QUERIES` and `_OUT`
 override the workload and destination; CI runs it at n=500, dim=32 as an
 end-to-end smoke check and asserts recall, never a timing.
 
+## Coverage
+
+| Spec operation | Measured by |
+|---|---|
+| L2 distance latency | `l2_sq/dim={128,768}` |
+| Cosine distance latency | `cosine/dim={128,768}` |
+| Dot distance latency | `dot/dim={128,768}` |
+| VectorStore add throughput | `store_add/n=10000` |
+| VectorStore search latency | `store_search/n={1000,10000}` |
+| HNSW build latency | `hnsw_build` |
+| HNSW search latency | `hnsw_search` |
+| HNSW recall@k | `report` binary |
+| mmap build latency | `mmap_build` |
+| mmap open latency | `mmap_open` |
+| mmap search latency | `mmap_search` |
+
+`coverage::SCOPE` holds this table as data and a test fails if a bench stops
+implementing a row, so a scope claim cannot drift from the code (#63).
+
 ## Headline snapshot (Apple M4 Pro, 2026-09, monorepo 47f6195)
 
 Criterion medians of three passes on an idle machine. Inter-pass spread
-0.3–6.6%; treat smaller differences as noise.
+0.3–6.6%; treat smaller differences as noise. Covers the operations measured
+at the time; the groups added for full spec coverage join at the next
+on-hardware refresh.
 
 | Op (n=10k, dim=128, L2) | C++ | Rust | rs/cpp |
 |---|---:|---:|---:|
@@ -55,7 +76,13 @@ rather than distance computation (vanedb#32).
 - The report bin samples the engines interleaved (cpp, rs, cpp, rs…) after a
   joint warmup.
 - Criterion is canonical. The report bin covers l2_sq, store_search, and
-  hnsw_search + recall only; hnsw_build and mmap_search are criterion-only.
+  hnsw_search + recall only; every other operation is criterion-only.
+- Construction and teardown are excluded from timed intervals: `hnsw_build`,
+  `store_add`, `mmap_build` and `mmap_open` time only the operation named.
+- `mmap_build` writes megabytes and fsyncs. Its spread is far wider than the
+  compute benches; never read a single run.
+- `mmap_open` maps a file already in page cache and validates every value, so
+  it is O(n·dim) by design rather than a constant-cost map.
 - Every setup return code and handle is asserted, so a failed engine fails the
   run instead of timing a null handle as infinitely fast.
 - On x86_64 the harness compiles the C++ capi with `-mavx2 -mfma`. C++ gates

--- a/bench/benches/distance.rs
+++ b/bench/benches/distance.rs
@@ -1,25 +1,52 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use std::hint::black_box;
+use vanedb_bench::coverage::groups;
 use vanedb_bench::{ffi, workloads};
 
-fn bench_distance(c: &mut Criterion) {
+/// Generic over the two calls rather than taking function pointers: a pointer
+/// table would make every metric an indirect call and shift the numbers
+/// against the published snapshot. Monomorphised closures keep the direct call
+/// the l2_sq figures were measured with.
+fn bench_metric(
+    c: &mut Criterion,
+    name: &str,
+    cpp: impl Fn(*const f32, *const f32, usize) -> f32,
+    rs: impl Fn(*const f32, *const f32, usize) -> f32,
+) {
     for &dim in &[128usize, 768] {
         let w = workloads::generate(1, dim, 2, 0);
         let a = &w.vectors[0..dim];
         let b = &w.vectors[dim..2 * dim];
-        let mut g = c.benchmark_group(format!("l2_sq/dim={dim}"));
+        let mut g = c.benchmark_group(format!("{name}/dim={dim}"));
         g.bench_with_input(BenchmarkId::new("cpp", dim), &dim, |bn, &d| {
-            bn.iter(|| unsafe {
-                ffi::vanedb_cpp_l2_sq(black_box(a.as_ptr()), black_box(b.as_ptr()), d)
-            });
+            bn.iter(|| cpp(black_box(a.as_ptr()), black_box(b.as_ptr()), d));
         });
         g.bench_with_input(BenchmarkId::new("rs", dim), &dim, |bn, &d| {
-            bn.iter(|| unsafe {
-                ffi::vanedb_rs_l2_sq(black_box(a.as_ptr()), black_box(b.as_ptr()), d)
-            });
+            bn.iter(|| rs(black_box(a.as_ptr()), black_box(b.as_ptr()), d));
         });
         g.finish();
     }
+}
+
+fn bench_distance(c: &mut Criterion) {
+    bench_metric(
+        c,
+        groups::L2_SQ,
+        |a, b, d| unsafe { ffi::vanedb_cpp_l2_sq(a, b, d) },
+        |a, b, d| unsafe { ffi::vanedb_rs_l2_sq(a, b, d) },
+    );
+    bench_metric(
+        c,
+        groups::COSINE,
+        |a, b, d| unsafe { ffi::vanedb_cpp_cosine_distance(a, b, d) },
+        |a, b, d| unsafe { ffi::vanedb_rs_cosine_distance(a, b, d) },
+    );
+    bench_metric(
+        c,
+        groups::DOT,
+        |a, b, d| unsafe { ffi::vanedb_cpp_dot_product(a, b, d) },
+        |a, b, d| unsafe { ffi::vanedb_rs_dot_product(a, b, d) },
+    );
 }
 
 criterion_group!(benches, bench_distance);

--- a/bench/benches/hnsw.rs
+++ b/bench/benches/hnsw.rs
@@ -1,6 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::hint::black_box;
 use std::time::{Duration, Instant};
+use vanedb_bench::coverage::groups;
 use vanedb_bench::{ffi, workloads};
 
 const DIM: usize = 128;
@@ -14,7 +15,7 @@ fn bench_hnsw(c: &mut Criterion) {
     let w = workloads::generate(3, DIM, N, 1);
     let q = &w.queries[0..DIM];
 
-    let mut build = c.benchmark_group("hnsw_build");
+    let mut build = c.benchmark_group(groups::HNSW_BUILD);
     build.sample_size(10);
     // Asserts inside the timed loop are symmetric across engines and cost
     // nanoseconds against ~0.1 ms inserts; they turn a failed engine into a
@@ -70,7 +71,7 @@ fn bench_hnsw(c: &mut Criterion) {
     build.finish();
 
     // Pre-build once each for the search benchmark.
-    let mut search = c.benchmark_group("hnsw_search");
+    let mut search = c.benchmark_group(groups::HNSW_SEARCH);
     unsafe {
         let hc = ffi::vanedb_cpp_hnsw_new(DIM, 0, N, M, EFC, SEED);
         let hr = ffi::vanedb_rs_hnsw_new(DIM, 0, N, M, EFC, SEED);

--- a/bench/benches/mmap.rs
+++ b/bench/benches/mmap.rs
@@ -1,44 +1,126 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::ffi::CString;
 use std::hint::black_box;
+use std::os::raw::c_char;
+use std::time::{Duration, Instant};
+use vanedb_bench::coverage::groups;
 use vanedb_bench::{ffi, workloads};
 
 const DIM: usize = 128;
 const N: usize = 10_000;
 
-fn bench_mmap_search(c: &mut Criterion) {
+// Files are created in the working directory on purpose. The documented
+// invocation runs from the repository root, on a real filesystem; /tmp is
+// tmpfs on many Linux distributions, which would benchmark RAM rather than
+// the mapped-file path these stores exist for.
+const CPP_FILE: &str = "bench_cpp.mmap";
+const RS_FILE: &str = "bench_rs.mmap";
+const CPP_BUILD_FILE: &str = "bench_cpp_build.mmap";
+const RS_BUILD_FILE: &str = "bench_rs_build.mmap";
+
+/// Both engines' `mmap_build` share this signature. The indirect call costs
+/// nanoseconds against a multi-megabyte write.
+type MmapBuildFn =
+    unsafe extern "C" fn(*const c_char, usize, u32, *const u64, *const f32, usize) -> i32;
+
+/// # Safety
+/// `build` must be one of the two engines' `mmap_build` entry points.
+unsafe fn build_into(build: MmapBuildFn, path: &CString, w: &workloads::Workload) -> i32 {
+    build(path.as_ptr(), DIM, 0, w.ids.as_ptr(), w.vectors.as_ptr(), N)
+}
+
+fn bench_mmap(c: &mut Criterion) {
     let w = workloads::generate(4, DIM, N, 1);
     let q = &w.queries[0..DIM];
-    let cpp_path = CString::new("bench_cpp.mmap").unwrap();
-    let rs_path = CString::new("bench_rs.mmap").unwrap();
+    let cpp_path = CString::new(CPP_FILE).unwrap();
+    let rs_path = CString::new(RS_FILE).unwrap();
+    let cpp_build_path = CString::new(CPP_BUILD_FILE).unwrap();
+    let rs_build_path = CString::new(RS_BUILD_FILE).unwrap();
 
     unsafe {
-        // A failed build/open (e.g. read-only cwd) must fail loudly, not
-        // benchmark a null handle as infinitely fast.
+        // Build the stores the open and search groups read. A failed
+        // build/open (e.g. read-only cwd) must fail loudly, not benchmark a
+        // null handle as infinitely fast.
         assert_eq!(
-            ffi::vanedb_cpp_mmap_build(
-                cpp_path.as_ptr(),
-                DIM,
-                0,
-                w.ids.as_ptr(),
-                w.vectors.as_ptr(),
-                N,
-            ),
+            build_into(ffi::vanedb_cpp_mmap_build, &cpp_path, &w),
             0,
             "cpp mmap_build failed"
         );
         assert_eq!(
-            ffi::vanedb_rs_mmap_build(
-                rs_path.as_ptr(),
-                DIM,
-                0,
-                w.ids.as_ptr(),
-                w.vectors.as_ptr(),
-                N,
-            ),
+            build_into(ffi::vanedb_rs_mmap_build, &rs_path, &w),
             0,
             "rs mmap_build failed"
         );
+
+        // --- build ---------------------------------------------------------
+        // Each iteration writes a fresh file: overwriting an existing one
+        // takes a different path through the filesystem. Removal is untimed.
+        // This group writes ~5 MB and syncs, so its run-to-run spread is far
+        // wider than the compute benches — see the README's noise floor.
+        let mut build = c.benchmark_group(groups::MMAP_BUILD);
+        build.sample_size(10);
+        build.bench_function("cpp", |bn| {
+            bn.iter_custom(|iterations| {
+                let mut elapsed = Duration::ZERO;
+                for _ in 0..iterations {
+                    let _ = std::fs::remove_file(CPP_BUILD_FILE);
+                    let start = Instant::now();
+                    let rc = build_into(ffi::vanedb_cpp_mmap_build, &cpp_build_path, &w);
+                    elapsed += start.elapsed();
+                    assert_eq!(rc, 0, "cpp mmap_build failed");
+                }
+                elapsed
+            })
+        });
+        build.bench_function("rs", |bn| {
+            bn.iter_custom(|iterations| {
+                let mut elapsed = Duration::ZERO;
+                for _ in 0..iterations {
+                    let _ = std::fs::remove_file(RS_BUILD_FILE);
+                    let start = Instant::now();
+                    let rc = build_into(ffi::vanedb_rs_mmap_build, &rs_build_path, &w);
+                    elapsed += start.elapsed();
+                    assert_eq!(rc, 0, "rs mmap_build failed");
+                }
+                elapsed
+            })
+        });
+        build.finish();
+
+        // --- open ----------------------------------------------------------
+        // Warm-cache open: the same file is mapped repeatedly, so this is the
+        // mapping and header-validation cost, not first-read I/O. mmap_free is
+        // outside the measured interval.
+        let mut open = c.benchmark_group(groups::MMAP_OPEN);
+        open.bench_function("cpp", |bn| {
+            bn.iter_custom(|iterations| {
+                let mut elapsed = Duration::ZERO;
+                for _ in 0..iterations {
+                    let start = Instant::now();
+                    let m = ffi::vanedb_cpp_mmap_open(cpp_path.as_ptr());
+                    elapsed += start.elapsed();
+                    assert!(!m.is_null(), "cpp mmap_open failed");
+                    ffi::vanedb_cpp_mmap_free(black_box(m));
+                }
+                elapsed
+            })
+        });
+        open.bench_function("rs", |bn| {
+            bn.iter_custom(|iterations| {
+                let mut elapsed = Duration::ZERO;
+                for _ in 0..iterations {
+                    let start = Instant::now();
+                    let m = ffi::vanedb_rs_mmap_open(rs_path.as_ptr());
+                    elapsed += start.elapsed();
+                    assert!(!m.is_null(), "rs mmap_open failed");
+                    ffi::vanedb_rs_mmap_free(black_box(m));
+                }
+                elapsed
+            })
+        });
+        open.finish();
+
+        // --- search --------------------------------------------------------
         let mc = ffi::vanedb_cpp_mmap_open(cpp_path.as_ptr());
         let mr = ffi::vanedb_rs_mmap_open(rs_path.as_ptr());
         assert!(!mc.is_null() && !mr.is_null(), "mmap_open failed");
@@ -53,7 +135,7 @@ fn bench_mmap_search(c: &mut Criterion) {
             ffi::vanedb_rs_mmap_search(mr, q.as_ptr(), 10, ids.as_mut_ptr(), ds.as_mut_ptr()),
             10
         );
-        let mut g = c.benchmark_group("mmap_search");
+        let mut g = c.benchmark_group(groups::MMAP_SEARCH);
         g.bench_function("cpp", |bn| {
             bn.iter(|| {
                 ffi::vanedb_cpp_mmap_search(
@@ -80,9 +162,11 @@ fn bench_mmap_search(c: &mut Criterion) {
         ffi::vanedb_cpp_mmap_free(mc);
         ffi::vanedb_rs_mmap_free(mr);
     }
-    let _ = std::fs::remove_file("bench_cpp.mmap");
-    let _ = std::fs::remove_file("bench_rs.mmap");
+
+    for file in [CPP_FILE, RS_FILE, CPP_BUILD_FILE, RS_BUILD_FILE] {
+        let _ = std::fs::remove_file(file);
+    }
 }
 
-criterion_group!(benches, bench_mmap_search);
+criterion_group!(benches, bench_mmap);
 criterion_main!(benches);

--- a/bench/benches/store.rs
+++ b/bench/benches/store.rs
@@ -1,24 +1,83 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use std::hint::black_box;
+use std::time::{Duration, Instant};
+use vanedb_bench::coverage::groups;
 use vanedb_bench::{ffi, workloads};
 
+const DIM: usize = 128;
+
+fn bench_store_add(c: &mut Criterion) {
+    const N: usize = 10_000;
+    let w = workloads::generate(5, DIM, N, 0);
+    let mut g = c.benchmark_group(format!("{}/n={N}", groups::STORE_ADD));
+    g.throughput(Throughput::Elements(N as u64));
+    g.sample_size(10);
+
+    // Neither C ABI exposes a reserve hook, so both engines start empty and
+    // grow on demand: the preallocation policy is equal by construction.
+    // store_new and store_free sit outside the measured interval — only the
+    // adds are the throughput under test (#62 was this mistake in hnsw_build).
+    g.bench_function("cpp", |bn| {
+        bn.iter_custom(|iterations| {
+            let mut elapsed = Duration::ZERO;
+            for _ in 0..iterations {
+                let s = unsafe { ffi::vanedb_cpp_store_new(DIM, 0) };
+                assert!(!s.is_null(), "cpp store_new failed");
+                let start = Instant::now();
+                for i in 0..N {
+                    assert_eq!(
+                        unsafe {
+                            ffi::vanedb_cpp_store_add(s, w.ids[i], w.vectors[i * DIM..].as_ptr())
+                        },
+                        0
+                    );
+                }
+                elapsed += start.elapsed();
+                unsafe { ffi::vanedb_cpp_store_free(black_box(s)) };
+            }
+            elapsed
+        });
+    });
+    g.bench_function("rs", |bn| {
+        bn.iter_custom(|iterations| {
+            let mut elapsed = Duration::ZERO;
+            for _ in 0..iterations {
+                let s = unsafe { ffi::vanedb_rs_store_new(DIM, 0) };
+                assert!(!s.is_null(), "rs store_new failed");
+                let start = Instant::now();
+                for i in 0..N {
+                    assert_eq!(
+                        unsafe {
+                            ffi::vanedb_rs_store_add(s, w.ids[i], w.vectors[i * DIM..].as_ptr())
+                        },
+                        0
+                    );
+                }
+                elapsed += start.elapsed();
+                unsafe { ffi::vanedb_rs_store_free(black_box(s)) };
+            }
+            elapsed
+        });
+    });
+    g.finish();
+}
+
 fn bench_store_search(c: &mut Criterion) {
-    let dim = 128usize;
     for &n in &[1_000usize, 10_000] {
-        let w = workloads::generate(2, dim, n, 1);
-        let q = &w.queries[0..dim];
-        let mut g = c.benchmark_group(format!("store_search/n={n}"));
+        let w = workloads::generate(2, DIM, n, 1);
+        let q = &w.queries[0..DIM];
+        let mut g = c.benchmark_group(format!("{}/n={n}", groups::STORE_SEARCH));
 
         unsafe {
             // Measurement policy: both engines' stores stay resident for the
             // whole group, built interleaved — matching hnsw.rs and the report
             // bin. A brute-force scan is cache-bound, so residency decides the
             // winner; every path must use the same policy.
-            let sc = ffi::vanedb_cpp_store_new(dim, 0);
-            let sr = ffi::vanedb_rs_store_new(dim, 0);
+            let sc = ffi::vanedb_cpp_store_new(DIM, 0);
+            let sr = ffi::vanedb_rs_store_new(DIM, 0);
             assert!(!sc.is_null() && !sr.is_null(), "store_new failed");
             for i in 0..n {
-                let v = w.vectors[i * dim..].as_ptr();
+                let v = w.vectors[i * DIM..].as_ptr();
                 assert_eq!(ffi::vanedb_cpp_store_add(sc, w.ids[i], v), 0);
                 assert_eq!(ffi::vanedb_rs_store_add(sr, w.ids[i], v), 0);
             }
@@ -63,5 +122,5 @@ fn bench_store_search(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, bench_store_search);
+criterion_group!(benches, bench_store_add, bench_store_search);
 criterion_main!(benches);

--- a/bench/src/coverage.rs
+++ b/bench/src/coverage.rs
@@ -1,0 +1,153 @@
+//! The approved scope, as data.
+//!
+//! `docs/superpowers/specs/2026-05-28-vanedb-bench-design.md` lists the
+//! operations this harness must measure. The implementation plan quietly
+//! covered a third of them while its self-review claimed the scope was
+//! complete (#63), so the claim is now checked mechanically rather than
+//! asserted in prose.
+
+/// Criterion group names. The benches build their group names from these, so
+/// deleting a group here breaks compilation and deleting one from a bench
+/// breaks [`SCOPE`]'s test — a scope claim cannot drift from the code silently.
+pub mod groups {
+    pub const L2_SQ: &str = "l2_sq";
+    pub const COSINE: &str = "cosine";
+    pub const DOT: &str = "dot";
+    pub const STORE_ADD: &str = "store_add";
+    pub const STORE_SEARCH: &str = "store_search";
+    pub const HNSW_BUILD: &str = "hnsw_build";
+    pub const HNSW_SEARCH: &str = "hnsw_search";
+    pub const MMAP_BUILD: &str = "mmap_build";
+    pub const MMAP_OPEN: &str = "mmap_open";
+    pub const MMAP_SEARCH: &str = "mmap_search";
+}
+
+/// One operation the approved scope promises, and where it is measured.
+pub struct Coverage {
+    /// The operation as the spec words it.
+    pub operation: &'static str,
+    /// Criterion group, or the report binary, that reports it.
+    pub measured_by: &'static str,
+    /// Crate-relative source that must implement the measurement.
+    pub source: &'static str,
+    /// Identifier that source must reference — the mechanical link.
+    pub must_reference: &'static str,
+}
+
+/// Every operation the approved design promises to measure.
+pub const SCOPE: &[Coverage] = &[
+    Coverage {
+        operation: "L2 distance latency",
+        measured_by: "l2_sq/dim={128,768}",
+        source: "benches/distance.rs",
+        must_reference: "groups::L2_SQ",
+    },
+    Coverage {
+        operation: "cosine distance latency",
+        measured_by: "cosine/dim={128,768}",
+        source: "benches/distance.rs",
+        must_reference: "groups::COSINE",
+    },
+    Coverage {
+        operation: "dot distance latency",
+        measured_by: "dot/dim={128,768}",
+        source: "benches/distance.rs",
+        must_reference: "groups::DOT",
+    },
+    Coverage {
+        operation: "VectorStore add throughput",
+        measured_by: "store_add/n=10000",
+        source: "benches/store.rs",
+        must_reference: "groups::STORE_ADD",
+    },
+    Coverage {
+        operation: "VectorStore search latency",
+        measured_by: "store_search/n={1000,10000}",
+        source: "benches/store.rs",
+        must_reference: "groups::STORE_SEARCH",
+    },
+    Coverage {
+        operation: "HNSW build latency",
+        measured_by: "hnsw_build",
+        source: "benches/hnsw.rs",
+        must_reference: "groups::HNSW_BUILD",
+    },
+    Coverage {
+        operation: "HNSW search latency",
+        measured_by: "hnsw_search",
+        source: "benches/hnsw.rs",
+        must_reference: "groups::HNSW_SEARCH",
+    },
+    Coverage {
+        operation: "HNSW recall@k",
+        measured_by: "report binary",
+        source: "src/bin/report.rs",
+        must_reference: "ground_truth::recall_at_k",
+    },
+    Coverage {
+        operation: "mmap build latency",
+        measured_by: "mmap_build",
+        source: "benches/mmap.rs",
+        must_reference: "groups::MMAP_BUILD",
+    },
+    Coverage {
+        operation: "mmap open latency",
+        measured_by: "mmap_open",
+        source: "benches/mmap.rs",
+        must_reference: "groups::MMAP_OPEN",
+    },
+    Coverage {
+        operation: "mmap search latency",
+        measured_by: "mmap_search",
+        source: "benches/mmap.rs",
+        must_reference: "groups::MMAP_SEARCH",
+    },
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Sources are embedded at compile time: the test must not depend on the
+    /// working directory it is run from.
+    fn source(path: &str) -> &'static str {
+        match path {
+            "benches/distance.rs" => include_str!("../benches/distance.rs"),
+            "benches/store.rs" => include_str!("../benches/store.rs"),
+            "benches/hnsw.rs" => include_str!("../benches/hnsw.rs"),
+            "benches/mmap.rs" => include_str!("../benches/mmap.rs"),
+            "src/bin/report.rs" => include_str!("bin/report.rs"),
+            other => panic!("SCOPE names {other}, which the test cannot read"),
+        }
+    }
+
+    /// Proves the named source registers the measurement. It cannot prove the
+    /// measurement is reached at runtime — that is what the CI smoke run and
+    /// `cargo bench --no-run` are for.
+    #[test]
+    fn every_promised_operation_is_measured() {
+        for entry in SCOPE {
+            let src = source(entry.source);
+            assert!(
+                src.lines()
+                    .filter(|line| !line.trim_start().starts_with("//"))
+                    .any(|line| line.contains(entry.must_reference)),
+                "{}: {} does not reference {}",
+                entry.operation,
+                entry.source,
+                entry.must_reference
+            );
+        }
+    }
+
+    #[test]
+    fn the_table_promises_each_operation_once() {
+        for (i, entry) in SCOPE.iter().enumerate() {
+            assert!(
+                !SCOPE[..i].iter().any(|e| e.operation == entry.operation),
+                "{} is listed twice",
+                entry.operation
+            );
+        }
+    }
+}

--- a/bench/src/lib.rs
+++ b/bench/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod coverage;
 pub mod ffi;
 pub mod ground_truth;
 pub mod workloads;


### PR DESCRIPTION
Closes #63.

The approved design promises three distance metrics, VectorStore add throughput and search, HNSW build/search/recall, and mmap build/open/search. The harness measured a third of that, and the plan's self-review claimed the scope was complete.

## What changed

**New groups:** `cosine` and `dot` at the same dimensions as L2, `store_add` throughput, and separate `mmap_build` and `mmap_open`. Construction and teardown stay outside every new measured interval, following #62.

**The scope claim is now data.** `coverage::SCOPE` lists each promised operation with the source that must implement it; a test fails when a bench stops referencing its group. It proves registration, not that a group is reached at runtime — `cargo bench --no-run` and the CI smoke run cover that. The table is mirrored in the README.

**The distance benches use monomorphised closures, not a function-pointer table.** A pointer table would have made every metric an indirect call and shifted the numbers against the published snapshot. Measured after the refactor:

| | published | after |
|---|---|---|
| l2_sq 128d cpp / rs | 16.9 / 16.5 ns | 16.68 / 16.71 ns |
| l2_sq 768d cpp / rs | 51.3 / 48.4 ns | 50.13 / 47.43 ns |

Within the documented 0.3–6.6% inter-pass spread, so the refactor did not move the baseline.

## The new coverage immediately found a defect

`mmap_build` on the first run: **C++ 4.89 ms, Rust 1.174 s** — 240×. `MmapVectorStoreBuilder::save` writes to an unbuffered `File` one element at a time: ~1.29 M `write` syscalls for a 5 MB store, against two bulk writes on the C++ side. Filed separately rather than folded in here, since it is a `vanedb` core change. HNSW's `save` is unaffected — it already serialises to one buffer.

`mmap_open` at ~500 µs on both engines is the deliberate O(n·dim) finite-value validation from #41, not a defect; the README now says so.

## Verification

| Check | Result |
|---|---|
| `cargo fmt --check` / `clippy -D warnings` | clean |
| `cargo test` (bench crate) | 11 passed (2 new) |
| Coverage test on unfixed benches | failed first — `benches/distance.rs does not reference groups::L2_SQ` |
| `cargo bench --quick` (distance, store, mmap) | all 22 benchmarks execute |

No snapshot numbers are published here: the new groups join the README table at the next on-hardware refresh, after the mmap fix lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H