### PR TITLE
release: 0.1.0-rc.1, and derive __version__ instead of hardcoding it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,7 +1240,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vanedb"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "bincode",
  "criterion",
@@ -1256,7 +1256,7 @@ dependencies = [
 
 [[package]]
 name = "vanedb-capi"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "cbindgen",
  "vanedb",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "vanedb-py"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "pyo3",
  "vanedb",
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "vanedb-wasm"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",

--- a/bench/Cargo.lock
+++ b/bench/Cargo.lock
@@ -883,7 +883,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vanedb"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "bincode",
  "memmap2",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "vanedb-capi"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "cbindgen",
  "vanedb",

--- a/cpp/docs/GUIDE.md
+++ b/cpp/docs/GUIDE.md
@@ -141,7 +141,7 @@ import vanedb_cpp as vanedb
 import numpy as np
 
 # Check version
-print(vanedb.__version__)  # "0.1.0"
+print(vanedb.__version__)  # "0.1.0-rc.1"
 
 # === HNSW Index (approximate, fastest for large datasets) ===
 index = vanedb.HNSWIndex(128, vanedb.DistanceMetric.COSINE)

--- a/cpp/pyproject.toml
+++ b/cpp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vanedb-cpp"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 description = "Supplementary C++ Python bindings for VaneDB"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/cpp/src/core/version.h
+++ b/cpp/src/core/version.h
@@ -15,7 +15,7 @@ constexpr int VERSION_MINOR = 1;
 constexpr int VERSION_PATCH = 0;
 
 /// Full version string
-constexpr const char* VERSION_STRING = "0.1.0";
+constexpr const char* VERSION_STRING = "0.1.0-rc.1";
 
 /**
  * @brief Returns the version as a single integer for comparison.

--- a/cpp/tests/test_python_bindings.py
+++ b/cpp/tests/test_python_bindings.py
@@ -27,7 +27,13 @@ def test_version():
     import vanedb_cpp
     assert hasattr(vanedb_cpp, '__version__')
     assert isinstance(vanedb_cpp.__version__, str)
-    assert vanedb_cpp.__version__ == "0.1.0"
+    from importlib.metadata import version
+
+    from packaging.version import Version
+
+    # Against the distribution metadata, not a literal — see the note in
+    # vanedb-py/tests/test_vanedb.py.
+    assert Version(vanedb_cpp.__version__) == Version(version("vanedb-cpp"))
     assert vanedb_cpp.VERSION_MAJOR == 0
     assert vanedb_cpp.VERSION_MINOR == 1
     assert vanedb_cpp.VERSION_PATCH == 0

--- a/vanedb-capi/Cargo.toml
+++ b/vanedb-capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vanedb-capi"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 edition = "2021"
 # Not published: the vanedb dependency is a path without a version, and the
 # crate carries no description or license, so `cargo publish` rejects it. The

--- a/vanedb-py/Cargo.toml
+++ b/vanedb-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vanedb-py"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 edition = "2021"
 publish = false
 

--- a/vanedb-py/pyproject.toml
+++ b/vanedb-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "vanedb"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 description = "Embeddable vector database for edge AI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/vanedb-py/src/lib.rs
+++ b/vanedb-py/src/lib.rs
@@ -322,7 +322,10 @@ impl PyHnswIndex {
 
 #[pymodule]
 fn vanedb(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add("__version__", "0.1.0")?;
+    // From Cargo.toml, never a literal: a hardcoded string silently
+    // disagreed with the wheel's own metadata the first time the
+    // version moved.
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     m.add_class::<PyDistanceMetric>()?;
     m.add_class::<PyVectorStore>()?;
     m.add_class::<PyHnswIndex>()?;

--- a/vanedb-py/tests/test_vanedb.py
+++ b/vanedb-py/tests/test_vanedb.py
@@ -6,7 +6,15 @@ import pytest
 
 
 def test_version():
-    assert vanedb.__version__ == "0.1.0"
+    # Compared against the distribution's own metadata rather than a literal:
+    # a literal has to be edited on every bump, and silently passed while
+    # __version__ and the wheel metadata disagreed. Version() normalises, so
+    # the SemVer spelling (0.1.0-rc.1) and the PEP 440 one (0.1.0rc1) match.
+    from importlib.metadata import version
+
+    from packaging.version import Version
+
+    assert Version(vanedb.__version__) == Version(version("vanedb"))
 
 
 # --- VectorStore ---

--- a/vanedb-wasm/Cargo.toml
+++ b/vanedb-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vanedb-wasm"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 edition = "2021"
 publish = false
 

--- a/vanedb/Cargo.toml
+++ b/vanedb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vanedb"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 edition = "2021"
 description = "Embeddable vector database for edge AI"
 readme = "README.md"


### PR DESCRIPTION
Sets every package to `0.1.0-rc.1` so the first real publication is opt-in.

## Why a pre-release rather than 0.0.1

`0.0.1` and `0.1.0` are both *normal* releases — `pip install vanedb` and `cargo add vanedb` pick either up by default. A low number signals immaturity to a human and to nothing else.

A pre-release is the only version the resolvers themselves treat as opt-in: pip skips it without `--pre`, and Cargo's `"0.1.0"` requirement does **not** match `0.1.0-rc.1`. Under Cargo there's a second reason to avoid `0.0.x`: every `0.0.x` is mutually incompatible, so each patch would be a breaking bump for anyone depending on you.

It also claims all four names now — the only item here with an external clock — while leaving `0.1.0` free for the release you actually stand behind.

## One spelling, both ecosystems

`0.1.0-rc.1` is valid SemVer; PEP 440 normalises it to `0.1.0rc1`. Verified rather than assumed:

| Check | Result |
|---|---|
| `cargo publish --dry-run` | `Packaging vanedb v0.1.0-rc.1` |
| `maturin build` | `vanedb-0.1.0rc1-cp313-cp313-macosx_11_0_arm64.whl` |
| `twine check --strict` | PASSED (wheel + sdist) |
| `validate_python_release.py` | `validated vanedb 0.1.0rc1: 1 wheels, 1 sdist` |

The validator compares through `packaging.version.Version`, so the declared `0.1.0-rc.1` and the built `0.1.0rc1` match.

## The bump exposed a real defect

`vanedb-py` **hardcoded** `__version__` as `"0.1.0"` in `lib.rs`, so the installed wheel reported:

```
__version__   : '0.1.0'        ← hardcoded literal
dist metadata : '0.1.0rc1'     ← actual package version
```

The package disagreed with itself, and would have shipped that way. `__version__` now comes from `CARGO_PKG_VERSION` and cannot drift again:

```
__version__   : '0.1.0-rc.1'
dist metadata : '0.1.0rc1'
agree         : True
```

Both test suites now compare `__version__` against the distribution's own metadata instead of a literal — the literal is what let the two disagree silently, and it had to be hand-edited on every bump. `pytest` already requires `packaging>=22`, so no new test dependency.

## Also

Both lockfiles updated, including `bench/Cargo.lock`, which `--locked` would have rejected in CI.

`cargo fmt --check`, `clippy -D warnings`, full workspace tests: clean. 35 Python tests pass against a freshly built and installed rc wheel.

## Next

After merge, a full TestPyPI publication at the rc — exercising the same path end to end before anything irreversible on real PyPI or crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H