### PR TITLE
ci(python): build, install and test the wheel on every PR

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -125,6 +125,7 @@ jobs:
           python -m pip install pytest numpy
           python -m pip install --no-index --no-deps --find-links dist --force-reinstall vanedb
           python -m pip check
+          python scripts/check_wheel_install.py vanedb
           python -m pytest vanedb-py/tests -v
 
   macos:
@@ -160,6 +161,7 @@ jobs:
           python -m pip install --no-index --no-deps --find-links dist --force-reinstall vanedb
           python -m pip install pytest numpy
           python -m pip check
+          python scripts/check_wheel_install.py vanedb
           python -m pytest vanedb-py/tests -v
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -192,6 +194,7 @@ jobs:
           python -m pip install --no-index --no-deps --find-links dist --force-reinstall vanedb
           python -m pip install pytest numpy
           python -m pip check
+          python scripts/check_wheel_install.py vanedb
           python -m pytest vanedb-py/tests -v
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -236,6 +239,7 @@ jobs:
           python -m pip install pytest numpy
           python -m pip install --no-deps --force-reinstall dist/*.tar.gz
           python -m pip check
+          python scripts/check_wheel_install.py vanedb
           python -m pytest vanedb-py/tests -v
 
   validate-artifacts:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -30,9 +30,47 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       # vanedb-py is excluded from the workspace jobs (building a wheel needs
       # maturin), but `cargo check` needs only a Python interpreter, so the
-      # crate at least compiling is verified on every PR. Full behavior tests
-      # still run locally via maturin develop + pytest.
+      # crate at least compiling is verified cheaply. Behaviour is covered by
+      # the wheel-py job below.
       - run: cargo check -p vanedb-py --locked
+
+  wheel-py:
+    name: Python wheel (build, install, test)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+      # Built the way the release workflow builds it — same action, same
+      # manylinux target and flags — so this gate exercises the artifact that
+      # ships rather than a differently configured one. Until now the Python
+      # bindings had no behavioural coverage before a release.
+      - name: Build the wheel
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          target: x86_64
+          manylinux: '2_17'
+          args: >-
+            --release --locked --compatibility pypi --out dist
+            --manifest-path vanedb-py/Cargo.toml -i python3.11
+      - name: Install from the wheel alone
+        run: |
+          python -m pip install --no-index --no-deps --find-links dist --force-reinstall vanedb
+          python -m pip install pytest numpy
+          python -m pip check
+      # A run that imports the checkout instead of the wheel proves nothing,
+      # and this repository has a directory named vanedb, so the hazard is
+      # live rather than theoretical.
+      - name: The import must resolve to the wheel
+        run: python scripts/check_wheel_install.py vanedb
+      # Run from outside the checkout for the same reason.
+      - name: Run the Python suite against the installed wheel
+        run: |
+          cp -R vanedb-py/tests "$RUNNER_TEMP/wheel-tests"
+          cd "$RUNNER_TEMP"
+          python -m pytest wheel-tests -v
 
   test-linux:
     name: Test (Linux x86_64)

--- a/scripts/check_wheel_install.py
+++ b/scripts/check_wheel_install.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Prove a test run exercises the installed wheel, not the source tree.
+
+The classic false pass: pytest runs from the repository root, `import vanedb`
+resolves to the checked-out directory, and the wheel under test is never
+loaded. This repository is unusually exposed to it — the Rust crate directory
+is literally named `vanedb`, so it is importable as a namespace package.
+
+Usage: check_wheel_install.py <import name>
+
+Exits non-zero unless the name resolves to a real module inside this
+interpreter's site-packages.
+"""
+
+import importlib
+import os
+import sys
+import sysconfig
+from importlib import metadata
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    name = sys.argv[1]
+
+    # Nothing in the checkout may satisfy the import, including the implicit
+    # "" entry for the working directory.
+    sys.path[:] = [
+        p for p in sys.path if p and not os.path.realpath(p).startswith(REPO)
+    ]
+
+    try:
+        module = importlib.import_module(name)
+    except ImportError as err:
+        print(f"{name} is not installed: {err}", file=sys.stderr)
+        return 1
+
+    location = getattr(module, "__file__", None)
+    if location is None:
+        print(
+            f"{name} resolved to a namespace package, not an installed "
+            f"distribution (path: {list(getattr(module, '__path__', []))})",
+            file=sys.stderr,
+        )
+        return 1
+
+    roots = {
+        os.path.realpath(sysconfig.get_paths()[key]) for key in ("purelib", "platlib")
+    }
+    resolved = os.path.realpath(location)
+    if not any(resolved.startswith(root) for root in roots):
+        print(
+            f"{name} resolved to {resolved}, outside site-packages "
+            f"({', '.join(sorted(roots))})",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        version = metadata.version(name)
+    except metadata.PackageNotFoundError:
+        version = "unknown version"
+    print(f"{name} {version} imported from {resolved}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
`vanedb-py` has **33 Python tests. None of them run on a PR today.** `cargo check -p vanedb-py` proves the crate compiles; the suite runs only in the release workflow, which has never executed end to end. So the Python bindings' behaviour is currently unverified until a release that has never happened.

## What this adds

A `wheel-py` job that builds the wheel **the way the release workflow builds it** — same `maturin-action` pin, same `manylinux: 2_17`, same `--compatibility pypi` flags — then installs it with `--no-index` and runs the suite against the installed package.

## The part that needed enforcing

Testing the artifact instead of the checkout can't be assumed here. This repo has a top-level directory named `vanedb`, so `import vanedb` from the repository root can resolve to the **Rust crate** as an implicit namespace package. A green suite would then prove nothing about the wheel.

`scripts/check_wheel_install.py` fails unless the name resolves to a real module inside `site-packages`, and the suite runs from a copy outside the checkout. The same one-line guard is added to the four release test steps, which currently run `pytest vanedb-py/tests` from the repository root.

## Verification

Full sequence run locally:

```
📦 Built wheel for CPython 3.13 to .../vanedb-0.1.0-cp313-cp313-macosx_11_0_arm64.whl
=== install from wheel alone ===        No broken requirements found.
=== import must resolve to the wheel === vanedb 0.1.0 imported from .../site-packages/vanedb/__init__.py
=== suite against the installed wheel === 33 passed in 1.29s
```

The guard was falsified three ways rather than assumed to work:

| Input | Result |
|---|---|
| `pip` (an installed distribution) | pass — `pip 25.3 imported from .../site-packages/pip/__init__.py` |
| `json` (stdlib, outside site-packages) | **fail**, exit 1 |
| `vanedb`, run from the repo root with `vanedb/` present but nothing installed | **fail**, exit 1 — the namespace-package hazard, caught |

`actionlint` (pinned 1.7.12, all workflows): clean.

## Scope

Rust side only — PR #72 owns the C++ wheel gate, and this touches no file it touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H