### PR TITLE
docs(vanedb): document the public API and keep it documented

### DIFF
--- a/vanedb/src/distance/avx2.rs
+++ b/vanedb/src/distance/avx2.rs
@@ -1,3 +1,9 @@
+//! x86-64 AVX2 kernels, unrolled across several accumulators because a
+//! single-accumulator FMA loop is latency-bound rather than throughput-bound.
+//!
+//! Every function here requires AVX2 and FMA; callers reach them through
+//! [`distance_fn`](super::distance_fn), which checks at runtime.
+
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
 

--- a/vanedb/src/distance/mod.rs
+++ b/vanedb/src/distance/mod.rs
@@ -1,5 +1,6 @@
 //! Distance metrics and their SIMD implementations.
 
+/// AVX2 kernels, compiled on x86-64.
 #[cfg(target_arch = "x86_64")]
 pub mod avx2;
 /// NEON kernels, compiled on AArch64.

--- a/vanedb/src/distance/mod.rs
+++ b/vanedb/src/distance/mod.rs
@@ -1,7 +1,11 @@
+//! Distance metrics and their SIMD implementations.
+
 #[cfg(target_arch = "x86_64")]
 pub mod avx2;
+/// NEON kernels, compiled on AArch64.
 #[cfg(target_arch = "aarch64")]
 pub mod neon;
+/// Portable kernels, always available.
 pub mod scalar;
 
 /// Distance metric for vector comparison.

--- a/vanedb/src/distance/neon.rs
+++ b/vanedb/src/distance/neon.rs
@@ -1,7 +1,12 @@
+//! AArch64 NEON kernels, unrolled across several accumulators because a
+//! single-accumulator FMA loop is latency-bound rather than throughput-bound.
+
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 
 #[cfg(target_arch = "aarch64")]
+/// Squared Euclidean distance. The square root is skipped: it does not
+/// change the ordering, and every caller here only ranks.
 pub fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
     debug_assert_eq!(a.len(), b.len());
     let n = a.len();
@@ -50,6 +55,9 @@ pub fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
 }
 
 #[cfg(target_arch = "aarch64")]
+/// Cosine distance, `1 - cos(a, b)`, clamped to `[0, 2]`. Returns `1.0`
+/// when a norm is zero or overflows to infinity, so a degenerate input
+/// ranks as orthogonal rather than as NaN.
 pub fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
     debug_assert_eq!(a.len(), b.len());
     let n = a.len();
@@ -112,6 +120,8 @@ pub fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
 }
 
 #[cfg(target_arch = "aarch64")]
+/// Negated dot product, so that lower still means nearer as it does for
+/// the other metrics.
 pub fn dot_distance(a: &[f32], b: &[f32]) -> f32 {
     debug_assert_eq!(a.len(), b.len());
     let n = a.len();

--- a/vanedb/src/distance/scalar.rs
+++ b/vanedb/src/distance/scalar.rs
@@ -1,3 +1,7 @@
+//! Portable reference kernels. The SIMD paths must agree with these.
+
+/// Squared Euclidean distance. The square root is skipped: it does not
+/// change the ordering, and every caller here only ranks.
 pub fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
     debug_assert_eq!(a.len(), b.len());
     a.iter()
@@ -9,6 +13,9 @@ pub fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
         .sum()
 }
 
+/// Cosine distance, `1 - cos(a, b)`, clamped to `[0, 2]`. Returns `1.0`
+/// when a norm is zero or overflows to infinity, so a degenerate input
+/// ranks as orthogonal rather than as NaN.
 pub fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
     debug_assert_eq!(a.len(), b.len());
     let mut dot = 0.0f32;
@@ -37,6 +44,8 @@ pub fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
     1.0 - sim.clamp(-1.0, 1.0)
 }
 
+/// Negated dot product, so that lower still means nearer as it does for
+/// the other metrics.
 pub fn dot_distance(a: &[f32], b: &[f32]) -> f32 {
     debug_assert_eq!(a.len(), b.len());
     -a.iter().zip(b.iter()).map(|(x, y)| x * y).sum::<f32>()

--- a/vanedb/src/error.rs
+++ b/vanedb/src/error.rs
@@ -1,13 +1,40 @@
+//! The error type returned by every fallible operation.
+
+/// Everything that can go wrong in this crate.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VaneError {
-    DimensionMismatch { expected: usize, got: usize },
+    /// A vector's length did not match the dimension the store was created with.
+    DimensionMismatch {
+        /// The dimension the store expects.
+        expected: usize,
+        /// The length actually supplied.
+        got: usize,
+    },
+    /// A zero-length vector was supplied.
     EmptyVector,
-    NotFound { id: u64 },
-    DuplicateId { id: u64 },
+    /// No vector is stored under this id.
+    NotFound {
+        /// The id that was looked up.
+        id: u64,
+    },
+    /// This id is already present; ids are unique within a store.
+    DuplicateId {
+        /// The id that was already taken.
+        id: u64,
+    },
+    /// `k` was zero, so there is no nearest neighbour to return.
     InvalidK,
+    /// The index has reached the capacity it was built with.
     IndexFull,
-    NonFiniteValue { input: &'static str },
+    /// An input held a NaN or an infinity, which have no meaningful distance.
+    NonFiniteValue {
+        /// Which input was rejected, for the message.
+        input: &'static str,
+    },
+    /// A parameter was outside its valid range, or an allocation it implies
+    /// would overflow.
     InvalidParameter(&'static str),
+    /// A filesystem or serialisation failure, with the underlying message.
     Io(String),
 }
 
@@ -33,6 +60,7 @@ impl std::fmt::Display for VaneError {
 
 impl std::error::Error for VaneError {}
 
+/// `Result` with this crate's error type.
 pub type Result<T> = std::result::Result<T, VaneError>;
 
 #[cfg(test)]

--- a/vanedb/src/hnsw/mod.rs
+++ b/vanedb/src/hnsw/mod.rs
@@ -1,3 +1,5 @@
+//! Approximate nearest-neighbour search over an HNSW graph.
+
 use std::cell::RefCell;
 use std::cmp::Reverse;
 use std::collections::{BinaryHeap, HashMap, HashSet};
@@ -94,6 +96,17 @@ impl Ord for FloatOrd {
 pub(super) const MAX_LEVEL: i32 = 32;
 const MIN_LEVEL_RANDOM: f64 = 1e-9;
 
+/// Approximate k-nearest-neighbour search over a Hierarchical Navigable
+/// Small World graph.
+///
+/// Search is sub-linear in the corpus, at the cost of occasionally missing a
+/// true neighbour. Recall is traded against speed at query time with
+/// [`set_ef_search`](Self::set_ef_search) and at build time with
+/// [`m`](HnswIndexBuilder::m) and
+/// [`ef_construction`](HnswIndexBuilder::ef_construction).
+///
+/// Built through [`HnswIndex::builder`]. Mutating methods take `&self`; the
+/// index is internally synchronised.
 pub struct HnswIndex {
     pub(super) dim: usize,
     pub(super) metric: DistanceMetric,
@@ -123,6 +136,10 @@ pub(super) struct Inner {
     pub(super) rng: StdRng,
 }
 
+/// Configures an [`HnswIndex`] before construction.
+///
+/// Capacity is fixed once built, because the graph's storage is allocated up
+/// front.
 pub struct HnswIndexBuilder {
     dim: usize,
     metric: DistanceMetric,
@@ -133,6 +150,7 @@ pub struct HnswIndexBuilder {
 }
 
 impl HnswIndex {
+    /// Starts configuring an index over vectors of `dim` components.
     pub fn builder(dim: usize, metric: DistanceMetric) -> HnswIndexBuilder {
         HnswIndexBuilder {
             dim,
@@ -144,30 +162,38 @@ impl HnswIndex {
         }
     }
 
+    /// Number of vectors in the graph.
     pub fn size(&self) -> usize {
         self.inner.read().count
     }
 
+    /// Whether the graph holds no vectors.
     pub fn is_empty(&self) -> bool {
         self.size() == 0
     }
 
+    /// Vectors this index can hold; adding beyond it fails with
+    /// [`crate::VaneError::IndexFull`].
     pub fn capacity(&self) -> usize {
         self.max_elements
     }
 
+    /// Component count of every vector in this index.
     pub fn dimension(&self) -> usize {
         self.dim
     }
 
+    /// The metric this index ranks by.
     pub fn metric(&self) -> DistanceMetric {
         self.metric
     }
 
+    /// Whether a vector is stored under `id`.
     pub fn contains(&self, id: u64) -> bool {
         self.inner.read().id_map.contains_key(&id)
     }
 
+    /// Returns a copy of the vector stored under `id`.
     pub fn get_vector(&self, id: u64) -> Result<Vec<f32>> {
         let inner = self.inner.read();
         let &iid = inner.id_map.get(&id).ok_or(VaneError::NotFound { id })?;
@@ -175,10 +201,13 @@ impl HnswIndex {
         Ok(inner.vectors[start..start + self.dim].to_vec())
     }
 
+    /// Sets the search beam width: higher recovers more true neighbours and
+    /// costs more time. Applies to subsequent searches.
     pub fn set_ef_search(&self, ef: usize) {
         self.ef_search.store(ef, Ordering::Relaxed);
     }
 
+    /// The current search beam width.
     pub fn get_ef_search(&self) -> usize {
         self.ef_search.load(Ordering::Relaxed)
     }
@@ -364,6 +393,10 @@ impl HnswIndex {
         }
     }
 
+    /// The `k` nearest vectors to `query`, nearest first.
+    ///
+    /// Approximate: a true neighbour can be missed. Raise the beam width with
+    /// [`set_ef_search`](Self::set_ef_search) to trade speed for recall.
     pub fn search(&self, query: &[f32], k: usize) -> Result<Vec<SearchResult>> {
         if query.len() != self.dim {
             return Err(VaneError::DimensionMismatch {
@@ -578,26 +611,34 @@ impl HnswIndex {
 }
 
 impl HnswIndexBuilder {
+    /// Vectors the index will be able to hold. Fixed once built.
     pub fn capacity(mut self, cap: usize) -> Self {
         self.capacity = cap;
         self
     }
 
+    /// Links kept per node. Larger graphs recall better and cost more memory
+    /// and build time.
     pub fn m(mut self, m: usize) -> Self {
         self.m = m;
         self
     }
 
+    /// Beam width used while building. Larger yields a better-connected graph
+    /// and a slower build; it does not affect query cost.
     pub fn ef_construction(mut self, ef: usize) -> Self {
         self.ef_construction = ef;
         self
     }
 
+    /// Seeds the level-assignment RNG. A fixed seed makes construction
+    /// reproducible.
     pub fn seed(mut self, seed: u64) -> Self {
         self.seed = seed;
         self
     }
 
+    /// Allocates the graph and returns the index.
     pub fn build(self) -> Result<HnswIndex> {
         if self.dim == 0 {
             return Err(VaneError::EmptyVector);

--- a/vanedb/src/hnsw/persistence.rs
+++ b/vanedb/src/hnsw/persistence.rs
@@ -71,6 +71,10 @@ fn u32_to_metric(v: u32) -> Result<DistanceMetric> {
 }
 
 impl HnswIndex {
+    /// Writes the index to `path`.
+    ///
+    /// Written beside the destination and renamed in after an fsync, so an
+    /// interrupted write cannot replace a good index with a partial one.
     pub fn save(&self, path: impl AsRef<Path>) -> Result<()> {
         let inner = self.inner.read();
         let data = HnswData {
@@ -119,6 +123,11 @@ impl HnswIndex {
         temp.commit(path)
     }
 
+    /// Reads an index written by [`save`](Self::save).
+    ///
+    /// Files from earlier released versions stay loadable. Structural
+    /// invariants are checked on the way in, so a corrupt file is rejected
+    /// rather than producing wrong search results.
     pub fn load(path: impl AsRef<Path>) -> Result<Self> {
         let bytes = fs::read(path.as_ref()).map_err(|e| VaneError::Io(format!("read: {e}")))?;
         if bytes.len() < HEADER_LEN {

--- a/vanedb/src/lib.rs
+++ b/vanedb/src/lib.rs
@@ -1,3 +1,36 @@
+//! Embeddable vector database for edge AI.
+//!
+//! Three ways to hold vectors, all searchable by k nearest neighbours:
+//!
+//! - [`VectorStore`] — exact brute-force scan, held in memory.
+//! - [`HnswIndex`] — approximate graph index: sub-linear search, recall traded
+//!   against speed through `ef_search`.
+//! - [`MmapVectorStore`] — exact scan over a memory-mapped file, so a corpus
+//!   larger than RAM stays searchable (feature `mmap`).
+//!
+//! Each takes a [`DistanceMetric`] and returns [`SearchResult`]s nearest first.
+//!
+//! ```
+//! use vanedb::{DistanceMetric, HnswIndex};
+//!
+//! let index = HnswIndex::builder(3, DistanceMetric::Cosine)
+//!     .capacity(1_000)
+//!     .build()?;
+//! index.add(1, &[1.0, 0.0, 0.0])?;
+//!
+//! let hits = index.search(&[0.9, 0.1, 0.0], 1)?;
+//! assert_eq!(hits[0].id, 1);
+//! # Ok::<(), vanedb::VaneError>(())
+//! ```
+//!
+//! Distance kernels dispatch to NEON or AVX2 at runtime and fall back to a
+//! portable scalar path, which is the reference the others must agree with.
+//!
+//! A header-only C++ implementation sharing these file formats and graph
+//! construction is maintained alongside this crate.
+
+#![warn(missing_docs)]
+
 mod atomic_write;
 pub mod distance;
 pub mod error;

--- a/vanedb/src/mmap.rs
+++ b/vanedb/src/mmap.rs
@@ -1,3 +1,5 @@
+//! Exact search over a memory-mapped file.
+
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{BufWriter, Write};
@@ -37,6 +39,10 @@ fn u32_to_metric(v: u32) -> Result<DistanceMetric> {
     }
 }
 
+/// Collects vectors and writes them to a file [`MmapVectorStore`] can open.
+///
+/// Vectors are held in memory until [`save`](Self::save); the memory saving
+/// is on the reading side.
 pub struct MmapVectorStoreBuilder {
     dim: usize,
     metric: DistanceMetric,
@@ -46,6 +52,7 @@ pub struct MmapVectorStoreBuilder {
 }
 
 impl MmapVectorStoreBuilder {
+    /// Starts a store for vectors of `dim` components.
     pub fn new(dim: usize, metric: DistanceMetric) -> Result<Self> {
         if dim == 0 {
             return Err(VaneError::EmptyVector);
@@ -59,6 +66,10 @@ impl MmapVectorStoreBuilder {
         })
     }
 
+    /// Adds `vector` under `id`.
+    ///
+    /// Fails if `id` is taken, if the length differs from `dim`, or if any
+    /// component is not finite.
     pub fn add(&mut self, id: u64, vector: &[f32]) -> Result<()> {
         if vector.len() != self.dim {
             return Err(VaneError::DimensionMismatch {
@@ -76,10 +87,18 @@ impl MmapVectorStoreBuilder {
         Ok(())
     }
 
+    /// Number of vectors collected so far.
+    /// Number of vectors in the mapped file.
     pub fn size(&self) -> usize {
         self.ids.len()
     }
 
+    /// Writes the store to `path`.
+    ///
+    /// The file is built beside the destination and renamed into place after
+    /// an fsync, so an interrupted write cannot leave a half-written store
+    /// where a reader would find it. The layout is little-endian and shared
+    /// with the C++ implementation.
     pub fn save(&self, path: impl AsRef<Path>) -> Result<()> {
         let path = path.as_ref();
         let temp = crate::atomic_write::AtomicFile::new(path);
@@ -128,6 +147,11 @@ impl MmapVectorStoreBuilder {
     }
 }
 
+/// Exact k-nearest-neighbour search over a memory-mapped file.
+///
+/// Vectors stay on disk and are paged in by the kernel as the scan touches
+/// them, so a corpus larger than RAM remains searchable. Read-only; build
+/// one with [`MmapVectorStoreBuilder`].
 pub struct MmapVectorStore {
     mmap: Mmap,
     dim: usize,
@@ -139,6 +163,12 @@ pub struct MmapVectorStore {
 }
 
 impl MmapVectorStore {
+    /// Maps the store at `path`.
+    ///
+    /// Validates the header, checks every stored component is finite, and
+    /// builds the id index, so this is linear in the corpus rather than a
+    /// constant-cost mapping. A corrupt or truncated file is rejected here
+    /// rather than surfacing as a wrong answer later.
     pub fn open(path: impl AsRef<Path>) -> Result<Self> {
         let file =
             fs::File::open(path.as_ref()).map_err(|e| VaneError::Io(format!("open: {e}")))?;
@@ -212,18 +242,22 @@ impl MmapVectorStore {
         })
     }
 
+    /// Number of vectors in the mapped file.
     pub fn size(&self) -> usize {
         self.num_vectors
     }
 
+    /// Component count of every vector in this store.
     pub fn dimension(&self) -> usize {
         self.dim
     }
 
+    /// The metric recorded in the file.
     pub fn metric(&self) -> DistanceMetric {
         self.metric
     }
 
+    /// Whether a vector is stored under `id`.
     pub fn contains(&self, id: u64) -> bool {
         self.id_map.contains_key(&id)
     }
@@ -234,6 +268,9 @@ impl MmapVectorStore {
         Ok(self.get_vec(idx))
     }
 
+    /// The `k` nearest vectors to `query`, nearest first.
+    ///
+    /// Returns fewer than `k` results when the file holds fewer vectors.
     pub fn search(&self, query: &[f32], k: usize) -> Result<Vec<SearchResult>> {
         if query.len() != self.dim {
             return Err(VaneError::DimensionMismatch {

--- a/vanedb/src/store/mod.rs
+++ b/vanedb/src/store/mod.rs
@@ -1,3 +1,5 @@
+//! In-memory exact vector storage.
+
 mod search_result;
 mod vector_store;
 

--- a/vanedb/src/store/search_result.rs
+++ b/vanedb/src/store/search_result.rs
@@ -8,6 +8,7 @@ pub struct SearchResult {
 }
 
 impl SearchResult {
+    /// Pairs an id with its distance from the query.
     pub fn new(id: u64, distance: f32) -> Self {
         Self { id, distance }
     }

--- a/vanedb/src/store/vector_store.rs
+++ b/vanedb/src/store/vector_store.rs
@@ -7,6 +7,25 @@ use crate::error::{Result, VaneError};
 use crate::store::SearchResult;
 use crate::validation::validate_finite;
 
+/// Exact k-nearest-neighbour search over vectors held in memory.
+///
+/// Every scan touches every vector, so cost is linear in the corpus. Use it
+/// when exactness matters or the corpus is small; reach for [`HnswIndex`]
+/// when it is not.
+///
+/// Mutating methods take `&self`: the store is internally synchronised and
+/// can be shared across threads without an outer lock.
+///
+/// ```
+/// use vanedb::{DistanceMetric, VectorStore};
+///
+/// let store = VectorStore::new(2, DistanceMetric::L2)?;
+/// store.add(7, &[1.0, 0.0])?;
+/// assert_eq!(store.search(&[1.0, 0.0], 1)?[0].id, 7);
+/// # Ok::<(), vanedb::VaneError>(())
+/// ```
+///
+/// [`HnswIndex`]: crate::HnswIndex
 pub struct VectorStore {
     dim: usize,
     metric: DistanceMetric,
@@ -20,6 +39,9 @@ struct Inner {
 }
 
 impl VectorStore {
+    /// Creates an empty store for vectors of `dim` components.
+    ///
+    /// Fails with [`VaneError::InvalidParameter`] if `dim` is zero.
     pub fn new(dim: usize, metric: DistanceMetric) -> Result<Self> {
         if dim == 0 {
             return Err(VaneError::EmptyVector);
@@ -35,6 +57,10 @@ impl VectorStore {
         })
     }
 
+    /// Stores `vector` under `id`.
+    ///
+    /// Fails if `id` is taken, if the length differs from the store's
+    /// dimension, or if any component is not finite.
     pub fn add(&self, id: u64, vector: &[f32]) -> Result<()> {
         if vector.len() != self.dim {
             return Err(VaneError::DimensionMismatch {
@@ -84,6 +110,7 @@ impl VectorStore {
         Ok(())
     }
 
+    /// Returns a copy of the vector stored under `id`.
     pub fn get(&self, id: u64) -> Result<Vec<f32>> {
         let inner = self.inner.read();
         let &index = inner
@@ -94,6 +121,7 @@ impl VectorStore {
         Ok(inner.data[start..start + self.dim].to_vec())
     }
 
+    /// Removes the vector stored under `id`.
     pub fn remove(&self, id: u64) -> Result<()> {
         let mut inner = self.inner.write();
         let index = inner
@@ -118,26 +146,34 @@ impl VectorStore {
         Ok(())
     }
 
+    /// Whether a vector is stored under `id`.
     pub fn contains(&self, id: u64) -> bool {
         self.inner.read().id_to_index.contains_key(&id)
     }
 
+    /// Number of vectors stored.
     pub fn len(&self) -> usize {
         self.inner.read().ids.len()
     }
 
+    /// Whether the store holds no vectors.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
+    /// Component count of every vector in this store.
     pub fn dimension(&self) -> usize {
         self.dim
     }
 
+    /// The metric this store ranks by.
     pub fn metric(&self) -> DistanceMetric {
         self.metric
     }
 
+    /// The `k` nearest vectors to `query`, nearest first.
+    ///
+    /// Returns fewer than `k` results when the store holds fewer vectors.
     pub fn search(&self, query: &[f32], k: usize) -> Result<Vec<SearchResult>> {
         if query.len() != self.dim {
             return Err(VaneError::DimensionMismatch {


### PR DESCRIPTION
The crate had **74 undocumented public items** — including the crate root, five structs, and the error enum. Published as-is, docs.rs would have shown a landing page with no description and undocumented core types.

## What changed

All 74 documented, and `#![warn(missing_docs)]` enabled. CI already runs `clippy -D warnings`, so the lint is an error there — the gap cannot reopen.

The docs are written to answer what a caller has to decide, not to restate signatures:

- `VectorStore` scans every vector; `HnswIndex` does not, and can miss a true neighbour.
- `MmapVectorStore::open` is linear in the corpus because it validates every stored value and builds the id index — not a constant-cost mapping. Worth knowing before calling it in a loop.
- Both save paths write beside the destination and rename after an fsync, so an interrupted write cannot replace a good file with a partial one.
- `ef_search` trades recall against query time; `ef_construction` costs build time and does **not** affect query cost. That distinction is the one people get wrong.
- `dot_distance` is negated so lower still means nearer, matching the other metrics.
- `cosine_distance` returns `1.0` rather than NaN when a norm is zero or overflows.

## Verification

| Check | Result |
|---|---|
| `missing_docs` warnings | 74 → **0** |
| `cargo doc --no-deps` | **0** rustdoc warnings (one redundant intra-doc link found and fixed) |
| Doctests | **2 pass** — the crate example and `VectorStore` |
| `cargo test -p vanedb --features mmap` | all suites pass |
| `cargo fmt --check`, `clippy -D warnings` | clean |

The doctests are real: they construct an index, add a vector, search it and assert the result, so the crate example cannot drift from the API without CI failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H