### PR TITLE
fix(python)!: export the same class names as vanedb_cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ let hits = index.search(&query, 10)?;
 import numpy as np
 import vanedb
 
-index = vanedb.PyHnswIndex(768, vanedb.PyDistanceMetric.Cosine, capacity=100_000)
+index = vanedb.HNSWIndex(768, vanedb.DistanceMetric.COSINE, capacity=100_000)
 vecs = np.asarray(embeddings, dtype=np.float32)  # shape (n, 768)
 index.add_batch(np.arange(len(vecs), dtype=np.uint64), vecs)
 hits = index.search(vecs[0], 10)  # [(id, distance), ...]

--- a/vanedb-capi/Cargo.toml
+++ b/vanedb-capi/Cargo.toml
@@ -2,6 +2,11 @@
 name = "vanedb-capi"
 version = "0.1.0"
 edition = "2021"
+# Not published: the vanedb dependency is a path without a version, and the
+# crate carries no description or license, so `cargo publish` rejects it. The
+# C ABI ships as a built artifact, not a crates.io package. Give it real
+# metadata and a versioned dependency before removing this.
+publish = false
 
 [lib]
 crate-type = ["staticlib", "cdylib", "rlib"]

--- a/vanedb-py/README.md
+++ b/vanedb-py/README.md
@@ -20,26 +20,26 @@ can also be used for vector and batch inputs.
 
 ## Quick start
 
-Use `PyVectorStore` for exact search, or `PyHnswIndex` for approximate search.
+Use `VectorStore` for exact search, or `HNSWIndex` for approximate search.
 Both return `(id, distance)` pairs, with the nearest results first.
 
 ```python
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from vanedb import PyDistanceMetric, PyHnswIndex, PyVectorStore
+from vanedb import DistanceMetric, HNSWIndex, VectorStore
 
 ids = [101, 202]
 vectors = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
 query = [1.0, 0.0, 0.0]
 
 # Exact cosine-distance search.
-store = PyVectorStore(3, PyDistanceMetric.Cosine)
+store = VectorStore(3, DistanceMetric.COSINE)
 store.add_batch(ids, vectors)
 assert store.search(query, 1) == [(101, 0.0)]
 
 # Approximate search, with a fixed maximum capacity.
-index = PyHnswIndex(3, PyDistanceMetric.Cosine, capacity=100, seed=42)
+index = HNSWIndex(3, DistanceMetric.COSINE, capacity=100, seed=42)
 index.add_batch(ids, vectors)
 index.ef_search = 100
 hits = index.search(query, 1)
@@ -49,12 +49,12 @@ assert hits == [(101, 0.0)]
 with TemporaryDirectory() as directory:
     path = str(Path(directory) / "index.bin")
     index.save(path)
-    restored = PyHnswIndex.load(path)
+    restored = HNSWIndex.load(path)
     assert restored.search(query, 1) == hits
 ```
 
-Supported metrics are `PyDistanceMetric.L2` (squared Euclidean distance),
-`PyDistanceMetric.Cosine`, and `PyDistanceMetric.Dot` (negative dot product).
+Supported metrics are `DistanceMetric.L2` (squared Euclidean distance),
+`DistanceMetric.COSINE`, and `DistanceMetric.DOT` (negative dot product).
 For each metric, smaller distances rank first. Vectors must match the store or
 index dimension and contain finite values; IDs must be unique unsigned 64-bit
 integers.

--- a/vanedb-py/src/lib.rs
+++ b/vanedb-py/src/lib.rs
@@ -119,11 +119,18 @@ fn check_batch_len(ids: &[u64], rows: usize) -> PyResult<()> {
 }
 
 /// Distance metric enum.
-#[pyclass(eq, eq_int, from_py_object)]
+///
+/// The `Py` prefix disambiguates these wrappers from the core types they hold,
+/// which are imported in this file. It is an implementation detail: the names
+/// exported to Python match `vanedb_cpp` exactly, so swapping engines is an
+/// import-line change.
+#[pyclass(name = "DistanceMetric", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq)]
 enum PyDistanceMetric {
     L2 = 0,
+    #[pyo3(name = "COSINE")]
     Cosine = 1,
+    #[pyo3(name = "DOT")]
     Dot = 2,
 }
 
@@ -138,7 +145,7 @@ impl From<PyDistanceMetric> for DistanceMetric {
 }
 
 /// Brute-force vector store with thread-safe k-NN search.
-#[pyclass]
+#[pyclass(name = "VectorStore")]
 struct PyVectorStore {
     inner: VectorStore,
 }
@@ -209,7 +216,7 @@ impl PyVectorStore {
 }
 
 /// HNSW approximate nearest-neighbor index.
-#[pyclass]
+#[pyclass(name = "HNSWIndex")]
 struct PyHnswIndex {
     inner: HnswIndex,
 }

--- a/vanedb-py/tests/test_numpy_batch.py
+++ b/vanedb-py/tests/test_numpy_batch.py
@@ -11,7 +11,7 @@ import vanedb
 # --- single-vector buffer input (issue #20) ---
 
 def test_store_add_and_search_numpy_f32():
-    store = vanedb.PyVectorStore(3)
+    store = vanedb.VectorStore(3)
     store.add(1, np.array([1.0, 2.0, 3.0], dtype=np.float32))
     store.add(2, np.array([4.0, 5.0, 6.0], dtype=np.float32))
     assert store.get(1) == [1.0, 2.0, 3.0]
@@ -21,19 +21,19 @@ def test_store_add_and_search_numpy_f32():
 
 def test_store_add_numpy_f64_falls_back():
     # float64 has no f32 fast path but must still work via the sequence path
-    store = vanedb.PyVectorStore(2)
+    store = vanedb.VectorStore(2)
     store.add(1, np.array([1.0, 2.0]))  # default dtype float64
     assert store.get(1) == [1.0, 2.0]
 
 
 def test_store_add_2d_buffer_rejected_for_single_add():
-    store = vanedb.PyVectorStore(2)
+    store = vanedb.VectorStore(2)
     with pytest.raises(ValueError, match="1-D"):
         store.add(1, np.zeros((2, 2), dtype=np.float32))
 
 
 def test_lists_still_work():
-    store = vanedb.PyVectorStore(2)
+    store = vanedb.VectorStore(2)
     store.add(1, [1.0, 2.0])
     assert store.search([1.0, 2.0], 1)[0][0] == 1
 
@@ -44,7 +44,7 @@ def test_store_add_batch_numpy():
     rng = np.random.default_rng(0)
     vecs = rng.random((100, 8), dtype=np.float32)
     ids = np.arange(100, dtype=np.uint64)
-    store = vanedb.PyVectorStore(8)
+    store = vanedb.VectorStore(8)
     store.add_batch(ids, vecs)
     assert len(store) == 100
     results = store.search(vecs[42], 1)
@@ -53,26 +53,26 @@ def test_store_add_batch_numpy():
 
 def test_store_add_batch_int64_ids():
     # np.arange default dtype is int64; must be accepted
-    store = vanedb.PyVectorStore(2)
+    store = vanedb.VectorStore(2)
     store.add_batch(np.arange(3), np.ones((3, 2), dtype=np.float32))
     assert len(store) == 3
 
 
 def test_store_add_batch_negative_id_raises():
-    store = vanedb.PyVectorStore(2)
+    store = vanedb.VectorStore(2)
     with pytest.raises(ValueError, match="negative"):
         store.add_batch(np.array([0, -1]), np.ones((2, 2), dtype=np.float32))
     assert len(store) == 0
 
 
 def test_store_add_batch_list_fallback():
-    store = vanedb.PyVectorStore(2)
+    store = vanedb.VectorStore(2)
     store.add_batch([10, 20], [[1.0, 2.0], [3.0, 4.0]])
     assert store.get(20) == [3.0, 4.0]
 
 
 def test_store_add_batch_ragged_rows_raise():
-    store = vanedb.PyVectorStore(3)
+    store = vanedb.VectorStore(3)
     # total length 6 == 2*3 would pass a naive flat check; per-row must fail
     with pytest.raises(ValueError):
         store.add_batch([1, 2], [[1.0, 2.0], [3.0, 4.0, 5.0, 6.0]])
@@ -80,14 +80,14 @@ def test_store_add_batch_ragged_rows_raise():
 
 
 def test_store_add_batch_wrong_width_raises():
-    store = vanedb.PyVectorStore(3)
+    store = vanedb.VectorStore(3)
     with pytest.raises(ValueError):
         store.add_batch(np.arange(2), np.ones((2, 4), dtype=np.float32))
     assert len(store) == 0
 
 
 def test_store_add_batch_ids_vectors_count_mismatch():
-    store = vanedb.PyVectorStore(2)
+    store = vanedb.VectorStore(2)
     with pytest.raises(ValueError):
         store.add_batch(np.arange(3), np.ones((2, 2), dtype=np.float32))
     assert len(store) == 0
@@ -95,7 +95,7 @@ def test_store_add_batch_ids_vectors_count_mismatch():
 
 def test_store_add_batch_numpy_f64_2d():
     # float64 is numpy's default dtype; a well-formed 2-D batch must insert
-    store = vanedb.PyVectorStore(3)
+    store = vanedb.VectorStore(3)
     store.add_batch(np.arange(2), np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
     assert len(store) == 2
     assert store.get(1) == [4.0, 5.0, 6.0]
@@ -105,7 +105,7 @@ def test_store_add_batch_f64_wrong_rank_raises():
     # Shape validation must not depend on dtype: the float32 twin of this
     # array is rejected as 3-D, so the float64 one must be too — not silently
     # flattened through numpy's element coercion.
-    store = vanedb.PyVectorStore(3)
+    store = vanedb.VectorStore(3)
     with pytest.raises(ValueError, match="2-D"):
         store.add_batch(np.arange(2), np.zeros((2, 3, 1)))
     assert len(store) == 0
@@ -113,14 +113,14 @@ def test_store_add_batch_f64_wrong_rank_raises():
 
 def test_store_add_f64_wrong_rank_raises():
     # float64 twin of test_store_add_2d_buffer_rejected_for_single_add
-    store = vanedb.PyVectorStore(3)
+    store = vanedb.VectorStore(3)
     with pytest.raises(ValueError, match="1-D"):
         store.add(1, np.zeros((3, 1)))
     assert len(store) == 0
 
 
 def test_store_add_batch_duplicate_is_all_or_nothing():
-    store = vanedb.PyVectorStore(2)
+    store = vanedb.VectorStore(2)
     store.add(5, [0.0, 0.0])
     with pytest.raises(ValueError, match="duplicate"):
         store.add_batch(np.array([4, 5], dtype=np.uint64),
@@ -132,7 +132,7 @@ def test_store_add_batch_duplicate_is_all_or_nothing():
 def test_store_add_batch_noncontiguous_slice():
     vecs = np.arange(40, dtype=np.float32).reshape(10, 4)
     view = vecs[::2]  # non C-contiguous
-    store = vanedb.PyVectorStore(4)
+    store = vanedb.VectorStore(4)
     store.add_batch(np.arange(5, dtype=np.uint64), view)
     assert store.get(1) == view[1].tolist()
 
@@ -144,10 +144,10 @@ def test_hnsw_add_batch_matches_serial():
     vecs = rng.random((200, 16), dtype=np.float32)
     ids = np.arange(200, dtype=np.uint64)
 
-    serial = vanedb.PyHnswIndex(16, capacity=200, seed=3)
+    serial = vanedb.HNSWIndex(16, capacity=200, seed=3)
     for i in range(200):
         serial.add(int(ids[i]), vecs[i])
-    batched = vanedb.PyHnswIndex(16, capacity=200, seed=3)
+    batched = vanedb.HNSWIndex(16, capacity=200, seed=3)
     batched.add_batch(ids, vecs)
 
     assert len(batched) == 200
@@ -156,7 +156,7 @@ def test_hnsw_add_batch_matches_serial():
 
 
 def test_hnsw_add_batch_capacity_all_or_nothing():
-    index = vanedb.PyHnswIndex(2, capacity=3)
+    index = vanedb.HNSWIndex(2, capacity=3)
     with pytest.raises(ValueError, match="full"):
         index.add_batch(np.arange(4), np.ones((4, 2), dtype=np.float32))
     assert len(index) == 0

--- a/vanedb-py/tests/test_vanedb.py
+++ b/vanedb-py/tests/test_vanedb.py
@@ -12,7 +12,7 @@ def test_version():
 # --- VectorStore ---
 
 def test_vector_store_basic():
-    store = vanedb.PyVectorStore(3)
+    store = vanedb.VectorStore(3)
     store.add(1, [1.0, 2.0, 3.0])
     store.add(2, [4.0, 5.0, 6.0])
     assert len(store) == 2
@@ -22,13 +22,13 @@ def test_vector_store_basic():
 
 
 def test_vector_store_get():
-    store = vanedb.PyVectorStore(3)
+    store = vanedb.VectorStore(3)
     store.add(1, [1.0, 2.0, 3.0])
     assert store.get(1) == [1.0, 2.0, 3.0]
 
 
 def test_vector_store_search():
-    store = vanedb.PyVectorStore(2)
+    store = vanedb.VectorStore(2)
     store.add(1, [0.0, 0.0])
     store.add(2, [1.0, 0.0])
     store.add(3, [10.0, 10.0])
@@ -38,7 +38,7 @@ def test_vector_store_search():
 
 
 def test_vector_store_cosine():
-    store = vanedb.PyVectorStore(2, vanedb.PyDistanceMetric.Cosine)
+    store = vanedb.VectorStore(2, vanedb.DistanceMetric.COSINE)
     store.add(1, [1.0, 0.0])
     store.add(2, [0.0, 1.0])
     results = store.search([0.9, 0.1], 1)
@@ -46,7 +46,7 @@ def test_vector_store_cosine():
 
 
 def test_vector_store_remove():
-    store = vanedb.PyVectorStore(2)
+    store = vanedb.VectorStore(2)
     store.add(1, [1.0, 2.0])
     store.add(2, [3.0, 4.0])
     store.remove(1)
@@ -56,7 +56,7 @@ def test_vector_store_remove():
 
 
 def test_vector_store_errors():
-    store = vanedb.PyVectorStore(3)
+    store = vanedb.VectorStore(3)
     try:
         store.add(1, [1.0, 2.0])  # wrong dim
         assert False, "Should have raised"
@@ -74,7 +74,7 @@ def test_vector_store_errors():
 # --- HnswIndex ---
 
 def test_hnsw_basic():
-    idx = vanedb.PyHnswIndex(3, capacity=100)
+    idx = vanedb.HNSWIndex(3, capacity=100)
     idx.add(1, [1.0, 0.0, 0.0])
     idx.add(2, [0.0, 1.0, 0.0])
     assert len(idx) == 2
@@ -84,7 +84,7 @@ def test_hnsw_basic():
 
 
 def test_hnsw_search():
-    idx = vanedb.PyHnswIndex(3, capacity=100)
+    idx = vanedb.HNSWIndex(3, capacity=100)
     idx.add(1, [0.0, 0.0, 0.0])
     idx.add(2, [10.0, 10.0, 10.0])
     results = idx.search([0.0, 0.0, 0.0], 1)
@@ -97,12 +97,12 @@ def test_hnsw_save_load():
         path = f.name
 
     try:
-        idx = vanedb.PyHnswIndex(4, capacity=100, seed=42)
+        idx = vanedb.HNSWIndex(4, capacity=100, seed=42)
         for i in range(20):
             idx.add(i, [float(i)] * 4)
         idx.save(path)
 
-        loaded = vanedb.PyHnswIndex.load(path)
+        loaded = vanedb.HNSWIndex.load(path)
         assert len(loaded) == 20
         assert loaded.get_vector(5) == [5.0, 5.0, 5.0, 5.0]
 
@@ -115,14 +115,14 @@ def test_hnsw_save_load():
 
 
 def test_hnsw_ef_search():
-    idx = vanedb.PyHnswIndex(3, capacity=100)
+    idx = vanedb.HNSWIndex(3, capacity=100)
     assert idx.ef_search == 50  # default
     idx.ef_search = 200
     assert idx.ef_search == 200
 
 
 def test_hnsw_errors():
-    idx = vanedb.PyHnswIndex(3, capacity=2)
+    idx = vanedb.HNSWIndex(3, capacity=2)
     idx.add(0, [0.0, 0.0, 0.0])
     idx.add(1, [1.0, 1.0, 1.0])
     try:
@@ -134,7 +134,7 @@ def test_hnsw_errors():
 
 @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
 def test_non_finite_vectors_and_queries_are_rejected(value):
-    store = vanedb.PyVectorStore(2)
+    store = vanedb.VectorStore(2)
     with pytest.raises(ValueError, match="finite"):
         store.add(1, [value, 0.0])
     assert len(store) == 0
@@ -143,7 +143,7 @@ def test_non_finite_vectors_and_queries_are_rejected(value):
     with pytest.raises(ValueError, match="finite"):
         store.search([value, 0.0], 1)
 
-    index = vanedb.PyHnswIndex(2, capacity=4)
+    index = vanedb.HNSWIndex(2, capacity=4)
     with pytest.raises(ValueError, match="finite"):
         index.add(1, [value, 0.0])
     assert len(index) == 0


### PR DESCRIPTION
Found by auditing the **built wheel** rather than the source. The published package exported:

```
['PyDistanceMetric', 'PyHnswIndex', 'PyVectorStore', 'vanedb']
```

The `Py` prefix is PyO3's convention for disambiguating a wrapper struct from the type it wraps. It is an implementation detail, and it had leaked into the public API — the root README instructed users to type `vanedb.PyHnswIndex(...)`.

`vanedb_cpp` already exposed clean names, so the two engines disagreed about what to call the same concepts. For a project whose thesis is two implementations under one contract, that is the contract leaking.

## After

| | before | after |
|---|---|---|
| index | `vanedb.PyHnswIndex` | `vanedb.HNSWIndex` |
| store | `vanedb.PyVectorStore` | `vanedb.VectorStore` |
| metric | `vanedb.PyDistanceMetric.Cosine` | `vanedb.DistanceMetric.COSINE` |

Identical to `vanedb_cpp`, **including enum members** — C++ exposes `COSINE`/`DOT`, Rust exposed `Cosine`/`Dot`, so fixing only the class names would have left the swap broken on the very next line. Switching engines is now an import-line change.

The Rust structs keep their `Py` prefix, which is what it exists for: `vanedb::HnswIndex` is imported in the same file.

**`HNSWIndex` rather than `Index`:** `VectorStore` and `MMapVectorStore` are peers, so a bare `Index` would imply they are not indexes, and would hide which tradeoff the caller is taking. It also matches both native APIs and leaves room for a second ANN structure.

## Also

`vanedb-capi` is now `publish = false`. It was publishable by default, but `cargo publish` rejects it — the `vanedb` dependency is a path with no version, and it carries no description or license. It ships as a built artifact, not a crates.io package.

## Verification

Against the installed wheel, not the source tree:

```
exports: ['DistanceMetric', 'HNSWIndex', 'VectorStore', 'vanedb']
members: ['COSINE', 'DOT', 'L2']
vanedb.HNSWIndex(3, vanedb.DistanceMetric.COSINE, capacity=10) → search: [(1, 0.0)]
33 passed
```

`cargo fmt --check`, `clippy -D warnings`, and the full workspace test suite: clean.

## Breaking

Breaking for anyone using a locally built wheel. Nothing is published, which is why this is landing now rather than after a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H