### PR TITLE
docs(bench): refresh the snapshot with the full measured scope

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -71,28 +71,34 @@ end-to-end smoke check and asserts recall, never a timing.
 `coverage::SCOPE` holds this table as data and a test fails if a bench stops
 implementing a row, so a scope claim cannot drift from the code (#63).
 
-## Headline snapshot (Apple M4 Pro, 2026-09, monorepo 47f6195)
+## Headline snapshot (Apple M4 Pro, 2026-09, monorepo 80066a2)
 
-Criterion medians of three passes on an idle machine. Inter-pass spread
-0.3–6.6%; treat smaller differences as noise. Covers the operations measured
-at the time; the groups added for full spec coverage join at the next
-on-hardware refresh.
+Criterion medians of three passes. Inter-pass spread 0.2–10.4%, median 2.2%;
+treat smaller differences as noise.
 
-| Op (n=10k, dim=128, L2) | C++ | Rust | rs/cpp |
+| Op (dim=128, n=10k unless noted) | C++ | Rust | rs/cpp |
 |---|---:|---:|---:|
-| l2_sq (128d) | 16.9 ns | 16.5 ns | 0.98 |
-| l2_sq (768d) | 51.3 ns | 48.4 ns | 0.94 |
-| hnsw_build (M=16, efC=200) | 938 ms | 1013 ms | 1.08 |
+| l2_sq (128d) | 16.7 ns | 16.6 ns | 1.00 |
+| l2_sq (768d) | 51.8 ns | 48.4 ns | 0.93 |
+| cosine (128d) | 26.8 ns | 27.2 ns | 1.02 |
+| cosine (768d) | 96.4 ns | 86.7 ns | 0.90 |
+| dot (128d) | 16.1 ns | 16.3 ns | 1.01 |
+| dot (768d) | 53.7 ns | 46.4 ns | 0.86 |
+| store_add (n=10k) | 745 µs | 1.21 ms | 1.63 |
+| store_search (k=10, n=1k) | 8.12 µs | 8.73 µs | 1.08 |
+| store_search (k=10, n=10k) | 78.9 µs | 93.1 µs | 1.18 |
+| hnsw_build (M=16, efC=200) | 938 ms | 1.01 s | 1.08 |
 | hnsw_search (ef=50) | 18.8 µs | 21.3 µs | 1.13 |
-| mmap_search (k=10) | 78.4 µs | 95.5 µs | 1.22 |
-| store_search (k=10, n=1k) | 8.10 µs | 8.67 µs | 1.07 |
-| store_search (k=10, n=10k) | 79.0 µs | 92.5 µs | 1.17 |
+| mmap_build | 4.98 ms | 12.0 ms | 2.40 |
+| mmap_open | 507 µs | 576 µs | 1.14 |
+| mmap_search (k=10) | 78.6 µs | 95.7 µs | 1.22 |
 
 HNSW recall@10 (100 queries, ef=50): C++ 0.689, Rust 0.700.
 
-Rust leads the distance kernels and trails every path that scans.
-`hnsw_search` at 1.13 with identical kernels points at selection overhead
-rather than distance computation (vanedb#32).
+Rust leads the distance kernels at 768 dimensions and is at parity at 128. It
+trails on every scan (1.08–1.22, vanedb#32) and, now that the write paths are
+measured, on `store_add` at 1.63 and `mmap_build` at 2.40 — different work
+from the scan gap, tracked separately.
 
 ## Measurement policy
 

--- a/bench/RESULTS.md
+++ b/bench/RESULTS.md
@@ -1,17 +1,16 @@
 # VaneDB Benchmark Results
 
-Engines: vanedb-cpp (CMake Release) and vanedb (Rust), monorepo 47f6195.
+Engines: vanedb-cpp (CMake Release) and vanedb (Rust), monorepo 80066a2.
 Workload: dim=128, n=10000, k=10, L2. Latencies are medians of 501 interleaved paired samples (one query) after a joint warmup; recall is averaged over 100 queries. Both engines' data stays resident in one process (interleaved construction).
 
-Covers l2_sq, store_search, and hnsw_search + recall@10 only; hnsw_build and mmap_search live in the criterion suite (see README).
+Covers l2_sq, store_search, and hnsw_search + recall@10 only; every other operation is criterion-only (see README).
+
+Criterion is canonical; see the README table. This bin times l2_sq in batches of 1000 calls, which inlines differently from criterion's per-call harness.
 
 | Op | C++ (ns) | Rust (ns) | ratio (rs/cpp) |
 |---|---:|---:|---:|
-| l2_sq | 13 | 17 | 1.26 |
-| store_search | 81833 | 99750 | 1.22 |
-| hnsw_search | 20542 | 22458 | 1.09 |
+| l2_sq | 14 | 17 | 1.15 |
+| store_search | 79500 | 88250 | 1.11 |
+| hnsw_search | 20042 | 21834 | 1.09 |
 
 HNSW recall@10: C++ 0.689, Rust 0.700
-
-Criterion is canonical; see the README table. This bin times l2_sq in batches
-of 1000 calls, which inlines differently from criterion's per-call harness.

--- a/bench/src/bin/report.rs
+++ b/bench/src/bin/report.rs
@@ -65,9 +65,14 @@ fn main() -> ExitCode {
          averaged over {queries} queries. Both engines' data stays resident \
          in one process (interleaved construction).\n\n"
     ));
+    // Regenerating this file must not lose the caveats: anything a reader
+    // needs alongside the numbers belongs here, not hand-added afterwards.
     md.push_str(&format!(
-        "Covers l2_sq, store_search, and hnsw_search + recall@{k} only; \
-         hnsw_build and mmap_search live in the criterion suite (see README).\n\n"
+        "Covers l2_sq, store_search, and hnsw_search + recall@{k} only; every \
+         other operation is criterion-only (see README).\n\n\
+         Criterion is canonical; see the README table. This bin times l2_sq in \
+         batches of 1000 calls, which inlines differently from criterion's \
+         per-call harness.\n\n"
     ));
     md.push_str("| Op | C++ (ns) | Rust (ns) | ratio (rs/cpp) |\n|---|---:|---:|---:|\n");
 


### PR DESCRIPTION
Three passes at `80066a2` on an M4 Pro. Inter-pass spread **0.2–10.4%, median 2.2%**.

## The run validates itself

The operations that did not change reproduce the previous snapshot, several identically — `hnsw_build` 938 ms, `hnsw_search` 18.8/21.3 µs, `l2_sq` 768d rs 48.4 ns. So this is comparable to the snapshot it replaces, not a fresh baseline on a differently-behaving machine.

## Two new parity gaps

The five operations added for full spec coverage (#63) get published numbers for the first time, and two of them are gaps nobody had seen because the operations had never been measured:

| Op | C++ | Rust | rs/cpp |
|---|---:|---:|---:|
| `store_add` (n=10k) | 745 µs | 1.21 ms | **1.63** |
| `mmap_build` | 4.98 ms | 12.0 ms | **2.40** |

Neither is the scan gap #32 describes — these are write paths, different work. `mmap_build` is *after* the 118× buffering fix; the residual is the per-element encode loop against C++'s two bulk writes, as flagged when that landed.

The distance picture also fills in: Rust leads at 768 dimensions (`dot` 0.86, `cosine` 0.90, `l2_sq` 0.93) and is at parity at 128, where per-call overhead dominates the kernel.

## Also fixed

The report binary now emits the "criterion is canonical" caveat itself. That paragraph had been hand-added to `RESULTS.md`, so regenerating the file silently dropped it — the same failure mode as the output path fixed in #68. Regeneration is now stable.

## Method

Built before measuring, so no compilation inside a timed pass. Spotlight indexing was running when I first checked and I waited for it to finish rather than measure through it. Desktop applications were running; the reproduction of the prior snapshot is the evidence that this did not distort the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H