### PR TITLE
perf(mmap): buffer the builder's writes instead of one syscall per element

### DIFF
--- a/vanedb/src/mmap.rs
+++ b/vanedb/src/mmap.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::io::Write;
+use std::io::{BufWriter, Write};
 use std::path::Path;
 
 use memmap2::Mmap;
@@ -13,6 +13,12 @@ use crate::validation::validate_finite;
 const MAGIC: u32 = 0x564E4442; // "VNDB"
 const VERSION: u32 = 1;
 const HEADER_SIZE: usize = 32;
+
+/// Write buffer for [`MmapVectorStoreBuilder::save`]. Ids and vectors are
+/// encoded element-wise to keep the on-disk layout explicitly little-endian;
+/// unbuffered that cost one `write` syscall per element, so a 10k x 128 store
+/// issued 1.29M of them.
+const WRITE_BUFFER_BYTES: usize = 64 * 1024;
 
 fn metric_to_u32(m: DistanceMetric) -> u32 {
     match m {
@@ -77,8 +83,9 @@ impl MmapVectorStoreBuilder {
     pub fn save(&self, path: impl AsRef<Path>) -> Result<()> {
         let path = path.as_ref();
         let temp = crate::atomic_write::AtomicFile::new(path);
-        let mut f =
+        let file =
             fs::File::create(temp.path()).map_err(|e| VaneError::Io(format!("create: {e}")))?;
+        let mut f = BufWriter::with_capacity(WRITE_BUFFER_BYTES, file);
 
         // Header
         f.write_all(&MAGIC.to_le_bytes())
@@ -106,7 +113,9 @@ impl MmapVectorStoreBuilder {
                 .map_err(|e| VaneError::Io(format!("write: {e}")))?;
         }
 
-        f.flush()
+        // into_inner flushes the buffer; the fsync below must see every byte.
+        let f = f
+            .into_inner()
             .map_err(|e| VaneError::Io(format!("flush: {e}")))?;
         // Durability: fsync data + metadata before rename so a crash mid-write
         // can't leave a half-written file in place. Mirrors fsync_file in


### PR DESCRIPTION
Closes #70. Found by the `mmap_build` group added in #69 — the operation had never been benchmarked.

`MmapVectorStoreBuilder::save` wrote to an unbuffered `File` one element at a time: **~1.29 M `write` syscalls to produce a 5 MB store**. `vanedb-cpp` writes the same two arrays in two bulk calls on a buffered `ofstream`.

## The change

A 64 KiB `BufWriter`. The bytes are identical — element-wise `to_le_bytes()` keeps the layout explicitly little-endian — and only the syscall batching changes. `into_inner` flushes before `sync_all`, so the fsync ahead of the atomic rename still sees every byte.

12 insertions, 3 deletions.

## Measurement

Apple M4 Pro, interleaved A-B-A:

| | A1 (fix) | B1 (unfixed) | A2 (fix) | same-arm spread |
|---|---|---|---|---|
| `mmap_build/rs` | 10.33 ms | **1.196 s** | 9.99 ms | 3.4% |
| `mmap_build/cpp` (control) | 4.93 ms | 4.96 ms | 5.06 ms | 2.6% |
| `mmap_open/rs` (control) | 562.9 µs | 575.9 µs | 571.0 µs | 2.3% |
| `mmap_search/rs` (control) | 96.0 µs | 95.1 µs | 96.7 µs | 1.7% |

118× on the target metric with every control arm inside the noise floor, so the machine did not drift.

## Why no new test

The behaviour changed is syscall count, and a timing assertion in the test suite would contradict this repo's own rule that timings from shared runners are meaningless. Correctness is pinned by the existing round-trip and corruption tests (`roundtrip_build_open_search`, `mmap_load_rejects_*`), which pass unchanged because the byte layout is unchanged; the regression guard is the `mmap_build` criterion group.

`cargo clippy --workspace --exclude vanedb-py --all-targets --features mmap -D warnings`: clean. `cargo test --workspace --exclude vanedb-py --features mmap`: **135 passed, 0 failed**.

## Not fixed here

A residual ~2× gap against C++ remains (10.2 ms vs 4.96 ms), from the per-element encode loop versus two bulk writes. Closing it needs a transient full-size byte buffer or an endianness-guarded reinterpret — a perf optimisation rather than a defect, so it is out of scope for this fix.

## Cross-repo

No port needed: no algorithm or format change, and the C++ side is already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H