### PR TITLE
fix(python): make C++ wheels safe without AVX2/FMA

### DIFF
--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -207,6 +207,20 @@ jobs:
       run: |
         python -m pytest tests/test_python_bindings.py -v
 
+    - name: Retain Linux wheel for baseline-CPU execution
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: vanedb-cpp-ci-linux-cp311
+        path: cpp/wheelhouse/*.whl
+        if-no-files-found: error
+
+  wheel-cpu-portability:
+    needs: python-tests
+    uses: ./.github/workflows/cpp-wheel-portability.yml
+    with:
+      wheel-artifact: vanedb-cpp-ci-linux-cp311
+
   sanitizers:
     name: Sanitizer Checks (${{ matrix.sanitizer }})
     runs-on: ubuntu-latest

--- a/.github/workflows/cpp-wheel-portability.yml
+++ b/.github/workflows/cpp-wheel-portability.yml
@@ -1,0 +1,38 @@
+name: C++ wheel CPU portability
+
+on:
+  workflow_call:
+    inputs:
+      wheel-artifact:
+        description: Artifact containing the Linux x86-64 CPython 3.11 wheel
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  baseline-and-avx2:
+    name: Installed wheel on baseline, AVX-only, no-FMA, and AVX2 CPUs
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.11'
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.wheel-artifact }}
+          path: wheelhouse
+      - name: Install emulator and wheel dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user
+          python -m pip install pytest numpy
+      - name: Install the already-built wheel
+        run: |
+          python -m pip install --no-index --no-deps --find-links wheelhouse vanedb-cpp
+          python -m pip check
+      - name: Verify fallback, accelerated dispatch, and Python behavior
+        run: bash cpp/tests/run_wheel_cpu_checks.sh "$(command -v python)"

--- a/.github/workflows/publish-cpp.yml
+++ b/.github/workflows/publish-cpp.yml
@@ -188,9 +188,15 @@ jobs:
           python -m pip check
           python -m pytest tests/test_python_bindings.py -v
 
+  wheel-cpu-portability:
+    needs: build-wheels
+    uses: ./.github/workflows/cpp-wheel-portability.yml
+    with:
+      wheel-artifact: vanedb-cpp-wheels-linux-x86_64
+
   validate-artifacts:
     name: Validate release artifacts
-    needs: [build-wheels, sdist-test]
+    needs: [build-wheels, sdist-test, wheel-cpu-portability]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -230,9 +236,8 @@ jobs:
     name: Publish vanedb-cpp to PyPI
     needs: validate-artifacts
     runs-on: ubuntu-latest
-    # Product tag pushes build and retain artifacts. Publication stays manual
-    # until the generic x86-64 CPU baseline is safe:
-    # https://github.com/vanedb/vanedb-cpp/issues/39
+    # Product tag pushes build and retain artifacts. CPU portability is checked
+    # above (#59); publication still requires manual dispatch and approval.
     if: >-
       github.event_name == 'workflow_dispatch' &&
       inputs.publish &&

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -35,6 +35,43 @@ option(VANEDB_BUILD_EXAMPLES "Build examples" ON)
 option(VANEDB_BUILD_PYTHON "Build Python bindings" ON)
 option(VANEDB_COVERAGE "Build with code coverage instrumentation" OFF)
 
+# Opt-in compiled dispatch for distributable wheels (the public C++ library
+# remains header-only). Never apply AVX flags to the extension or dispatcher.
+function(vanedb_use_runtime_dispatch target)
+  if(VANEDB_X86_64)
+    if(MSVC)
+      set(baseline_flags /arch:SSE2)
+      set(avx2_flags /arch:AVX2 /GL-)
+    else()
+      set(baseline_flags -march=x86-64 -mtune=generic -mno-avx -mno-avx2 -mno-fma)
+      set(avx2_flags -march=x86-64 -mtune=generic -mavx2 -mfma -fno-lto)
+    endif()
+  endif()
+
+  if(NOT TARGET vanedb_distance_runtime)
+    add_library(vanedb_distance_runtime STATIC src/distance_runtime.cpp)
+    target_include_directories(vanedb_distance_runtime PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+    target_compile_definitions(vanedb_distance_runtime PUBLIC VANEDB_RUNTIME_DISPATCH=1)
+    target_compile_options(vanedb_distance_runtime PRIVATE ${baseline_flags} ${COVERAGE_COMPILE_FLAGS})
+    target_link_options(vanedb_distance_runtime INTERFACE ${COVERAGE_LINK_FLAGS})
+    set_target_properties(vanedb_distance_runtime PROPERTIES
+      POSITION_INDEPENDENT_CODE ON INTERPROCEDURAL_OPTIMIZATION OFF)
+
+    if(VANEDB_X86_64)
+      add_library(vanedb_distance_avx2 OBJECT src/distance_avx2.cpp)
+      target_include_directories(vanedb_distance_avx2 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+      target_compile_options(vanedb_distance_avx2 PRIVATE ${avx2_flags} ${COVERAGE_COMPILE_FLAGS})
+      # LTO must not move ISA-specific code across the runtime-check boundary.
+      set_target_properties(vanedb_distance_avx2 PROPERTIES
+        POSITION_INDEPENDENT_CODE ON INTERPROCEDURAL_OPTIMIZATION OFF)
+      target_sources(vanedb_distance_runtime PRIVATE $<TARGET_OBJECTS:vanedb_distance_avx2>)
+      target_compile_definitions(vanedb_distance_runtime PRIVATE VANEDB_HAS_AVX2_OBJECT=1)
+    endif()
+  endif()
+  target_compile_options(${target} PRIVATE ${baseline_flags})
+  target_link_libraries(${target} PRIVATE vanedb_distance_runtime)
+endfunction()
+
 # Fetch dependencies
 include(FetchContent)
 
@@ -176,6 +213,21 @@ target_link_options(test_hnsw_derived_size_conformance PRIVATE ${COVERAGE_LINK_F
 include(CTest)
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
 include(Catch)
+
+# Keep the original compile-time tests and run the distance/conformance suites
+# again through the same compiled runtime dispatcher as the installed wheels.
+add_executable(test_runtime_distance
+  tests/test_runtime_distance.cpp
+  tests/test_distance.cpp
+  tests/test_cosine_conformance.cpp
+  tests/test_non_finite_conformance.cpp)
+target_link_libraries(test_runtime_distance PRIVATE vanedb Catch2::Catch2WithMain)
+target_compile_definitions(test_runtime_distance PRIVATE
+  VANEDB_CONFORMANCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../conformance")
+target_compile_options(test_runtime_distance PRIVATE ${COVERAGE_COMPILE_FLAGS})
+vanedb_use_runtime_dispatch(test_runtime_distance)
+catch_discover_tests(test_runtime_distance TEST_PREFIX "runtime/")
+
 catch_discover_tests(test_distance)
 catch_discover_tests(test_vector_store)
 catch_discover_tests(test_hnsw_index)
@@ -266,10 +318,7 @@ if(VANEDB_BUILD_PYTHON)
 
   pybind11_add_module(vanedb_cpp MODULE python/vanedb.cpp)
   target_link_libraries(vanedb_cpp PRIVATE vanedb pybind11::module)
-  target_compile_options(vanedb_cpp PRIVATE
-    $<$<CXX_COMPILER_ID:MSVC>:/W4 /arch:AVX2>
-    $<$<AND:$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>,$<BOOL:${VANEDB_X86_64}>>:-mavx2 -mfma>
-  )
+  vanedb_use_runtime_dispatch(vanedb_cpp)
   install(TARGETS vanedb_cpp
     LIBRARY DESTINATION .
     RUNTIME DESTINATION .

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -71,6 +71,33 @@ index.add(1, np.random.rand(768).astype(np.float32))
 ids, distances = index.search(query, 10)
 ```
 
+### Python wheel CPU support
+
+Generic x86-64 wheels target the baseline x86-64 instruction set (SSE2), not
+AVX2. The extension and its dispatcher are compiled for that baseline;
+AVX2/FMA distance kernels live in a separate object with cross-object LTO
+disabled. They are selected only when CPUID advertises AVX2 and FMA and the OS
+has enabled saving both XMM and YMM register state. Other x86-64 CPUs use the
+scalar kernel; arm64 wheels use NEON. Python and NumPy distributions have their
+own CPU requirements: the complete application must also meet those. CI checks
+the module's baseline import separately and uses no-AVX Nehalem for full NumPy
+search tests, not a claim that every NumPy wheel works on an SSE2-only CPU.
+
+```python
+import vanedb_cpp
+print(vanedb_cpp.simd_backend())  # "scalar", "avx2_fma", or "neon"
+```
+
+Both PR CI and the release artifact gate install the already-built Linux wheel
+and execute its Python tests under QEMU with baseline, AVX-only, AVX2-without-FMA,
+and AVX2/FMA CPU profiles. CPU compatibility does not override the Python/OS
+requirements encoded in wheel tags. Publishing still requires explicit approval.
+
+Header-only C++ consumers and the C API benchmark harness retain their existing
+compile-time specialization/inlining. When building those with `-mavx2 -mfma`
+or `/arch:AVX2`, the resulting binary still requires a suitable CPU; the portable
+runtime dispatcher described above is enabled for the Python distribution.
+
 ## Build
 
 ```bash

--- a/cpp/python/vanedb.cpp
+++ b/cpp/python/vanedb.cpp
@@ -2,6 +2,10 @@
 #include <pybind11/stl.h>
 #include <pybind11/numpy.h>
 
+#if defined(__AVX__) || defined(__AVX2__) || defined(__FMA__)
+#error "The Python extension must be compiled for baseline x86-64"
+#endif
+
 #include "core/hnsw_index.h"
 #include "core/vector_store.h"
 #include "core/mmap_vector_store.h"
@@ -18,6 +22,9 @@ PYBIND11_MODULE(vanedb_cpp, m) {
     m.attr("VERSION_MAJOR") = VERSION_MAJOR;
     m.attr("VERSION_MINOR") = VERSION_MINOR;
     m.attr("VERSION_PATCH") = VERSION_PATCH;
+
+    m.def("simd_backend", []() { return detail::runtime_kernels().name; },
+          "Active distance backend: scalar, neon, or avx2_fma (CPU/OS checked).");
 
     py::enum_<DistanceMetric>(m, "DistanceMetric")
         .value("L2", DistanceMetric::L2)

--- a/cpp/src/core/cpu_features.h
+++ b/cpp/src/core/cpu_features.h
@@ -1,0 +1,23 @@
+// VaneDB - Copyright (c) 2025 Anton Tsvetkov - MIT License
+#pragma once
+#include <cstdint>
+
+namespace vanedb::detail {
+
+// CPUID.1:ECX: FMA, XSAVE, OSXSAVE, AVX. CPUID.7.0:EBX: AVX2.
+// OSXSAVE alone is insufficient: XCR0 must enable both XMM and YMM state.
+inline constexpr uint32_t avx_prerequisites =
+    (1u << 12) | (1u << 26) | (1u << 27) | (1u << 28);
+
+[[nodiscard]] constexpr bool can_read_avx_state(uint32_t leaf1_ecx) noexcept {
+  return (leaf1_ecx & avx_prerequisites) == avx_prerequisites;
+}
+
+[[nodiscard]] constexpr bool supports_avx2_fma(uint32_t leaf1_ecx,
+                                             uint32_t leaf7_ebx,
+                                             uint64_t xcr0) noexcept {
+  return can_read_avx_state(leaf1_ecx) && (leaf7_ebx & (1u << 5)) != 0 &&
+         (xcr0 & 0x6) == 0x6;
+}
+
+} // namespace vanedb::detail

--- a/cpp/src/core/distance.h
+++ b/cpp/src/core/distance.h
@@ -1,204 +1,39 @@
 // VaneDB - Copyright (c) 2025 Anton Tsvetkov - MIT License
 #pragma once
-#include <algorithm>
-#include <cassert>
-#include <cmath>
-#include <cstddef>
 
-#if defined(__ARM_NEON) || defined(__aarch64__)
-#include <arm_neon.h>
-#define VANE_ARM_NEON
-#elif defined(__AVX2__)
-#include <immintrin.h>
-#define VANE_AVX2
-#endif
-
-#if defined(_MSC_VER)
-#define RESTRICT __restrict
+#ifdef VANEDB_RUNTIME_DISPATCH
+#include "distance_runtime.h"
 #else
-#define RESTRICT __restrict__
+#include "distance_kernels.h"
 #endif
 
 namespace vanedb {
 
-// Below this denominator (||a|| · ||b||) the vectors are treated as orthogonal.
-
-#ifdef VANE_ARM_NEON
-[[nodiscard]] inline float hsum(float32x4_t v) noexcept {
-#if defined(__aarch64__)
-  return vaddvq_f32(v);
+// Header-only consumers retain compile-time specialization and inlining.
+// Distributable Python wheels instead select an isolated kernel object once,
+// after checking CPU features AND the OS's saved AVX register state.
+[[nodiscard]] inline float l2_sq(const float* a, const float* b, size_t n) noexcept {
+#ifdef VANEDB_RUNTIME_DISPATCH
+  return detail::runtime_kernels().l2(a, b, n);
 #else
-  float32x2_t r = vadd_f32(vget_low_f32(v), vget_high_f32(v));
-  return vget_lane_f32(vpadd_f32(r, r), 0);
+  return detail::compiled::l2_sq(a, b, n);
 #endif
 }
+
+[[nodiscard]] inline float dot_product(const float* a, const float* b, size_t n) noexcept {
+#ifdef VANEDB_RUNTIME_DISPATCH
+  return detail::runtime_kernels().dot(a, b, n);
+#else
+  return detail::compiled::dot_product(a, b, n);
 #endif
-
-#ifdef VANE_AVX2
-[[nodiscard]] inline float hsum(__m256 v) noexcept {
-  __m128 lo = _mm256_castps256_ps128(v);
-  __m128 hi = _mm256_extractf128_ps(v, 1);
-  lo = _mm_add_ps(lo, hi);
-  __m128 shuf = _mm_movehdup_ps(lo);
-  lo = _mm_add_ps(lo, shuf);
-  return _mm_cvtss_f32(_mm_add_ss(lo, _mm_movehl_ps(shuf, lo)));
-}
-#endif
-
-[[nodiscard]] inline float l2_sq(const float* RESTRICT a, const float* RESTRICT b, size_t n) noexcept {
-  assert(a && b);
-  float sum = 0.0f;
-  size_t i = 0;
-
-#ifdef VANE_ARM_NEON
-  // Four independent accumulators hide the fused multiply-add latency
-  // (~4 cycles); a single-accumulator loop is latency-bound at one vector
-  // per FMA-latency regardless of ALU width.
-  float32x4_t acc0 = vdupq_n_f32(0.0f), acc1 = acc0, acc2 = acc0, acc3 = acc0;
-  for (; i + 16 <= n; i += 16) {
-    float32x4_t d0 = vsubq_f32(vld1q_f32(a + i), vld1q_f32(b + i));
-    float32x4_t d1 = vsubq_f32(vld1q_f32(a + i + 4), vld1q_f32(b + i + 4));
-    float32x4_t d2 = vsubq_f32(vld1q_f32(a + i + 8), vld1q_f32(b + i + 8));
-    float32x4_t d3 = vsubq_f32(vld1q_f32(a + i + 12), vld1q_f32(b + i + 12));
-    acc0 = vmlaq_f32(acc0, d0, d0);
-    acc1 = vmlaq_f32(acc1, d1, d1);
-    acc2 = vmlaq_f32(acc2, d2, d2);
-    acc3 = vmlaq_f32(acc3, d3, d3);
-  }
-  float32x4_t acc = vaddq_f32(vaddq_f32(acc0, acc1), vaddq_f32(acc2, acc3));
-  for (; i + 4 <= n; i += 4) {
-    float32x4_t d = vsubq_f32(vld1q_f32(a + i), vld1q_f32(b + i));
-    acc = vmlaq_f32(acc, d, d);
-  }
-  sum = hsum(acc);
-#elif defined(VANE_AVX2)
-  __m256 acc0 = _mm256_setzero_ps(), acc1 = _mm256_setzero_ps();
-  __m256 acc2 = _mm256_setzero_ps(), acc3 = _mm256_setzero_ps();
-  for (; i + 32 <= n; i += 32) {
-    __m256 d0 = _mm256_sub_ps(_mm256_loadu_ps(a + i), _mm256_loadu_ps(b + i));
-    __m256 d1 = _mm256_sub_ps(_mm256_loadu_ps(a + i + 8), _mm256_loadu_ps(b + i + 8));
-    __m256 d2 = _mm256_sub_ps(_mm256_loadu_ps(a + i + 16), _mm256_loadu_ps(b + i + 16));
-    __m256 d3 = _mm256_sub_ps(_mm256_loadu_ps(a + i + 24), _mm256_loadu_ps(b + i + 24));
-    acc0 = _mm256_fmadd_ps(d0, d0, acc0);
-    acc1 = _mm256_fmadd_ps(d1, d1, acc1);
-    acc2 = _mm256_fmadd_ps(d2, d2, acc2);
-    acc3 = _mm256_fmadd_ps(d3, d3, acc3);
-  }
-  __m256 acc = _mm256_add_ps(_mm256_add_ps(acc0, acc1), _mm256_add_ps(acc2, acc3));
-  for (; i + 8 <= n; i += 8) {
-    __m256 d = _mm256_sub_ps(_mm256_loadu_ps(a + i), _mm256_loadu_ps(b + i));
-    acc = _mm256_fmadd_ps(d, d, acc);
-  }
-  sum = hsum(acc);
-#endif
-
-  for (; i < n; ++i) {
-    float d = a[i] - b[i];
-    sum += d * d;
-  }
-  return sum;
 }
 
-[[nodiscard]] inline float dot_product(const float* RESTRICT a, const float* RESTRICT b, size_t n) noexcept {
-  assert(a && b);
-  float sum = 0.0f;
-  size_t i = 0;
-
-#ifdef VANE_ARM_NEON
-  // Same latency-hiding unroll as l2_sq.
-  float32x4_t acc0 = vdupq_n_f32(0.0f), acc1 = acc0, acc2 = acc0, acc3 = acc0;
-  for (; i + 16 <= n; i += 16) {
-    acc0 = vmlaq_f32(acc0, vld1q_f32(a + i), vld1q_f32(b + i));
-    acc1 = vmlaq_f32(acc1, vld1q_f32(a + i + 4), vld1q_f32(b + i + 4));
-    acc2 = vmlaq_f32(acc2, vld1q_f32(a + i + 8), vld1q_f32(b + i + 8));
-    acc3 = vmlaq_f32(acc3, vld1q_f32(a + i + 12), vld1q_f32(b + i + 12));
-  }
-  float32x4_t acc = vaddq_f32(vaddq_f32(acc0, acc1), vaddq_f32(acc2, acc3));
-  for (; i + 4 <= n; i += 4)
-    acc = vmlaq_f32(acc, vld1q_f32(a + i), vld1q_f32(b + i));
-  sum = hsum(acc);
-#elif defined(VANE_AVX2)
-  __m256 acc0 = _mm256_setzero_ps(), acc1 = _mm256_setzero_ps();
-  __m256 acc2 = _mm256_setzero_ps(), acc3 = _mm256_setzero_ps();
-  for (; i + 32 <= n; i += 32) {
-    acc0 = _mm256_fmadd_ps(_mm256_loadu_ps(a + i), _mm256_loadu_ps(b + i), acc0);
-    acc1 = _mm256_fmadd_ps(_mm256_loadu_ps(a + i + 8), _mm256_loadu_ps(b + i + 8), acc1);
-    acc2 = _mm256_fmadd_ps(_mm256_loadu_ps(a + i + 16), _mm256_loadu_ps(b + i + 16), acc2);
-    acc3 = _mm256_fmadd_ps(_mm256_loadu_ps(a + i + 24), _mm256_loadu_ps(b + i + 24), acc3);
-  }
-  __m256 acc = _mm256_add_ps(_mm256_add_ps(acc0, acc1), _mm256_add_ps(acc2, acc3));
-  for (; i + 8 <= n; i += 8)
-    acc = _mm256_fmadd_ps(_mm256_loadu_ps(a + i), _mm256_loadu_ps(b + i), acc);
-  sum = hsum(acc);
+[[nodiscard]] inline float cosine_distance(const float* a, const float* b, size_t n) noexcept {
+#ifdef VANEDB_RUNTIME_DISPATCH
+  return detail::runtime_kernels().cosine(a, b, n);
+#else
+  return detail::compiled::cosine_distance(a, b, n);
 #endif
-
-  for (; i < n; ++i)
-    sum += a[i] * b[i];
-  return sum;
-}
-
-[[nodiscard]] inline float cosine_distance(const float* RESTRICT a, const float* RESTRICT b, size_t n) noexcept {
-  assert(a && b);
-  float dot = 0.0f, na = 0.0f, nb = 0.0f;
-  size_t i = 0;
-
-#ifdef VANE_ARM_NEON
-  // Two-way unroll on top of the three naturally independent chains.
-  float32x4_t vdot0 = vdupq_n_f32(0.0f), vna0 = vdot0, vnb0 = vdot0;
-  float32x4_t vdot1 = vdot0, vna1 = vdot0, vnb1 = vdot0;
-  for (; i + 8 <= n; i += 8) {
-    float32x4_t va0 = vld1q_f32(a + i), vb0 = vld1q_f32(b + i);
-    float32x4_t va1 = vld1q_f32(a + i + 4), vb1 = vld1q_f32(b + i + 4);
-    vdot0 = vmlaq_f32(vdot0, va0, vb0);
-    vna0 = vmlaq_f32(vna0, va0, va0);
-    vnb0 = vmlaq_f32(vnb0, vb0, vb0);
-    vdot1 = vmlaq_f32(vdot1, va1, vb1);
-    vna1 = vmlaq_f32(vna1, va1, va1);
-    vnb1 = vmlaq_f32(vnb1, vb1, vb1);
-  }
-  float32x4_t vdot = vaddq_f32(vdot0, vdot1);
-  float32x4_t vna = vaddq_f32(vna0, vna1);
-  float32x4_t vnb = vaddq_f32(vnb0, vnb1);
-  for (; i + 4 <= n; i += 4) {
-    float32x4_t va = vld1q_f32(a + i), vb = vld1q_f32(b + i);
-    vdot = vmlaq_f32(vdot, va, vb);
-    vna = vmlaq_f32(vna, va, va);
-    vnb = vmlaq_f32(vnb, vb, vb);
-  }
-  dot = hsum(vdot); na = hsum(vna); nb = hsum(vnb);
-#elif defined(VANE_AVX2)
-  __m256 vdot = _mm256_setzero_ps(), vna = _mm256_setzero_ps(), vnb = _mm256_setzero_ps();
-  for (; i + 8 <= n; i += 8) {
-    __m256 va = _mm256_loadu_ps(a + i), vb = _mm256_loadu_ps(b + i);
-    vdot = _mm256_fmadd_ps(va, vb, vdot);
-    vna = _mm256_fmadd_ps(va, va, vna);
-    vnb = _mm256_fmadd_ps(vb, vb, vnb);
-  }
-  dot = hsum(vdot); na = hsum(vna); nb = hsum(vnb);
-#endif
-
-  for (; i < n; ++i) {
-    dot += a[i] * b[i];
-    na += a[i] * a[i];
-    nb += b[i] * b[i];
-  }
-
-  // Normalise by each vector's own norm. `na * nb` grows with the fourth
-  // power of magnitude, so a fixed epsilon on that product classified ordinary
-  // small vectors as zero and overflowed to infinity for large ones — both
-  // returned 1.0 for identical inputs (vanedb#40 / vanedb-cpp#36).
-  //
-  // Zero-vector policy, shared with the Rust engine: a vector is zero only
-  // when its own squared norm is zero. It has no direction, so its cosine
-  // distance to anything, including itself, is 1.0.
-  // Multiplying the roots rather than rooting the product keeps the
-  // denominator in range for both tiny and huge vectors. A vector with no
-  // usable direction — zero, or a squared norm that overflowed float — is
-  // 1.0 away from everything, including itself.
-  float denom = sqrtf(na) * sqrtf(nb);
-  if (!(denom > 0.0f && std::isfinite(denom))) return 1.0f;
-  float sim = dot / denom;
-  return 1.0f - std::clamp(sim, -1.0f, 1.0f);
 }
 
 } // namespace vanedb

--- a/cpp/src/core/distance_kernels.h
+++ b/cpp/src/core/distance_kernels.h
@@ -1,0 +1,220 @@
+// VaneDB - Copyright (c) 2025 Anton Tsvetkov - MIT License
+#pragma once
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+
+#if defined(__ARM_NEON) || defined(__aarch64__)
+#include <arm_neon.h>
+#define VANE_ARM_NEON
+#elif defined(__AVX2__) && (defined(__FMA__) || defined(_MSC_VER))
+#include <immintrin.h>
+#define VANE_AVX2
+#endif
+
+#if defined(_MSC_VER)
+#define RESTRICT __restrict
+#else
+#define RESTRICT __restrict__
+#endif
+
+// ISA-specific namespaces keep the inline definitions ODR-safe when baseline
+// and accelerated objects are linked into the same Python extension.
+#ifdef VANE_ARM_NEON
+namespace vanedb::detail::neon {
+#elif defined(VANE_AVX2)
+namespace vanedb::detail::avx2_fma {
+#else
+namespace vanedb::detail::scalar {
+#endif
+
+#ifdef VANE_ARM_NEON
+[[nodiscard]] inline float hsum(float32x4_t v) noexcept {
+#if defined(__aarch64__)
+  return vaddvq_f32(v);
+#else
+  float32x2_t r = vadd_f32(vget_low_f32(v), vget_high_f32(v));
+  return vget_lane_f32(vpadd_f32(r, r), 0);
+#endif
+}
+#endif
+
+#ifdef VANE_AVX2
+[[nodiscard]] inline float hsum(__m256 v) noexcept {
+  __m128 lo = _mm256_castps256_ps128(v);
+  __m128 hi = _mm256_extractf128_ps(v, 1);
+  lo = _mm_add_ps(lo, hi);
+  __m128 shuf = _mm_movehdup_ps(lo);
+  lo = _mm_add_ps(lo, shuf);
+  return _mm_cvtss_f32(_mm_add_ss(lo, _mm_movehl_ps(shuf, lo)));
+}
+#endif
+
+[[nodiscard]] inline float l2_sq(const float* RESTRICT a, const float* RESTRICT b, size_t n) noexcept {
+  assert(a && b);
+  float sum = 0.0f;
+  size_t i = 0;
+
+#ifdef VANE_ARM_NEON
+  // Four independent accumulators hide the fused multiply-add latency
+  // (~4 cycles); a single-accumulator loop is latency-bound at one vector
+  // per FMA-latency regardless of ALU width.
+  float32x4_t acc0 = vdupq_n_f32(0.0f), acc1 = acc0, acc2 = acc0, acc3 = acc0;
+  for (; i + 16 <= n; i += 16) {
+    float32x4_t d0 = vsubq_f32(vld1q_f32(a + i), vld1q_f32(b + i));
+    float32x4_t d1 = vsubq_f32(vld1q_f32(a + i + 4), vld1q_f32(b + i + 4));
+    float32x4_t d2 = vsubq_f32(vld1q_f32(a + i + 8), vld1q_f32(b + i + 8));
+    float32x4_t d3 = vsubq_f32(vld1q_f32(a + i + 12), vld1q_f32(b + i + 12));
+    acc0 = vmlaq_f32(acc0, d0, d0);
+    acc1 = vmlaq_f32(acc1, d1, d1);
+    acc2 = vmlaq_f32(acc2, d2, d2);
+    acc3 = vmlaq_f32(acc3, d3, d3);
+  }
+  float32x4_t acc = vaddq_f32(vaddq_f32(acc0, acc1), vaddq_f32(acc2, acc3));
+  for (; i + 4 <= n; i += 4) {
+    float32x4_t d = vsubq_f32(vld1q_f32(a + i), vld1q_f32(b + i));
+    acc = vmlaq_f32(acc, d, d);
+  }
+  sum = hsum(acc);
+#elif defined(VANE_AVX2)
+  __m256 acc0 = _mm256_setzero_ps(), acc1 = _mm256_setzero_ps();
+  __m256 acc2 = _mm256_setzero_ps(), acc3 = _mm256_setzero_ps();
+  for (; i + 32 <= n; i += 32) {
+    __m256 d0 = _mm256_sub_ps(_mm256_loadu_ps(a + i), _mm256_loadu_ps(b + i));
+    __m256 d1 = _mm256_sub_ps(_mm256_loadu_ps(a + i + 8), _mm256_loadu_ps(b + i + 8));
+    __m256 d2 = _mm256_sub_ps(_mm256_loadu_ps(a + i + 16), _mm256_loadu_ps(b + i + 16));
+    __m256 d3 = _mm256_sub_ps(_mm256_loadu_ps(a + i + 24), _mm256_loadu_ps(b + i + 24));
+    acc0 = _mm256_fmadd_ps(d0, d0, acc0);
+    acc1 = _mm256_fmadd_ps(d1, d1, acc1);
+    acc2 = _mm256_fmadd_ps(d2, d2, acc2);
+    acc3 = _mm256_fmadd_ps(d3, d3, acc3);
+  }
+  __m256 acc = _mm256_add_ps(_mm256_add_ps(acc0, acc1), _mm256_add_ps(acc2, acc3));
+  for (; i + 8 <= n; i += 8) {
+    __m256 d = _mm256_sub_ps(_mm256_loadu_ps(a + i), _mm256_loadu_ps(b + i));
+    acc = _mm256_fmadd_ps(d, d, acc);
+  }
+  sum = hsum(acc);
+#endif
+
+  for (; i < n; ++i) {
+    float d = a[i] - b[i];
+    sum += d * d;
+  }
+  return sum;
+}
+
+[[nodiscard]] inline float dot_product(const float* RESTRICT a, const float* RESTRICT b, size_t n) noexcept {
+  assert(a && b);
+  float sum = 0.0f;
+  size_t i = 0;
+
+#ifdef VANE_ARM_NEON
+  // Same latency-hiding unroll as l2_sq.
+  float32x4_t acc0 = vdupq_n_f32(0.0f), acc1 = acc0, acc2 = acc0, acc3 = acc0;
+  for (; i + 16 <= n; i += 16) {
+    acc0 = vmlaq_f32(acc0, vld1q_f32(a + i), vld1q_f32(b + i));
+    acc1 = vmlaq_f32(acc1, vld1q_f32(a + i + 4), vld1q_f32(b + i + 4));
+    acc2 = vmlaq_f32(acc2, vld1q_f32(a + i + 8), vld1q_f32(b + i + 8));
+    acc3 = vmlaq_f32(acc3, vld1q_f32(a + i + 12), vld1q_f32(b + i + 12));
+  }
+  float32x4_t acc = vaddq_f32(vaddq_f32(acc0, acc1), vaddq_f32(acc2, acc3));
+  for (; i + 4 <= n; i += 4)
+    acc = vmlaq_f32(acc, vld1q_f32(a + i), vld1q_f32(b + i));
+  sum = hsum(acc);
+#elif defined(VANE_AVX2)
+  __m256 acc0 = _mm256_setzero_ps(), acc1 = _mm256_setzero_ps();
+  __m256 acc2 = _mm256_setzero_ps(), acc3 = _mm256_setzero_ps();
+  for (; i + 32 <= n; i += 32) {
+    acc0 = _mm256_fmadd_ps(_mm256_loadu_ps(a + i), _mm256_loadu_ps(b + i), acc0);
+    acc1 = _mm256_fmadd_ps(_mm256_loadu_ps(a + i + 8), _mm256_loadu_ps(b + i + 8), acc1);
+    acc2 = _mm256_fmadd_ps(_mm256_loadu_ps(a + i + 16), _mm256_loadu_ps(b + i + 16), acc2);
+    acc3 = _mm256_fmadd_ps(_mm256_loadu_ps(a + i + 24), _mm256_loadu_ps(b + i + 24), acc3);
+  }
+  __m256 acc = _mm256_add_ps(_mm256_add_ps(acc0, acc1), _mm256_add_ps(acc2, acc3));
+  for (; i + 8 <= n; i += 8)
+    acc = _mm256_fmadd_ps(_mm256_loadu_ps(a + i), _mm256_loadu_ps(b + i), acc);
+  sum = hsum(acc);
+#endif
+
+  for (; i < n; ++i)
+    sum += a[i] * b[i];
+  return sum;
+}
+
+[[nodiscard]] inline float cosine_distance(const float* RESTRICT a, const float* RESTRICT b, size_t n) noexcept {
+  assert(a && b);
+  float dot = 0.0f, na = 0.0f, nb = 0.0f;
+  size_t i = 0;
+
+#ifdef VANE_ARM_NEON
+  // Two-way unroll on top of the three naturally independent chains.
+  float32x4_t vdot0 = vdupq_n_f32(0.0f), vna0 = vdot0, vnb0 = vdot0;
+  float32x4_t vdot1 = vdot0, vna1 = vdot0, vnb1 = vdot0;
+  for (; i + 8 <= n; i += 8) {
+    float32x4_t va0 = vld1q_f32(a + i), vb0 = vld1q_f32(b + i);
+    float32x4_t va1 = vld1q_f32(a + i + 4), vb1 = vld1q_f32(b + i + 4);
+    vdot0 = vmlaq_f32(vdot0, va0, vb0);
+    vna0 = vmlaq_f32(vna0, va0, va0);
+    vnb0 = vmlaq_f32(vnb0, vb0, vb0);
+    vdot1 = vmlaq_f32(vdot1, va1, vb1);
+    vna1 = vmlaq_f32(vna1, va1, va1);
+    vnb1 = vmlaq_f32(vnb1, vb1, vb1);
+  }
+  float32x4_t vdot = vaddq_f32(vdot0, vdot1);
+  float32x4_t vna = vaddq_f32(vna0, vna1);
+  float32x4_t vnb = vaddq_f32(vnb0, vnb1);
+  for (; i + 4 <= n; i += 4) {
+    float32x4_t va = vld1q_f32(a + i), vb = vld1q_f32(b + i);
+    vdot = vmlaq_f32(vdot, va, vb);
+    vna = vmlaq_f32(vna, va, va);
+    vnb = vmlaq_f32(vnb, vb, vb);
+  }
+  dot = hsum(vdot); na = hsum(vna); nb = hsum(vnb);
+#elif defined(VANE_AVX2)
+  __m256 vdot = _mm256_setzero_ps(), vna = _mm256_setzero_ps(), vnb = _mm256_setzero_ps();
+  for (; i + 8 <= n; i += 8) {
+    __m256 va = _mm256_loadu_ps(a + i), vb = _mm256_loadu_ps(b + i);
+    vdot = _mm256_fmadd_ps(va, vb, vdot);
+    vna = _mm256_fmadd_ps(va, va, vna);
+    vnb = _mm256_fmadd_ps(vb, vb, vnb);
+  }
+  dot = hsum(vdot); na = hsum(vna); nb = hsum(vnb);
+#endif
+
+  for (; i < n; ++i) {
+    dot += a[i] * b[i];
+    na += a[i] * a[i];
+    nb += b[i] * b[i];
+  }
+
+  // Normalise by each vector's own norm. `na * nb` grows with the fourth
+  // power of magnitude, so a fixed epsilon on that product classified ordinary
+  // small vectors as zero and overflowed to infinity for large ones — both
+  // returned 1.0 for identical inputs (vanedb#40 / vanedb-cpp#36).
+  //
+  // Zero-vector policy, shared with the Rust engine: a vector is zero only
+  // when its own squared norm is zero. It has no direction, so its cosine
+  // distance to anything, including itself, is 1.0.
+  // Multiplying the roots rather than rooting the product keeps the
+  // denominator in range for both tiny and huge vectors. A vector with no
+  // usable direction — zero, or a squared norm that overflowed float — is
+  // 1.0 away from everything, including itself.
+  float denom = sqrtf(na) * sqrtf(nb);
+  if (!(denom > 0.0f && std::isfinite(denom))) return 1.0f;
+  float sim = dot / denom;
+  return 1.0f - std::clamp(sim, -1.0f, 1.0f);
+}
+
+} // namespace vanedb::detail::<compiled ISA>
+
+namespace vanedb::detail {
+#ifdef VANE_ARM_NEON
+namespace compiled = neon;
+#elif defined(VANE_AVX2)
+namespace compiled = avx2_fma;
+#else
+namespace compiled = scalar;
+#endif
+} // namespace vanedb::detail

--- a/cpp/src/core/distance_runtime.h
+++ b/cpp/src/core/distance_runtime.h
@@ -1,0 +1,21 @@
+// VaneDB - Copyright (c) 2025 Anton Tsvetkov - MIT License
+#pragma once
+#include <cstddef>
+
+namespace vanedb::detail {
+
+using DistanceKernel = float (*)(const float*, const float*, size_t) noexcept;
+
+struct DistanceKernels {
+  DistanceKernel l2;
+  DistanceKernel dot;
+  DistanceKernel cosine;
+  const char* name;
+};
+
+// The false branch lets tests compare the baseline with the selected backend.
+// Passing true never forces an unsupported ISA.
+[[nodiscard]] const DistanceKernels& select_kernels(bool allow_avx2) noexcept;
+[[nodiscard]] const DistanceKernels& runtime_kernels() noexcept;
+
+} // namespace vanedb::detail

--- a/cpp/src/core/distance_strategy.h
+++ b/cpp/src/core/distance_strategy.h
@@ -17,8 +17,9 @@ using HNSWDistanceMetric
 // Default-constructibility is required for MMapVectorStore which assigns
 // dist_ in its constructor body (after parsing metric/dim from the file).
 //
-// operator() dispatches via switch (not a function pointer) so the SIMD
-// distance functions inline into the hot loop. Don't refactor this back.
+// Header-only operator() dispatches via switch so the SIMD distance functions
+// inline into the hot loop. Wheels use the same metric switch with a separate
+// runtime ISA dispatcher; do not impose that indirection on header-only users.
 class DistanceComputer {
 public:
   DistanceComputer() noexcept = default;

--- a/cpp/src/distance_avx2.cpp
+++ b/cpp/src/distance_avx2.cpp
@@ -1,0 +1,17 @@
+// VaneDB - Copyright (c) 2025 Anton Tsvetkov - MIT License
+#include "core/distance_kernels.h"
+#include "core/distance_runtime.h"
+
+#ifndef VANE_AVX2
+#error "Compile only this object with AVX2 and FMA enabled"
+#endif
+
+namespace vanedb::detail {
+
+const DistanceKernels& avx2_kernels() noexcept {
+  static const DistanceKernels kernels = {
+      avx2_fma::l2_sq, avx2_fma::dot_product, avx2_fma::cosine_distance, "avx2_fma"};
+  return kernels;
+}
+
+} // namespace vanedb::detail

--- a/cpp/src/distance_runtime.cpp
+++ b/cpp/src/distance_runtime.cpp
@@ -1,0 +1,78 @@
+// VaneDB - Copyright (c) 2025 Anton Tsvetkov - MIT License
+#include "core/cpu_features.h"
+#include "core/distance_kernels.h"
+#include "core/distance_runtime.h"
+
+#if defined(__AVX__) || defined(__AVX2__) || defined(__FMA__)
+#error "The runtime dispatcher must be compiled for baseline x86-64"
+#endif
+
+#ifdef VANEDB_HAS_AVX2_OBJECT
+#if defined(_MSC_VER)
+#include <intrin.h>
+#else
+#include <cpuid.h>
+#endif
+#endif
+
+namespace vanedb::detail {
+
+#ifdef VANEDB_HAS_AVX2_OBJECT
+// Defined in an AVX2/FMA object that is never compiled with LTO. Calling this
+// function is itself forbidden until the CPU/OS check has succeeded.
+const DistanceKernels& avx2_kernels() noexcept;
+
+static bool cpu_has_avx2_fma() noexcept {
+  uint32_t leaf1_ecx, leaf7_ebx;
+  uint64_t xcr0;
+#if defined(_MSC_VER)
+  int regs[4];
+  __cpuid(regs, 0);
+  if (regs[0] < 7) return false;
+  __cpuidex(regs, 1, 0);
+  leaf1_ecx = static_cast<uint32_t>(regs[2]);
+  if (!can_read_avx_state(leaf1_ecx)) return false;
+  __cpuidex(regs, 7, 0);
+  leaf7_ebx = static_cast<uint32_t>(regs[1]);
+  xcr0 = _xgetbv(0);
+#else
+  if (__get_cpuid_max(0, nullptr) < 7) return false;
+  unsigned int eax, ebx, ecx, edx;
+  __cpuid_count(1, 0, eax, ebx, ecx, edx);
+  leaf1_ecx = ecx;
+  if (!can_read_avx_state(leaf1_ecx)) return false;
+  __cpuid_count(7, 0, eax, ebx, ecx, edx);
+  leaf7_ebx = ebx;
+  // XGETBV is safe only after checking XSAVE + OSXSAVE above; unlike the
+  // intrinsic, inline assembly does not require -mxsave on the baseline TU.
+  __asm__ volatile("xgetbv" : "=a"(eax), "=d"(edx) : "c"(0));
+  xcr0 = (static_cast<uint64_t>(edx) << 32) | eax;
+#endif
+  return supports_avx2_fma(leaf1_ecx, leaf7_ebx, xcr0);
+}
+#endif
+
+const DistanceKernels& select_kernels(bool allow_avx2) noexcept {
+  static const DistanceKernels baseline = {
+      compiled::l2_sq, compiled::dot_product, compiled::cosine_distance,
+#ifdef VANE_ARM_NEON
+      "neon"
+#else
+      "scalar"
+#endif
+  };
+#ifdef VANEDB_HAS_AVX2_OBJECT
+  if (allow_avx2 && cpu_has_avx2_fma()) return avx2_kernels();
+#else
+  (void)allow_avx2;
+#endif
+  return baseline;
+}
+
+const DistanceKernels& runtime_kernels() noexcept {
+  // C++ guarantees thread-safe initialization. No CPUID on the hot path.
+  static const DistanceKernels& kernels = select_kernels(true);
+  return kernels;
+}
+
+} // namespace vanedb::detail

--- a/cpp/tests/run_wheel_cpu_checks.sh
+++ b/cpp/tests/run_wheel_cpu_checks.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Execute the installed wheel, not a rebuild, under each emulated CPU profile.
+set -euo pipefail
+
+wheel_python="${1:?Pass the absolute path to the Python containing the wheel}"
+test_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
+
+# NumPy's own binary CPU baseline can exceed SSE2. Check our module's import
+# without NumPy on qemu64, then exercise the complete stack on no-AVX Nehalem.
+qemu-x86_64 -cpu qemu64 "$wheel_python" -I -c \
+  'import vanedb_cpp as v; assert v.simd_backend() == "scalar"; print("baseline module import: scalar")'
+
+for cpu_profile in 'Nehalem' 'SandyBridge' 'Haswell,-fma' 'Haswell'; do
+  expected_backend=scalar
+  if [[ "$cpu_profile" == Haswell ]]; then
+    expected_backend=avx2_fma
+  fi
+  export VANEDB_EXPECT_BACKEND="$expected_backend"
+  echo "CPU=$cpu_profile expected=$expected_backend"
+  qemu-x86_64 -cpu "$cpu_profile" "$wheel_python" -I -c \
+    'import os, vanedb_cpp as v; print(v.__file__, v.simd_backend()); assert v.simd_backend() == os.environ["VANEDB_EXPECT_BACKEND"]'
+  qemu-x86_64 -cpu "$cpu_profile" "$wheel_python" -I -m pytest \
+    -q -p no:cacheprovider "$test_directory/test_python_bindings.py"
+done

--- a/cpp/tests/test_python_bindings.py
+++ b/cpp/tests/test_python_bindings.py
@@ -28,6 +28,46 @@ def test_version():
     assert vanedb_cpp.VERSION_PATCH == 0
 
 
+def test_simd_backend():
+    import vanedb_cpp
+    backend = vanedb_cpp.simd_backend()
+    assert backend in {"scalar", "neon", "avx2_fma"}
+    # The QEMU acceptance job checks actual selection, not merely no crash.
+    expected = os.environ.get("VANEDB_EXPECT_BACKEND")
+    if expected:
+        assert backend == expected
+
+
+@pytest.mark.parametrize("dimension", [7, 8, 31, 32, 33, 128, 773])
+@pytest.mark.parametrize("metric", ["L2", "COSINE", "DOT"])
+def test_dispatched_search_matches_numpy(dimension, metric):
+    import vanedb_cpp
+    rng = np.random.default_rng(59)
+    vectors = rng.normal(size=(24, dimension)).astype(np.float32)
+    query = rng.normal(size=dimension).astype(np.float32)
+    index = vanedb_cpp.HNSWIndex(
+        dimension, getattr(vanedb_cpp.DistanceMetric, metric), max_elements=32
+    )
+    index.set_ef_search(64)
+    for i, vector in enumerate(vectors):
+        index.add(i + 1000, vector)
+    data, q = vectors.astype(np.float64), query.astype(np.float64)
+    # Avoid BLAS here: its vendor/model dispatch can assume FMA on a Haswell
+    # whose FMA flag a VM deliberately masks. This oracle tests our kernels,
+    # not OpenBLAS's separate CPU dispatch policy.
+    dot = np.sum(data * q, axis=1)
+    if metric == "L2":
+        distances = np.sum((data - q) ** 2, axis=1)
+    elif metric == "DOT":
+        distances = -dot
+    else:
+        distances = 1 - dot / (np.sqrt(np.sum(data * data, axis=1)) * np.sqrt(np.sum(q * q)))
+    expected = np.argsort(distances)[:5]
+    ids, actual = index.search(query, 5)
+    np.testing.assert_array_equal(ids, expected + 1000)
+    np.testing.assert_allclose(actual, distances[expected], rtol=2e-5, atol=2e-5)
+
+
 def test_distance_metrics():
     """Test that distance metric enum values are accessible."""
     import vanedb_cpp

--- a/cpp/tests/test_runtime_distance.cpp
+++ b/cpp/tests/test_runtime_distance.cpp
@@ -1,0 +1,70 @@
+#include "core/cpu_features.h"
+#include "core/distance.h"
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <cmath>
+#include <string_view>
+#include <vector>
+
+using Catch::Approx;
+
+TEST_CASE("runtime ISA selection requires CPU and OS support", "[distance][runtime]") {
+  using namespace vanedb::detail;
+  constexpr uint32_t avx2 = 1u << 5;
+  REQUIRE(supports_avx2_fma(avx_prerequisites, avx2, 0x6));
+  for (unsigned bit : {12u, 26u, 27u, 28u}) {
+    INFO("missing CPUID.1:ECX bit " << bit);
+    const auto missing = avx_prerequisites & ~(1u << bit);
+    REQUIRE_FALSE(can_read_avx_state(missing));
+    REQUIRE_FALSE(supports_avx2_fma(missing, avx2, 0x6));
+  }
+  REQUIRE_FALSE(supports_avx2_fma(avx_prerequisites, 0, 0x6));
+  for (uint64_t state : {0u, 0x2u, 0x4u}) {
+    INFO("XCR0=" << state);
+    REQUIRE_FALSE(supports_avx2_fma(avx_prerequisites, avx2, state));
+  }
+}
+
+TEST_CASE("runtime and baseline kernels match independent references", "[distance][runtime]") {
+  using namespace vanedb::detail;
+  const auto& baseline = select_kernels(false);
+  const auto& selected = runtime_kernels();
+  REQUIRE(std::string_view(baseline.name) != "avx2_fma");
+  REQUIRE(&selected == &runtime_kernels());
+  REQUIRE(&selected == &select_kernels(true));
+
+  for (size_t n : {1u, 7u, 8u, 9u, 16u, 31u, 32u, 33u, 127u, 768u, 773u, 1536u}) {
+    INFO("dimension=" << n << " backend=" << selected.name);
+    // Non-aligned pointers and tails exercise both vector and remainder loops.
+    std::vector<float> a(n + 1), b(n + 1);
+    double l2 = 0, dot = 0, na = 0, nb = 0;
+    for (size_t i = 1; i <= n; ++i) {
+      a[i] = static_cast<float>(std::sin(static_cast<double>(i)));
+      b[i] = static_cast<float>(std::cos(static_cast<double>(i)));
+      const double x = a[i], y = b[i];
+      l2 += (x - y) * (x - y);
+      dot += x * y;
+      na += x * x;
+      nb += y * y;
+    }
+    for (const auto* kernels : {&baseline, &selected}) {
+      REQUIRE(kernels->l2(a.data() + 1, b.data() + 1, n) == Approx(l2).epsilon(2e-5));
+      REQUIRE(kernels->dot(a.data() + 1, b.data() + 1, n) == Approx(dot).margin(2e-5));
+      REQUIRE(kernels->cosine(a.data() + 1, b.data() + 1, n) ==
+              Approx(1 - dot / (std::sqrt(na) * std::sqrt(nb))).margin(2e-5));
+    }
+    REQUIRE(vanedb::l2_sq(a.data() + 1, b.data() + 1, n) == Approx(l2).epsilon(2e-5));
+  }
+}
+
+TEST_CASE("runtime vector loops preserve cosine scaling", "[distance][runtime]") {
+  for (float scale : {1e-18f, 1e-9f, 1.0f, 1e9f, 1e18f}) {
+    std::vector<float> values(64, scale);
+    for (const auto* kernels : {&vanedb::detail::select_kernels(false),
+                               &vanedb::detail::runtime_kernels()}) {
+      INFO("scale=" << scale << " backend=" << kernels->name);
+      REQUIRE(kernels->cosine(values.data(), values.data(), values.size()) ==
+              Approx(0.0f).margin(2e-6));
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #59.

The Python extension is now compiled for baseline x86-64. AVX2/FMA distance
kernels live in a separate object compiled with ISA flags and **without LTO**.
The baseline dispatcher checks CPUID AVX2/FMA/XSAVE/OSXSAVE/AVX plus XCR0's XMM
and YMM bits before entering any accelerated code. Selection is cached once.
Arm64 retains NEON; header-only consumers and the benchmark C API retain their
compile-time specialization and inlining. Rust already performs runtime CPU
dispatch and needs no corresponding kernel change.

- Reuses the existing kernels in ISA-specific namespaces; no distance algorithm
  or persistence-format changes.
- Adds `vanedb_cpp.simd_backend()` for observable selection.
- Preserves every existing test and adds runtime-dispatch copies of the distance,
  cosine, and non-finite conformance suites, feature/OS-state tests, and 22 Python
  checks for backend selection and NumPy-reference search across SIMD tails.
- Adds a reusable CPU portability gate to both PR CI and the release workflow.
  It installs the **already-built artifact**, rather than building a different
  binary for each CPU, and checks scalar fallback and accelerated dispatch under
  QEMU. The release gate consumes the real manylinux artifact.
- Documents the extension's CPU baseline separately from Python/NumPy's own
  requirements. Publication remains manual and environment-protected.

## Executed acceptance evidence

Actual before/after Linux CPython 3.11 wheels were built and installed in a
disposable x86-64 container on the local ARM host (QEMU user-mode execution).
NumPy's import was separately verified on Nehalem before attributing the old
wheel's failure to VaneDB.

| Installed wheel / CPU | Backend | Result |
|---|---|---|
| Before fix / Nehalem (no AVX) | unconditional AVX2 | **SIGILL, exit 132** |
| Fixed / qemu64 | scalar | module import succeeds without NumPy |
| Fixed / Nehalem (no AVX) | scalar | **53/53 Python tests pass** |
| Fixed / SandyBridge (AVX, no AVX2/FMA) | scalar | **53/53 pass** |
| Fixed / Haswell with FMA masked out | scalar | **53/53 pass** |
| Fixed / Haswell (AVX2/FMA) | avx2_fma | **53/53 pass** |
| Fixed / macOS arm64, Python 3.14 | neon | **53/53 pass** |

Also passed locally:

- Release C++ suite + C API: **83/83 tests**.
- UBSan C++ suite: **82/82 tests**, halt-on-error enabled (C API not enabled in
  this sanitizer configuration).
- Cross-engine harness tests, clippy and all benchmark compilation with `--locked`.
- `actionlint` and `git diff --check`.

The recorded Linux compile commands show baseline flags on `python/vanedb.cpp`
and `distance_runtime.cpp`, and `-mavx2 -mfma -fno-lto` only on
`distance_avx2.cpp`. `-DNDEBUG` remains present in all three Release objects.

Local fixed Linux wheel SHA-256:
`a25d6988a42128222971a0916c5ae351360a525da850641ea05c1e46d343ec36`

Before-fix wheel SHA-256:
`bf2df59b9142345a2c13db8a348ae848eefba06a2db61c954adc41494df50222`

## Limits / deliberately unchanged

- Local Linux evidence uses a `linux_x86_64` wheel, not a release manylinux
  artifact. The wired release gate will test the latter on the next rehearsal.
- Windows/MSVC and the full hosted Python matrix are verified by PR CI, not
  claimed as locally executed.
- Current NumPy does not run on the minimal qemu64 model. Hence baseline module
  import and complete no-AVX/NumPy execution on Nehalem are separate tests.
- The reference distance calculations deliberately avoid BLAS: its independent
  Haswell dispatch can assume FMA even when a VM masks that feature. This does
  not disable VaneDB's feature detection or skip its search tests.
- The separately discovered C++ mmap NumPy writeability crash is **not fixed by
  this PR**. No merge, tag, release dispatch, or publication has been performed.
- No performance claims are made from emulated timings.
