### PR TITLE
fix(bindings): stop leaking wrapper prefixes and unify the count method

### DIFF
--- a/vanedb-py/src/lib.rs
+++ b/vanedb-py/src/lib.rs
@@ -209,6 +209,15 @@ impl PyVectorStore {
         self.inner.len()
     }
 
+    /// Number of vectors stored.
+    ///
+    /// `len(store)` is the Pythonic spelling; `size()` is what vanedb_cpp and
+    /// the wasm bindings expose. Both work here so neither spelling ties a
+    /// program to one engine (#85).
+    fn size(&self) -> usize {
+        self.inner.len()
+    }
+
     #[getter]
     fn dimension(&self) -> usize {
         self.inner.dimension()
@@ -309,6 +318,11 @@ impl PyHnswIndex {
         self.inner.size()
     }
 
+    /// Number of vectors in the graph. See `VectorStore.size`.
+    fn size(&self) -> usize {
+        self.inner.size()
+    }
+
     #[getter]
     fn dimension(&self) -> usize {
         self.inner.dimension()
@@ -329,5 +343,12 @@ fn vanedb(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyDistanceMetric>()?;
     m.add_class::<PyVectorStore>()?;
     m.add_class::<PyHnswIndex>()?;
+    // maturin's generated __init__ does `from .vanedb import *` and copies
+    // __all__ verbatim, so this list is the package's entire public surface --
+    // omitting __version__ here removes it from the package altogether.
+    m.add(
+        "__all__",
+        vec!["DistanceMetric", "VectorStore", "HNSWIndex", "__version__"],
+    )?;
     Ok(())
 }

--- a/vanedb-py/tests/test_vanedb.py
+++ b/vanedb-py/tests/test_vanedb.py
@@ -155,3 +155,31 @@ def test_non_finite_vectors_and_queries_are_rejected(value):
     with pytest.raises(ValueError, match="finite"):
         index.add(1, [value, 0.0])
     assert len(index) == 0
+
+
+def test_count_spellings_agree():
+    """Both engines must answer "how many vectors?" the same way (#85)."""
+    store = vanedb.VectorStore(2)
+    index = vanedb.HNSWIndex(2, capacity=10)
+    for i, v in enumerate([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]):
+        store.add(i, v)
+        index.add(i, v)
+    assert len(store) == store.size() == 3
+    assert len(index) == index.size() == 3
+
+
+def test_public_surface_is_declared():
+    """__all__ is the whole package surface, not just a star-import filter.
+
+    maturin's generated __init__ copies __all__ verbatim after a star import,
+    so a name missing here is missing from the package: dropping __version__
+    from this list deleted vanedb.__version__ outright.
+    """
+    assert set(vanedb.__all__) == {
+        "DistanceMetric",
+        "VectorStore",
+        "HNSWIndex",
+        "__version__",
+    }
+    for name in vanedb.__all__:
+        assert hasattr(vanedb, name), f"{name} is exported but missing"

--- a/vanedb-wasm/src/lib.rs
+++ b/vanedb-wasm/src/lib.rs
@@ -5,13 +5,16 @@ use vanedb::hnsw::HnswIndex;
 use vanedb::store::{SearchResult, VectorStore};
 
 /// Search results with lossless 64-bit ids.
-#[wasm_bindgen]
+// The Wasm prefix disambiguates these wrappers from the core types
+// imported above; js_name keeps it out of the public JS API, which uses
+// the same three names as the Python packages (#83).
+#[wasm_bindgen(js_name = SearchResults)]
 pub struct WasmSearchResults {
     ids: Vec<u64>,
     distances: Vec<f32>,
 }
 
-#[wasm_bindgen]
+#[wasm_bindgen(js_class = SearchResults)]
 impl WasmSearchResults {
     /// Matched ids, in rank order, as a `BigUint64Array`.
     #[wasm_bindgen(getter)]
@@ -65,12 +68,12 @@ pub fn version() -> String {
 }
 
 /// Brute-force vector store for the browser.
-#[wasm_bindgen]
+#[wasm_bindgen(js_name = VectorStore)]
 pub struct WasmVectorStore {
     inner: VectorStore,
 }
 
-#[wasm_bindgen]
+#[wasm_bindgen(js_class = VectorStore)]
 impl WasmVectorStore {
     #[wasm_bindgen(constructor)]
     pub fn new(dim: usize, metric: &str) -> Result<WasmVectorStore, JsError> {
@@ -123,12 +126,12 @@ impl WasmVectorStore {
 }
 
 /// HNSW approximate nearest-neighbor index for the browser.
-#[wasm_bindgen]
+#[wasm_bindgen(js_name = HNSWIndex)]
 pub struct WasmHnswIndex {
     inner: HnswIndex,
 }
 
-#[wasm_bindgen]
+#[wasm_bindgen(js_class = HNSWIndex)]
 impl WasmHnswIndex {
     #[wasm_bindgen(constructor)]
     pub fn new(


### PR DESCRIPTION
Closes #83. Part of #85.

## The JS bindings had the same bug #79 fixed for Python

`vanedb-wasm` declared **no `js_name` anywhere**, so the internal `Wasm` prefix was the public JavaScript API:

```js
new WasmHnswIndex(...)   // before
new HNSWIndex(...)       // after
```

Three of four bindings agreed on `VectorStore` / `HNSWIndex`; JS was the outlier. Now all four match.

Renaming a struct also requires `js_class` on its `impl` block — without it the build fails with `class WasmHnswIndex referenced by an impl block does not match any exported struct`. Caught by actually running `wasm-pack build` rather than trusting the annotation.

## Counting no longer depends on the engine

`len(store)` worked on `vanedb` and failed on `vanedb_cpp`; `store.size()` was the reverse. Either spelling broke one engine. The Python classes now expose both.

## `__all__`, and what it actually does here

maturin's generated `__init__.py` is:

```python
from .vanedb import *
if hasattr(vanedb, "__all__"):
    __all__ = vanedb.__all__
```

So `__all__` is **the whole package surface**, not a star-import filter. My first attempt omitted `__version__` and thereby deleted `vanedb.__version__` from the package — caught immediately because the wheel tests run against the installed artifact. The test now asserts every exported name resolves, so that can't recur.

## Verified against built artifacts

| Check | Result |
|---|---|
| Generated `vanedb_wasm.d.ts` | `export class HNSWIndex` / `SearchResults` / `VectorStore` |
| `Wasm`-prefixed names remaining in `.d.ts` | **0** |
| `wasm-pack test --node` | 12 passed |
| Python suite vs installed wheel | 37 passed (2 new) |
| fmt / clippy / workspace tests / `cargo check -p vanedb-py` | clean |

## Left for follow-ups

- **#84** — `MmapVectorStore` missing from the Rust Python and wasm bindings. Additive, needs the `mmap` feature enabled on the dependency.
- **#85** — the Rust core still spells it `VectorStore::len()` but `HnswIndex::size()`. Breaking rename in the core; worth doing before 0.1.0 but not mixed into this.
- **#86** — `update`/`clear`/`reserve` are C++-only, and `ef_search` has three shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H