### PR TITLE
fix(python): include and validate PyPI long description

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -260,7 +260,7 @@ jobs:
         run: |
           python -m pip install --upgrade --constraint "${{ github.workspace }}/.github/requirements-release.txt" pip
           python -m pip install --constraint "${{ github.workspace }}/.github/requirements-release.txt" packaging twine
-          python -m twine check dist/*
+          python -m twine check --strict dist/*
           # Matrix contract: 6 Linux + (2 macOS architectures x 6) +
           # 6 Windows wheels = 24. Keep these tripwires aligned with the
           # linux, macos, and windows build matrices above.

--- a/vanedb-py/README.md
+++ b/vanedb-py/README.md
@@ -1,0 +1,69 @@
+# VaneDB for Python
+
+VaneDB is an embeddable vector database backed by Rust. Store vectors and search
+for their nearest neighbors inside your Python process, without a database
+server. Supply your own embeddings; VaneDB does not generate them.
+
+The `vanedb` package is the canonical Python implementation. The supplementary
+C++ package is named `vanedb-cpp` and imports as `vanedb_cpp`.
+
+## Installation
+
+Requires Python 3.11 or newer. To install a published release:
+
+```sh
+python -m pip install vanedb
+```
+
+Python lists work without additional dependencies. NumPy is optional; its arrays
+can also be used for vector and batch inputs.
+
+## Quick start
+
+Use `PyVectorStore` for exact search, or `PyHnswIndex` for approximate search.
+Both return `(id, distance)` pairs, with the nearest results first.
+
+```python
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from vanedb import PyDistanceMetric, PyHnswIndex, PyVectorStore
+
+ids = [101, 202]
+vectors = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
+query = [1.0, 0.0, 0.0]
+
+# Exact cosine-distance search.
+store = PyVectorStore(3, PyDistanceMetric.Cosine)
+store.add_batch(ids, vectors)
+assert store.search(query, 1) == [(101, 0.0)]
+
+# Approximate search, with a fixed maximum capacity.
+index = PyHnswIndex(3, PyDistanceMetric.Cosine, capacity=100, seed=42)
+index.add_batch(ids, vectors)
+index.ef_search = 100
+hits = index.search(query, 1)
+assert hits == [(101, 0.0)]
+
+# Save and reload the index without rebuilding it.
+with TemporaryDirectory() as directory:
+    path = str(Path(directory) / "index.bin")
+    index.save(path)
+    restored = PyHnswIndex.load(path)
+    assert restored.search(query, 1) == hits
+```
+
+Supported metrics are `PyDistanceMetric.L2` (squared Euclidean distance),
+`PyDistanceMetric.Cosine`, and `PyDistanceMetric.Dot` (negative dot product).
+For each metric, smaller distances rank first. Vectors must match the store or
+index dimension and contain finite values; IDs must be unique unsigned 64-bit
+integers.
+
+Persistence formats are currently pre-release and engine-specific. Do not use
+the Rust package to load C++ files, or vice versa; a shared format is planned.
+
+## Project
+
+- [Source code and examples](https://github.com/vanedb/vanedb)
+- [Issues](https://github.com/vanedb/vanedb/issues)
+- [MIT license](https://github.com/vanedb/vanedb/blob/main/LICENSE)

--- a/vanedb-py/pyproject.toml
+++ b/vanedb-py/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "maturin"
 name = "vanedb"
 version = "0.1.0"
 description = "Embeddable vector database for edge AI"
+readme = "README.md"
 requires-python = ">=3.11"
 license = "MIT"
 keywords = ["vector", "database", "embeddings", "similarity-search"]

--- a/vanedb-py/tests/test_package_metadata.py
+++ b/vanedb-py/tests/test_package_metadata.py
@@ -1,0 +1,19 @@
+"""Check the description users receive in the installed wheel, not the checkout."""
+
+from importlib.metadata import metadata
+import re
+
+
+def test_installed_package_has_markdown_description():
+    package = metadata("vanedb")
+    content_type = package.get("Description-Content-Type", "")
+    assert content_type.partition(";")[0].strip().lower() == "text/markdown"
+    assert package.get("Description", "").strip()
+
+
+def test_installed_readme_python_examples():
+    description = metadata("vanedb").get("Description", "")
+    examples = re.findall(r"```python\n(.*?)\n```", description, re.DOTALL)
+    assert examples, "The installed description must contain a runnable quick start"
+    for example in examples:
+        exec(compile(example, "<installed vanedb README>", "exec"), {})


### PR DESCRIPTION
## Summary

- Add a standalone Python-facing README and wire it into `vanedb`'s package metadata.
- Explain installation, exact/HNSW search, save/load, optional NumPy, and the current engine-specific persistence boundary, without benchmark or release-availability claims.
- Add two tests against the **installed distribution metadata**: require a non-empty Markdown description and execute its Python quick-start example. Existing PR wheel CI and release wheel/sdist jobs already run this suite.
- Make the Rust release artifact check use `twine check --strict`, so missing descriptions cannot silently pass with warnings.

No engine code, package version, dependency, publisher permissions, or publishing conditions changed. All 33 existing Python tests are retained; the suite now has 35 tests.

## Before / after evidence

The baseline is the actual artifact-only [Rust release rehearsal](https://github.com/vanedb/vanedb/actions/runs/33742794067) from `80066a2`.

| Check | Before | After |
|---|---|---|
| New installed-metadata regression tests | 2 failed: description and content type absent | 2 passed |
| Strict Twine check | Wheel and sdist failed with missing-description warnings | Direct wheel, sdist, and sdist-rebuilt wheel all passed |
| Full Python suite, direct wheel / fresh Python 3.11 venv | — | 35 passed |
| Full packaged Python suite, sdist-rebuilt wheel / fresh Python 3.14 venv | — | 35 passed |

Additional verification:

- Built the direct Release wheel with `maturin build --release --locked`.
- Built an sdist, extracted it outside the checkout, and built a wheel with the normal PEP 517 release path. Verified the referenced README is present in the archive.
- Compared both wheels' `METADATA` and the sdist's `PKG-INFO` against the standalone README: all descriptions match, with a Markdown content type.
- Executed the installed README example before installing NumPy: passed, including exact search, HNSW search and save/load.
- `pip check`, installed-module location guards, actionlint 1.7.12, `cargo fmt --all -- --check`, and `git diff --check`: passed.

An additional `--locked` sdist probe cannot accept maturin's repackaged workspace lockfile; the same failure reproduces on the unmodified baseline sdist. The successful sdist round trip above uses the existing release workflow's normal build behavior, not that additional flag. No lockfile change is included here.

No tags, PyPI uploads, or TestPyPI uploads were performed. This PR is for review; do not merge or publish without approval.
