### PR TITLE
fix: harden the index load path and give the C ABI a panic boundary

### DIFF
--- a/vanedb-capi/include/vanedb_rs_capi.h
+++ b/vanedb-capi/include/vanedb_rs_capi.h
@@ -21,6 +21,7 @@ extern "C" {
 #endif // __cplusplus
 
 /**
+ * # Safety
  * `a` and `b` must each point to at least `dim` valid `f32` values.
  */
 float vanedb_rs_l2_sq(const float *a, const float *b, uintptr_t dim);

--- a/vanedb-capi/include/vanedb_rs_capi.h
+++ b/vanedb-capi/include/vanedb_rs_capi.h
@@ -21,7 +21,6 @@ extern "C" {
 #endif // __cplusplus
 
 /**
- * # Safety
  * `a` and `b` must each point to at least `dim` valid `f32` values.
  */
 float vanedb_rs_l2_sq(const float *a, const float *b, uintptr_t dim);

--- a/vanedb-capi/src/lib.rs
+++ b/vanedb-capi/src/lib.rs
@@ -20,10 +20,26 @@ fn to_metric(m: u32) -> Metric {
 }
 
 /// # Safety
+
+/// Runs `body`, returning `fallback` if it panics.
+///
+/// A panic unwinding out of an `extern "C"` function aborts the process, taking
+/// the embedding application with it. Every entry point routes through here so
+/// a bug surfaces as this ABI's ordinary failure value — null, 1, 0 or NaN —
+/// instead. vanedb-cpp wraps every entry point in try/catch for the same reason.
+fn guard<T>(fallback: T, body: impl FnOnce() -> T) -> T {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(body)) {
+        Ok(value) => value,
+        Err(_) => fallback,
+    }
+}
+
 /// `a` and `b` must each point to at least `dim` valid `f32` values.
 #[no_mangle]
 pub unsafe extern "C" fn vanedb_rs_l2_sq(a: *const f32, b: *const f32, dim: usize) -> f32 {
-    distance_fn(Metric::L2)(slice::from_raw_parts(a, dim), slice::from_raw_parts(b, dim))
+    guard(f32::NAN, || {
+        distance_fn(Metric::L2)(slice::from_raw_parts(a, dim), slice::from_raw_parts(b, dim))
+    })
 }
 
 /// # Safety
@@ -34,17 +50,21 @@ pub unsafe extern "C" fn vanedb_rs_cosine_distance(
     b: *const f32,
     dim: usize,
 ) -> f32 {
-    distance_fn(Metric::Cosine)(slice::from_raw_parts(a, dim), slice::from_raw_parts(b, dim))
+    guard(f32::NAN, || {
+        distance_fn(Metric::Cosine)(slice::from_raw_parts(a, dim), slice::from_raw_parts(b, dim))
+    })
 }
 
 /// # Safety
 /// `a` and `b` must each point to at least `dim` valid `f32` values.
 #[no_mangle]
 pub unsafe extern "C" fn vanedb_rs_dot_product(a: *const f32, b: *const f32, dim: usize) -> f32 {
-    // Negate to get the raw inner product (+a·b). The core's distance_fn(Dot) returns the
-    // negated distance form (-a·b, lower=closer) for search ranking. This C ABI function must
-    // return the raw product to match vanedb_cpp_dot_product, which returns +a·b.
-    -distance_fn(Metric::Dot)(slice::from_raw_parts(a, dim), slice::from_raw_parts(b, dim))
+    guard(f32::NAN, || {
+        // Negate to get the raw inner product (+a·b). The core's distance_fn(Dot) returns the
+        // negated distance form (-a·b, lower=closer) for search ranking. This C ABI function must
+        // return the raw product to match vanedb_cpp_dot_product, which returns +a·b.
+        -distance_fn(Metric::Dot)(slice::from_raw_parts(a, dim), slice::from_raw_parts(b, dim))
+    })
 }
 
 /// # Safety
@@ -52,10 +72,12 @@ pub unsafe extern "C" fn vanedb_rs_dot_product(a: *const f32, b: *const f32, dim
 /// that must eventually be freed with `vanedb_rs_store_free`.
 #[no_mangle]
 pub unsafe extern "C" fn vanedb_rs_store_new(dim: usize, metric: u32) -> *mut Store {
-    match Store::new(dim, to_metric(metric)) {
-        Ok(s) => Box::into_raw(Box::new(s)),
-        Err(_) => std::ptr::null_mut(),
-    }
+    guard(std::ptr::null_mut(), || {
+        match Store::new(dim, to_metric(metric)) {
+            Ok(s) => Box::into_raw(Box::new(s)),
+            Err(_) => std::ptr::null_mut(),
+        }
+    })
 }
 
 /// # Safety
@@ -63,15 +85,17 @@ pub unsafe extern "C" fn vanedb_rs_store_new(dim: usize, metric: u32) -> *mut St
 /// `v` must point to at least `dim` valid `f32` values (where `dim` matches the store).
 #[no_mangle]
 pub unsafe extern "C" fn vanedb_rs_store_add(s: *mut Store, id: u64, v: *const f32) -> i32 {
-    if s.is_null() {
-        return 1;
-    }
-    let store = &*s;
-    let vec = slice::from_raw_parts(v, store.dimension());
-    match store.add(id, vec) {
-        Ok(()) => 0,
-        Err(_) => 1,
-    }
+    guard(1, || {
+        if s.is_null() {
+            return 1;
+        }
+        let store = &*s;
+        let vec = slice::from_raw_parts(v, store.dimension());
+        match store.add(id, vec) {
+            Ok(()) => 0,
+            Err(_) => 1,
+        }
+    })
 }
 
 /// # Safety
@@ -85,22 +109,24 @@ pub unsafe extern "C" fn vanedb_rs_store_add_batch(
     vecs: *const f32,
     n: usize,
 ) -> i32 {
-    if s.is_null() {
-        return 1;
-    }
-    let store = &*s;
-    let (id_slice, vec_slice): (&[u64], &[f32]) = if n == 0 {
-        (&[], &[])
-    } else {
-        (
-            slice::from_raw_parts(ids, n),
-            slice::from_raw_parts(vecs, n * store.dimension()),
-        )
-    };
-    match store.add_batch(id_slice, vec_slice) {
-        Ok(()) => 0,
-        Err(_) => 1,
-    }
+    guard(1, || {
+        if s.is_null() {
+            return 1;
+        }
+        let store = &*s;
+        let (id_slice, vec_slice): (&[u64], &[f32]) = if n == 0 {
+            (&[], &[])
+        } else {
+            (
+                slice::from_raw_parts(ids, n),
+                slice::from_raw_parts(vecs, n * store.dimension()),
+            )
+        };
+        match store.add_batch(id_slice, vec_slice) {
+            Ok(()) => 0,
+            Err(_) => 1,
+        }
+    })
 }
 
 /// # Safety
@@ -114,22 +140,24 @@ pub unsafe extern "C" fn vanedb_rs_store_search(
     out_ids: *mut u64,
     out_dists: *mut f32,
 ) -> usize {
-    if s.is_null() {
-        return 0;
-    }
-    let store = &*s;
-    let query = slice::from_raw_parts(q, store.dimension());
-    match store.search(query, k) {
-        Ok(res) => {
-            let n = res.len().min(k);
-            for (i, r) in res.iter().take(k).enumerate() {
-                *out_ids.add(i) = r.id;
-                *out_dists.add(i) = r.distance;
-            }
-            n
+    guard(0, || {
+        if s.is_null() {
+            return 0;
         }
-        Err(_) => 0,
-    }
+        let store = &*s;
+        let query = slice::from_raw_parts(q, store.dimension());
+        match store.search(query, k) {
+            Ok(res) => {
+                let n = res.len().min(k);
+                for (i, r) in res.iter().take(k).enumerate() {
+                    *out_ids.add(i) = r.id;
+                    *out_dists.add(i) = r.distance;
+                }
+                n
+            }
+            Err(_) => 0,
+        }
+    })
 }
 
 /// # Safety
@@ -137,9 +165,11 @@ pub unsafe extern "C" fn vanedb_rs_store_search(
 /// (or be null, which is a no-op).
 #[no_mangle]
 pub unsafe extern "C" fn vanedb_rs_store_free(s: *mut Store) {
-    if !s.is_null() {
-        drop(Box::from_raw(s));
-    }
+    guard((), || {
+        if !s.is_null() {
+            drop(Box::from_raw(s));
+        }
+    })
 }
 
 /// # Safety
@@ -154,16 +184,18 @@ pub unsafe extern "C" fn vanedb_rs_index_new(
     ef_construction: usize,
     seed: u64,
 ) -> *mut Index {
-    match Index::builder(dim, to_metric(metric))
-        .capacity(capacity)
-        .m(m)
-        .ef_construction(ef_construction)
-        .seed(seed)
-        .build()
-    {
-        Ok(h) => Box::into_raw(Box::new(h)),
-        Err(_) => std::ptr::null_mut(),
-    }
+    guard(std::ptr::null_mut(), || {
+        match Index::builder(dim, to_metric(metric))
+            .capacity(capacity)
+            .m(m)
+            .ef_construction(ef_construction)
+            .seed(seed)
+            .build()
+        {
+            Ok(h) => Box::into_raw(Box::new(h)),
+            Err(_) => std::ptr::null_mut(),
+        }
+    })
 }
 
 /// # Safety
@@ -171,15 +203,17 @@ pub unsafe extern "C" fn vanedb_rs_index_new(
 /// `v` must point to at least `dim` valid `f32` values (where `dim` matches the index).
 #[no_mangle]
 pub unsafe extern "C" fn vanedb_rs_index_add(h: *mut Index, id: u64, v: *const f32) -> i32 {
-    if h.is_null() {
-        return 1;
-    }
-    let idx = &*h;
-    let vec = slice::from_raw_parts(v, idx.dimension());
-    match idx.add(id, vec) {
-        Ok(()) => 0,
-        Err(_) => 1,
-    }
+    guard(1, || {
+        if h.is_null() {
+            return 1;
+        }
+        let idx = &*h;
+        let vec = slice::from_raw_parts(v, idx.dimension());
+        match idx.add(id, vec) {
+            Ok(()) => 0,
+            Err(_) => 1,
+        }
+    })
 }
 
 /// # Safety
@@ -193,22 +227,24 @@ pub unsafe extern "C" fn vanedb_rs_index_add_batch(
     vecs: *const f32,
     n: usize,
 ) -> i32 {
-    if h.is_null() {
-        return 1;
-    }
-    let idx = &*h;
-    let (id_slice, vec_slice): (&[u64], &[f32]) = if n == 0 {
-        (&[], &[])
-    } else {
-        (
-            slice::from_raw_parts(ids, n),
-            slice::from_raw_parts(vecs, n * idx.dimension()),
-        )
-    };
-    match idx.add_batch(id_slice, vec_slice) {
-        Ok(()) => 0,
-        Err(_) => 1,
-    }
+    guard(1, || {
+        if h.is_null() {
+            return 1;
+        }
+        let idx = &*h;
+        let (id_slice, vec_slice): (&[u64], &[f32]) = if n == 0 {
+            (&[], &[])
+        } else {
+            (
+                slice::from_raw_parts(ids, n),
+                slice::from_raw_parts(vecs, n * idx.dimension()),
+            )
+        };
+        match idx.add_batch(id_slice, vec_slice) {
+            Ok(()) => 0,
+            Err(_) => 1,
+        }
+    })
 }
 
 /// # Safety
@@ -223,23 +259,25 @@ pub unsafe extern "C" fn vanedb_rs_index_search(
     out_ids: *mut u64,
     out_dists: *mut f32,
 ) -> usize {
-    if h.is_null() {
-        return 0;
-    }
-    let idx = &*h;
-    idx.set_ef_search(ef_search);
-    let query = slice::from_raw_parts(q, idx.dimension());
-    match idx.search(query, k) {
-        Ok(res) => {
-            let n = res.len().min(k);
-            for (i, r) in res.iter().take(k).enumerate() {
-                *out_ids.add(i) = r.id;
-                *out_dists.add(i) = r.distance;
-            }
-            n
+    guard(0, || {
+        if h.is_null() {
+            return 0;
         }
-        Err(_) => 0,
-    }
+        let idx = &*h;
+        idx.set_ef_search(ef_search);
+        let query = slice::from_raw_parts(q, idx.dimension());
+        match idx.search(query, k) {
+            Ok(res) => {
+                let n = res.len().min(k);
+                for (i, r) in res.iter().take(k).enumerate() {
+                    *out_ids.add(i) = r.id;
+                    *out_dists.add(i) = r.distance;
+                }
+                n
+            }
+            Err(_) => 0,
+        }
+    })
 }
 
 /// # Safety
@@ -247,20 +285,22 @@ pub unsafe extern "C" fn vanedb_rs_index_search(
 /// `path` must be a valid NUL-terminated C string.
 #[no_mangle]
 pub unsafe extern "C" fn vanedb_rs_index_save(h: *mut Index, path: *const c_char) -> i32 {
-    if h.is_null() {
-        return 1;
-    }
-    if path.is_null() {
-        return 1;
-    }
-    let idx = &*h;
-    match CStr::from_ptr(path).to_str() {
-        Ok(p) => match idx.save(p) {
-            Ok(()) => 0,
+    guard(1, || {
+        if h.is_null() {
+            return 1;
+        }
+        if path.is_null() {
+            return 1;
+        }
+        let idx = &*h;
+        match CStr::from_ptr(path).to_str() {
+            Ok(p) => match idx.save(p) {
+                Ok(()) => 0,
+                Err(_) => 1,
+            },
             Err(_) => 1,
-        },
-        Err(_) => 1,
-    }
+        }
+    })
 }
 
 /// # Safety
@@ -268,16 +308,18 @@ pub unsafe extern "C" fn vanedb_rs_index_save(h: *mut Index, path: *const c_char
 /// that must be freed with `vanedb_rs_index_free`.
 #[no_mangle]
 pub unsafe extern "C" fn vanedb_rs_index_load(path: *const c_char) -> *mut Index {
-    if path.is_null() {
-        return std::ptr::null_mut();
-    }
-    match CStr::from_ptr(path).to_str() {
-        Ok(p) => match Index::load(p) {
-            Ok(h) => Box::into_raw(Box::new(h)),
+    guard(std::ptr::null_mut(), || {
+        if path.is_null() {
+            return std::ptr::null_mut();
+        }
+        match CStr::from_ptr(path).to_str() {
+            Ok(p) => match Index::load(p) {
+                Ok(h) => Box::into_raw(Box::new(h)),
+                Err(_) => std::ptr::null_mut(),
+            },
             Err(_) => std::ptr::null_mut(),
-        },
-        Err(_) => std::ptr::null_mut(),
-    }
+        }
+    })
 }
 
 /// # Safety
@@ -285,9 +327,11 @@ pub unsafe extern "C" fn vanedb_rs_index_load(path: *const c_char) -> *mut Index
 /// and not been freed already (or be null, which is a no-op).
 #[no_mangle]
 pub unsafe extern "C" fn vanedb_rs_index_free(h: *mut Index) {
-    if !h.is_null() {
-        drop(Box::from_raw(h));
-    }
+    guard((), || {
+        if !h.is_null() {
+            drop(Box::from_raw(h));
+        }
+    })
 }
 
 /// # Safety
@@ -302,32 +346,34 @@ pub unsafe extern "C" fn vanedb_rs_disk_build(
     vecs: *const f32,
     n: usize,
 ) -> i32 {
-    if path.is_null() {
-        return 1;
-    }
-    let p = match CStr::from_ptr(path).to_str() {
-        Ok(s) => s,
-        Err(_) => return 1,
-    };
-    let mut b = match DiskStoreBuilder::new(dim, to_metric(metric)) {
-        Ok(b) => b,
-        Err(_) => return 1,
-    };
-    let id_slice: &[u64] = if n == 0 {
-        &[]
-    } else {
-        slice::from_raw_parts(ids, n)
-    };
-    for (i, &id) in id_slice.iter().enumerate() {
-        let v = slice::from_raw_parts(vecs.add(i * dim), dim);
-        if b.add(id, v).is_err() {
+    guard(1, || {
+        if path.is_null() {
             return 1;
         }
-    }
-    match b.save(p) {
-        Ok(()) => 0,
-        Err(_) => 1,
-    }
+        let p = match CStr::from_ptr(path).to_str() {
+            Ok(s) => s,
+            Err(_) => return 1,
+        };
+        let mut b = match DiskStoreBuilder::new(dim, to_metric(metric)) {
+            Ok(b) => b,
+            Err(_) => return 1,
+        };
+        let id_slice: &[u64] = if n == 0 {
+            &[]
+        } else {
+            slice::from_raw_parts(ids, n)
+        };
+        for (i, &id) in id_slice.iter().enumerate() {
+            let v = slice::from_raw_parts(vecs.add(i * dim), dim);
+            if b.add(id, v).is_err() {
+                return 1;
+            }
+        }
+        match b.save(p) {
+            Ok(()) => 0,
+            Err(_) => 1,
+        }
+    })
 }
 
 /// # Safety
@@ -335,16 +381,18 @@ pub unsafe extern "C" fn vanedb_rs_disk_build(
 /// that must be freed with `vanedb_rs_disk_free`.
 #[no_mangle]
 pub unsafe extern "C" fn vanedb_rs_disk_open(path: *const c_char) -> *mut DiskStore {
-    if path.is_null() {
-        return std::ptr::null_mut();
-    }
-    match CStr::from_ptr(path).to_str() {
-        Ok(p) => match DiskStore::open(p) {
-            Ok(m) => Box::into_raw(Box::new(m)),
+    guard(std::ptr::null_mut(), || {
+        if path.is_null() {
+            return std::ptr::null_mut();
+        }
+        match CStr::from_ptr(path).to_str() {
+            Ok(p) => match DiskStore::open(p) {
+                Ok(m) => Box::into_raw(Box::new(m)),
+                Err(_) => std::ptr::null_mut(),
+            },
             Err(_) => std::ptr::null_mut(),
-        },
-        Err(_) => std::ptr::null_mut(),
-    }
+        }
+    })
 }
 
 /// # Safety
@@ -358,22 +406,24 @@ pub unsafe extern "C" fn vanedb_rs_disk_search(
     out_ids: *mut u64,
     out_dists: *mut f32,
 ) -> usize {
-    if m.is_null() {
-        return 0;
-    }
-    let store = &*m;
-    let query = slice::from_raw_parts(q, store.dimension());
-    match store.search(query, k) {
-        Ok(res) => {
-            let n = res.len().min(k);
-            for (i, r) in res.iter().take(k).enumerate() {
-                *out_ids.add(i) = r.id;
-                *out_dists.add(i) = r.distance;
-            }
-            n
+    guard(0, || {
+        if m.is_null() {
+            return 0;
         }
-        Err(_) => 0,
-    }
+        let store = &*m;
+        let query = slice::from_raw_parts(q, store.dimension());
+        match store.search(query, k) {
+            Ok(res) => {
+                let n = res.len().min(k);
+                for (i, r) in res.iter().take(k).enumerate() {
+                    *out_ids.add(i) = r.id;
+                    *out_dists.add(i) = r.distance;
+                }
+                n
+            }
+            Err(_) => 0,
+        }
+    })
 }
 
 /// # Safety
@@ -381,7 +431,32 @@ pub unsafe extern "C" fn vanedb_rs_disk_search(
 /// (or be null, which is a no-op).
 #[no_mangle]
 pub unsafe extern "C" fn vanedb_rs_disk_free(m: *mut DiskStore) {
-    if !m.is_null() {
-        drop(Box::from_raw(m));
+    guard((), || {
+        if !m.is_null() {
+            drop(Box::from_raw(m));
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::guard;
+
+    /// The guard is what stands between an engine bug and a dead host process,
+    /// so it is tested directly rather than through a contrived engine panic —
+    /// an entry-point test that never actually panics would pass with the
+    /// guard removed and prove nothing.
+    #[test]
+    fn a_panic_becomes_the_fallback() {
+        assert_eq!(guard(1i32, || panic!("engine bug")), 1);
+        assert_eq!(guard(0usize, || panic!("engine bug")), 0);
+        assert!(guard(f32::NAN, || panic!("engine bug")).is_nan());
+        assert!(guard(std::ptr::null_mut::<u8>(), || panic!("engine bug")).is_null());
+    }
+
+    #[test]
+    fn a_normal_return_passes_through_untouched() {
+        assert_eq!(guard(1i32, || 0i32), 0);
+        assert_eq!(guard(0usize, || 7usize), 7);
     }
 }

--- a/vanedb-capi/src/lib.rs
+++ b/vanedb-capi/src/lib.rs
@@ -19,8 +19,6 @@ fn to_metric(m: u32) -> Metric {
     }
 }
 
-/// # Safety
-
 /// Runs `body`, returning `fallback` if it panics.
 ///
 /// A panic unwinding out of an `extern "C"` function aborts the process, taking
@@ -34,6 +32,7 @@ fn guard<T>(fallback: T, body: impl FnOnce() -> T) -> T {
     }
 }
 
+/// # Safety
 /// `a` and `b` must each point to at least `dim` valid `f32` values.
 #[no_mangle]
 pub unsafe extern "C" fn vanedb_rs_l2_sq(a: *const f32, b: *const f32, dim: usize) -> f32 {

--- a/vanedb/src/index/persistence.rs
+++ b/vanedb/src/index/persistence.rs
@@ -20,6 +20,11 @@ use crate::error::{Result, VaneError};
 /// compatibility with files written before the rename. Rust never shipped
 /// pre-rename, so we use a clean per-format magic.
 const MAGIC: u32 = u32::from_le_bytes(*b"HNSW");
+
+/// Upper bound on `max_elements` accepted from a file. Mirrors `MAX_VEC_SIZE`
+/// in vanedb-cpp `src/core/index.h`: `load` re-expands every array to
+/// `max_elements`, so without a cap a few hundred bytes can request terabytes.
+const MAX_ELEMENTS: usize = 100_000_000;
 /// v1 stored the full pre-allocated arrays (`max_elements` entries even when
 /// only `count` were inserted). v2 stores only the `count` live entries and
 /// re-expands to `max_elements` on load (issue #18). v1 files remain loadable.
@@ -160,6 +165,35 @@ impl Index {
         if data.max_elements == 0 {
             return Err(VaneError::Io("invalid max_elements: 0".to_string()));
         }
+        // A file declares max_elements; load re-expands every array to it. Cap
+        // it so a few hundred bytes cannot request terabytes. vanedb-cpp caps
+        // every deserialized array the same way (MAX_VEC_SIZE in
+        // src/core/index.h).
+        if data.max_elements > MAX_ELEMENTS {
+            return Err(VaneError::Io(format!(
+                "corrupted file: max_elements {} exceeds the {MAX_ELEMENTS} limit",
+                data.max_elements
+            )));
+        }
+        // C++ validates these on load; Rust checked them only at build time,
+        // so a hostile file could set m = 0 and make the level maths degenerate.
+        if data.m < 2 {
+            return Err(VaneError::Io(format!(
+                "corrupted file: m {} is below 2",
+                data.m
+            )));
+        }
+        if data.ef_construction == 0 {
+            return Err(VaneError::Io(
+                "corrupted file: ef_construction is 0".to_string(),
+            ));
+        }
+        if data.m_max0 != data.m * 2 || data.m_max != data.m {
+            return Err(VaneError::Io(format!(
+                "corrupted file: m_max {} / m_max0 {} disagree with m {}",
+                data.m_max, data.m_max0, data.m
+            )));
+        }
         if data.count > data.max_elements {
             return Err(VaneError::Io(format!(
                 "corrupted file: count {} exceeds max_elements {}",
@@ -284,13 +318,22 @@ impl Index {
 
         // Re-expand to the pre-allocated capacity layout Inner expects. For
         // v1 the arrays are already full-length, so these are no-ops.
+        //
+        // Reserve fallibly first: `resize` aborts the process on allocation
+        // failure, and this is the path that reads untrusted files. The cap
+        // above bounds the request; this turns a genuine OOM into an error
+        // rather than killing the host application (#89).
         let mut vectors = data.vectors;
+        try_grow(&mut vectors, full_vecs_len, "vectors")?;
         vectors.resize(full_vecs_len, 0.0);
         let mut ext_ids = data.ext_ids;
+        try_grow(&mut ext_ids, data.max_elements, "ext_ids")?;
         ext_ids.resize(data.max_elements, 0);
         let mut levels = data.levels;
+        try_grow(&mut levels, data.max_elements, "levels")?;
         levels.resize(data.max_elements, 0);
         let mut neighbors = data.neighbors;
+        try_grow(&mut neighbors, data.max_elements, "neighbors")?;
         neighbors.resize_with(data.max_elements, Vec::new);
 
         // Reconstitute RNG: seed from the original seed, then advance through
@@ -327,4 +370,18 @@ impl Index {
             }),
         })
     }
+}
+
+/// Reserve room for `target` elements without aborting on failure.
+///
+/// `Vec::resize` cannot fail: allocation failure aborts the process. Every
+/// growth on the load path goes through here, so a hostile or corrupt file
+/// yields an error instead of killing the host application (#89).
+fn try_grow<T>(v: &mut Vec<T>, target: usize, what: &str) -> Result<()> {
+    let additional = target.saturating_sub(v.len());
+    v.try_reserve_exact(additional).map_err(|_| {
+        VaneError::Io(format!(
+            "corrupted file: cannot allocate {target} {what} entries"
+        ))
+    })
 }

--- a/vanedb/tests/corruption_tests.rs
+++ b/vanedb/tests/corruption_tests.rs
@@ -377,3 +377,63 @@ fn mmap_search_rejects_zero_k() {
     assert!(store.search(&[1.0, 2.0, 3.0], 0).is_err());
     let _ = fs::remove_file(&path);
 }
+
+/// A v2 payload whose arrays hold `count` live slots but which declares an
+/// enormous `max_elements`. `load` re-expands the arrays to `max_elements`,
+/// so an unbounded declaration is an allocation request from a tiny file.
+fn v2_huge_max_elements(max_elements: usize) -> HnswDataMirror {
+    HnswDataMirror {
+        dim: 2,
+        metric: 0,
+        max_elements,
+        m: 16,
+        m_max: 16,
+        m_max0: 32,
+        ef_construction: 200,
+        ef_search: 50,
+        mult: 1.0 / (16f64).ln(),
+        seed: 42,
+        count: 1,
+        entry_point: Some(0),
+        max_level: 0,
+        vectors: vec![1.0, 2.0],
+        ext_ids: vec![10],
+        levels: vec![0],
+        neighbors: vec![vec![vec![]]],
+        id_map: std::collections::HashMap::from([(10, 0)]),
+    }
+}
+
+#[test]
+fn hnsw_load_rejects_an_unallocatable_max_elements() {
+    // ~2^40 slots: the file is a few hundred bytes, the declared expansion is
+    // terabytes. Must be an error, not an abort.
+    let bytes = hnsw_file_bytes(2, &v2_huge_max_elements(1 << 40));
+    let p = write_tmp("huge_max_elements", &bytes);
+    let err = Index::load(&p).err().expect("must reject, not allocate");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("max_elements") || msg.contains("too large"),
+        "unhelpful message: {msg}"
+    );
+}
+
+#[test]
+fn hnsw_load_rejects_invalid_graph_parameters() {
+    // m < 2 makes mult and the level distribution meaningless; C++ validates
+    // it on load and Rust did not.
+    let mut data = v2_huge_max_elements(4);
+    data.m = 1;
+    let bytes = hnsw_file_bytes(2, &data);
+    let p = write_tmp("bad_m", &bytes);
+    assert!(Index::load(&p).is_err(), "m = 1 must be rejected on load");
+
+    let mut data = v2_huge_max_elements(4);
+    data.ef_construction = 0;
+    let bytes = hnsw_file_bytes(2, &data);
+    let p = write_tmp("bad_efc", &bytes);
+    assert!(
+        Index::load(&p).is_err(),
+        "ef_construction = 0 must be rejected on load"
+    );
+}


### PR DESCRIPTION
Refs #89. The critical half — the other half (`IndexBuilder::build`'s eager allocation) is subsumed by the chunked-storage work for #90, which removes that allocation entirely.

## The load path

`Index::load` re-expanded four arrays to a `max_elements` read straight from the file, using infallible `resize`. Validation checked only that it was non-zero and that `max_elements × dim` did not overflow.

The test I wrote for this **did not fail — it hung**, which is the vulnerability: a few-hundred-byte file declaring `2^40` slots drives a terabyte-scale allocation.

- `max_elements` capped at 100,000,000, mirroring `MAX_VEC_SIZE` in the C++ loader.
- All four re-expansions go through `try_reserve`, so a genuine allocation failure returns an error instead of aborting.
- `m`, `ef_construction` and the `m_max`/`m_max0` relationship are now validated on load. C++ checks these; Rust only checked them at build time, so a file could set `m = 0` and make the level maths degenerate.

Both new cases now return in milliseconds. Full corruption suite: **18 passed**.

## The panic boundary

A panic unwinding out of an `extern "C"` function aborts the process. The Rust C ABI had no boundary on any of its 19 entry points:

```
catch_unwind in vanedb-capi/src/lib.rs   0
catch blocks in cpp/capi/vanedb_capi.cpp 11
```

Where C++ returns a failure code, Rust took the embedding application down. All 19 now route through a guard returning that function's ordinary failure value — null, `1`, `0`, or NaN.

**On how the guard is tested:** I first wrote entry-point tests that drove `store_search` with a small output buffer. They passed — and they also passed with the guard *removed*, because they never actually panicked. They proved nothing. The guard is now unit-tested directly, which is honest about what is being verified.

## Verification

All eleven CI invocations green, including the two (`bench` fmt and clippy) that `--all` and `--workspace` silently skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H