### PR TITLE
fix(python): protect read-only mmap array views

### DIFF
--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -203,6 +203,17 @@ jobs:
       run: |
         python -I -c "import vanedb_cpp; print(vanedb_cpp.__file__)"
 
+    - name: Test minimum supported NumPy
+      if: matrix.python-version == '3.11'
+      shell: bash
+      # Keep this aligned with cpp/pyproject.toml. 1.24.2 is the first
+      # supported release whose fill() respects a read-only mmap view.
+      run: |
+        python -m pip install --only-binary=:all: numpy==1.24.2
+        python -m pip check
+        python -I -m pytest tests/test_python_bindings.py -v
+        python -m pip install --upgrade numpy
+
     - name: Run Python tests from installed wheel
       run: |
         python -m pytest tests/test_python_bindings.py -v

--- a/cpp/docs/GUIDE.md
+++ b/cpp/docs/GUIDE.md
@@ -164,7 +164,20 @@ builder.save("vectors.bin")
 
 mmap_store = vanedb.MMapVectorStore("vectors.bin")  # Instant load
 ids, dists = mmap_store.search(vec, 10)
+mapped = mmap_store.get(0)  # Read-only NumPy view; no vector copy
+editable = mapped.copy()   # Independent writable array, if needed
+editable[0] = 0.0          # Does not change the mapped vector or file
 ```
+
+`MMapVectorStore.get(id)` returns `None` for an unknown ID. Existing vectors
+are exposed as read-only NumPy views: assignment raises `ValueError`, and
+slices and memoryviews remain read-only. The array keeps the mapping alive
+even after the store variable is deleted. Use `.copy()` to obtain an editable
+array without changing the stored data.
+
+The C++ package requires NumPy 1.24.2 or newer: older 1.24 releases let
+`ndarray.fill()` bypass the read-only flag and crash on memory-mapped data
+([upstream fix](https://github.com/numpy/numpy/pull/22970)).
 
 ---
 

--- a/cpp/pyproject.toml
+++ b/cpp/pyproject.toml
@@ -9,7 +9,9 @@ authors = [
     {name = "Anton Tsvetkov"}
 ]
 keywords = ["vector", "database", "embedding", "hnsw", "similarity-search", "machine-learning"]
-dependencies = ["numpy>=1.24"]
+# NumPy 1.24.0/1.24.1 let ndarray.fill() write through read-only views.
+# 1.24.2 fixes this upstream (numpy/numpy#22970), which mmap safety requires.
+dependencies = ["numpy>=1.24.2"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",

--- a/cpp/python/vanedb.cpp
+++ b/cpp/python/vanedb.cpp
@@ -243,16 +243,21 @@ PYBIND11_MODULE(vanedb_cpp, m) {
                 if (ptr == nullptr) {
                     return py::none();
                 }
-                // Return a view into the mapped memory (zero-copy!)
-                return py::array_t<float>(
+                // Keep a zero-copy view and retain the mapping's owner.
+                auto view = py::array_t<float>(
                     {self.dimension()},
                     {sizeof(float)},
                     ptr,
                     py::cast(&self)  // Keep store alive while array exists
                 );
+                // A const pointer does not make a NumPy array read-only.
+                // Match the OS mapping protection before exposing any view.
+                view.attr("setflags")(py::arg("write") = false);
+                return view;
             },
             py::arg("id"),
-            "Gets a vector by ID (zero-copy from mmap), returns None if not found")
+            "Gets a read-only zero-copy vector from mmap, or None if not found. "
+            "The array keeps the mapping alive; use .copy() for an editable array.")
         .def("search", [](const MMapVectorStore& self, py::array_t<float, py::array::c_style | py::array::forcecast> query_array, size_t k) {
                 py::buffer_info buf = query_array.request();
                 if (buf.ndim != 1) {

--- a/cpp/tests/test_python_bindings.py
+++ b/cpp/tests/test_python_bindings.py
@@ -8,6 +8,11 @@ import pytest
 import numpy as np
 import tempfile
 import os
+import gc
+import subprocess
+import sys
+import textwrap
+import weakref
 
 
 def test_import():
@@ -461,6 +466,159 @@ def test_mmap_store_zero_copy_get(tmp_path):
 
     assert retrieved is not None
     np.testing.assert_array_almost_equal(retrieved, original)
+    assert retrieved.dtype == np.float32
+    assert retrieved.shape == (4,)
+    assert retrieved.strides == (original.itemsize,)
+    assert not retrieved.flags.owndata
+    assert retrieved.base is store
+    assert np.shares_memory(retrieved, store.get(42))
+
+
+def _mapped_vector(tmp_path):
+    """Keep ownership in the caller so lifetime tests can release the store."""
+    import vanedb_cpp
+
+    path = tmp_path / "readonly.bin"
+    original = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
+    builder = vanedb_cpp.MMapVectorStoreBuilder(dimension=4)
+    builder.add(42, original)
+    builder.save(str(path))
+    return path, original, vanedb_cpp.MMapVectorStore(str(path))
+
+
+@pytest.mark.parametrize("kind", ["direct", "slice", "asarray", "frombuffer"])
+def test_mmap_views_are_readonly(tmp_path, kind):
+    _, original, store = _mapped_vector(tmp_path)
+    mapped = store.get(42)
+    views = {
+        "direct": mapped,
+        "slice": mapped[::2],
+        "asarray": np.asarray(mapped),
+        "frombuffer": np.frombuffer(mapped, dtype=np.float32),
+    }
+    view = views[kind]
+    assert np.shares_memory(view, mapped)
+    assert not view.flags.writeable
+    assert memoryview(view).readonly
+    with pytest.raises(ValueError, match="WRITEABLE"):
+        view.setflags(write=True)
+    with pytest.raises(ValueError, match="WRITEABLE"):
+        view.flags.writeable = True
+    np.testing.assert_array_equal(store.get(42), original)
+
+
+@pytest.mark.parametrize("kind", ["array", "slice", "memoryview"])
+def test_mmap_views_keep_mapping_alive(tmp_path, kind):
+    path, original, store = _mapped_vector(tmp_path)
+    owner = weakref.ref(store)
+    mapped = store.get(42)
+    if kind == "slice":
+        escaped = mapped[::2]
+        expected = original[::2]
+    elif kind == "memoryview":
+        escaped = memoryview(mapped)
+        expected = original
+    else:
+        escaped = mapped
+        expected = original
+    del mapped, store
+    gc.collect()
+    assert owner() is not None
+    np.testing.assert_array_equal(escaped, expected)
+    if kind == "memoryview":
+        assert escaped.readonly
+    else:
+        assert not escaped.flags.writeable
+    del escaped
+    gc.collect()
+    assert owner() is None
+    # Windows also proves that the last view releases the mapped file handle.
+    path.unlink()
+
+
+def test_mmap_copy_is_independent_and_writable(tmp_path):
+    path, original, store = _mapped_vector(tmp_path)
+    before = path.read_bytes()
+    mapped = store.get(42)
+    editable = mapped.copy()
+    assert editable.flags.writeable
+    assert editable.flags.owndata
+    assert not np.shares_memory(editable, mapped)
+    editable[0] = 99.0
+    np.testing.assert_array_equal(mapped, original)
+    np.testing.assert_array_equal(store.get(42), original)
+    ids, distances = store.search(original, 1)
+    assert ids.tolist() == [42]
+    assert distances.tolist() == [0.0]
+    assert path.read_bytes() == before
+    del mapped, store
+    gc.collect()
+    assert editable[0] == 99.0
+
+
+def test_mmap_get_missing_id_returns_none(tmp_path):
+    _, _, store = _mapped_vector(tmp_path)
+    assert store.get(999) is None
+
+
+@pytest.mark.parametrize("operation", [
+    "direct", "slice", "memoryview", "ufunc_out", "copyto", "fill",
+])
+def test_mmap_writes_raise_without_crashing(tmp_path, operation):
+    # Execute the actual write, without a preceding flags assertion. A future
+    # regression must fail this test, not take down pytest with SIGSEGV/SIGBUS
+    # (or a Windows access violation). Only a new temporary database is used.
+    path, _, store = _mapped_vector(tmp_path)
+    before = path.read_bytes()
+    del store
+    script = textwrap.dedent("""
+        import os
+        import sys
+        if os.name == "nt":
+            import ctypes
+            # Suppress OS crash dialogs in the child, not the whole runner.
+            ctypes.windll.kernel32.SetErrorMode(0x0001 | 0x0002 | 0x8000)
+        else:
+            import resource
+            resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
+        import numpy as np
+        import vanedb_cpp
+        store = vanedb_cpp.MMapVectorStore(sys.argv[1])
+        vector = store.get(42)
+        operation = sys.argv[2]
+        expected_error = TypeError if operation == "memoryview" else ValueError
+        try:
+            if operation == "direct":
+                vector[0] = 99.0
+            elif operation == "slice":
+                vector[::2] = 99.0
+            elif operation == "memoryview":
+                memoryview(vector)[0] = 99.0
+            elif operation == "ufunc_out":
+                np.add(vector, np.float32(1), out=vector)
+            elif operation == "copyto":
+                np.copyto(vector, np.full_like(vector, 99.0))
+            elif operation == "fill":
+                vector.fill(99.0)
+            else:
+                raise AssertionError("unknown write operation")
+        except expected_error as error:
+            assert "read-only" in str(error).lower(), str(error)
+            print("SAFE:", type(error).__name__, str(error), flush=True)
+        else:
+            raise AssertionError("write to read-only mmap unexpectedly succeeded")
+        np.testing.assert_array_equal(vector, [1.0, 2.0, 3.0, 4.0])
+    """)
+    child = subprocess.run(
+        [sys.executable, "-I", "-c", script, str(path), operation],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert child.returncode == 0, (
+        f"{operation}: child returned {child.returncode}\n"
+        f"stdout: {child.stdout}\nstderr: {child.stderr}"
+    )
+    assert "SAFE:" in child.stdout
+    assert path.read_bytes() == before
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fix a Python-process crash when writing through `MMapVectorStore.get()`.
The C++ file mapping is read-only, but its NumPy view was advertised as
writable. A normal array assignment consequently caused SIGBUS on macOS or
SIGSEGV on Linux instead of a Python exception.

- Mark the returned array read-only before exposing it, retaining zero-copy
  access and the existing mapping owner/lifetime chain.
- Document read-only views, missing IDs, and `.copy()` for editable data.
- Add 15 regression cases; no existing tests were removed or weakened.
- Raise the runtime NumPy minimum from 1.24 to **1.24.2**. Minimum-version
  testing found that NumPy 1.24.0 still crashes on `view.fill()` even after
  the binding fix, because it ignores the read-only flag. This upstream bug
  was fixed in [NumPy 1.24.2](https://numpy.org/doc/stable/release/1.24.2-notes.html)
  ([numpy/numpy#22970](https://github.com/numpy/numpy/pull/22970)).
- Exercise exactly NumPy 1.24.2 in the existing Python 3.11 jobs on Linux,
  macOS, and Windows, then restore current NumPy for the normal suite. The
  step uses fail-fast Bash, including on Windows, so a failed minimum-version
  test cannot be hidden by the subsequent dependency upgrade.

## Before/after evidence

All tests use built and installed wheels, not an editable/source import.
Crashing operations run in isolated subprocesses against temporary files,
with core dumps / child Windows crash dialogs disabled.

| Check | Before | After |
| --- | --- | --- |
| Expanded mmap suite on macOS and Linux | 13 failures, 6 passes | 19/19 pass |
| Direct assignment, slice assignment, memoryview write, ufunc `out=`, `copyto`, `fill` | All six crash | All six raise the expected read-only Python exception |
| Slice/asarray/frombuffer views; attempt to re-enable writes | Writable | Read-only; re-enabling writes rejected |
| Zero-copy pointer sharing, mapping lifetime, writable independent copies | Preserved | Preserved |
| Linux real-user acceptance | 29/30 | **30/30** |

Local final validation:

- Rocky Linux 10.2 ARM64, Python 3.12 / NumPy 2.5.2: **79/79** Python tests
  (46 C++ + 33 Rust), **30/30** black-box scenarios, **66/66** C++ core tests.
- macOS ARM64, Python 3.14 / NumPy 2.5.2: **79/79** Python tests and **30/30**
  black-box scenarios.
- macOS ARM64, Python 3.11 / NumPy **1.24.2**: **46/46** C++ binding tests.
- A disposable source copy combining this patch with PR #72: **101/101**
  Python tests (68 C++ + 33 Rust), **30/30** black-box scenarios, NEON dispatch
  confirmed. Both PR branches remain independent and unmerged.
- `actionlint`, `cargo fmt --all -- --check`, and `git diff --check`: pass.

The black-box scenarios include document retrieval after fresh-process
reload, all three distance metrics, HNSW recall/reload (2,000 × 64 vectors,
40 queries, observed recall@10 1.0), invalid inputs, uint64 IDs, ownership,
concurrency, and mmap lifetime/read-only behavior. These are correctness
measurements, not performance claims.

## Scope and CI acceptance

Based directly on main `07914fd`, not stacked on #72. No format, core engine,
benchmark, release, or publishing changes. Rust Python bindings do not expose
this mmap view; their getters return owned vectors, and the Rust regression
suite is included in local acceptance. No new conformance fixture is needed
for a C++-specific Python ownership/write-protection contract.

## Hosted acceptance at `1990a8a`

[CI run 33725833289](https://github.com/vanedb/vanedb/actions/runs/33725833289)
succeeded; **Required CI Gate is green**. All 12 installed-wheel OS/Python jobs
passed. The actual completed job logs confirm:

- Windows Python **3.11, 3.12, 3.13, 3.14**: **46/46** tests each.
- Python 3.11 on **Windows, Linux, macOS**: the additional run at exactly
  NumPy **1.24.2** also passes **46/46**, followed by another **46/46** after
  restoring current NumPy.

**All 49 checks are now green**, including the independent
[benchmark workflow](https://github.com/vanedb/vanedb/actions/runs/33725833063).
This is CI regression coverage, not a performance improvement claim.
Local UTM acceptance remains deferred until the Mac is unlocked.
No merge or publication is requested.
