### PR TITLE
feat(index): grow storage on demand; capacity becomes a hint

### DIFF
--- a/vanedb-py/tests/test_numpy_batch.py
+++ b/vanedb-py/tests/test_numpy_batch.py
@@ -155,8 +155,11 @@ def test_hnsw_add_batch_matches_serial():
     assert serial.search(q, 10) == batched.search(q, 10)
 
 
-def test_hnsw_add_batch_capacity_all_or_nothing():
+def test_hnsw_add_batch_grows_past_the_capacity_hint():
+    """A batch running past the hint grows storage rather than failing.
+
+    All-or-nothing on a genuine failure is covered by the duplicate-id case.
+    """
     index = vanedb.Index(2, capacity=3)
-    with pytest.raises(ValueError, match="full"):
-        index.add_batch(np.arange(4), np.ones((4, 2), dtype=np.float32))
-    assert len(index) == 0
+    index.add_batch(np.arange(8), np.ones((8, 2), dtype=np.float32))
+    assert len(index) == 8

--- a/vanedb-py/tests/test_vanedb.py
+++ b/vanedb-py/tests/test_vanedb.py
@@ -129,15 +129,22 @@ def test_hnsw_ef_search():
     assert idx.ef_search == 200
 
 
+def test_hnsw_grows_past_the_capacity_hint():
+    """capacity reserves; it does not cap."""
+    idx = vanedb.Index(3, capacity=2)
+    for i in range(20):
+        idx.add(i, [float(i)] * 3)
+    assert len(idx) == 20
+    assert idx.search([19.0, 19.0, 19.0], 1)[0][0] == 19
+
+
 def test_hnsw_errors():
     idx = vanedb.Index(3, capacity=2)
     idx.add(0, [0.0, 0.0, 0.0])
-    idx.add(1, [1.0, 1.0, 1.0])
-    try:
-        idx.add(2, [2.0, 2.0, 2.0])  # full
-        assert False, "Should have raised"
-    except ValueError:
-        pass
+    with pytest.raises(ValueError):
+        idx.add(0, [1.0, 1.0, 1.0])  # duplicate id
+    with pytest.raises(ValueError):
+        idx.add(1, [1.0, 1.0])  # wrong dimension
 
 
 @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])

--- a/vanedb/src/error.rs
+++ b/vanedb/src/error.rs
@@ -24,8 +24,6 @@ pub enum VaneError {
     },
     /// `k` was zero, so there is no nearest neighbour to return.
     InvalidK,
-    /// The index has reached the capacity it was built with.
-    IndexFull,
     /// An input held a NaN or an infinity, which have no meaningful distance.
     NonFiniteValue {
         /// Which input was rejected, for the message.
@@ -48,7 +46,6 @@ impl std::fmt::Display for VaneError {
             Self::NotFound { id } => write!(f, "vector not found: {id}"),
             Self::DuplicateId { id } => write!(f, "duplicate id: {id}"),
             Self::InvalidK => write!(f, "k must be > 0"),
-            Self::IndexFull => write!(f, "index is full"),
             Self::NonFiniteValue { input } => {
                 write!(f, "{input} must contain only finite values")
             }
@@ -89,9 +86,7 @@ mod tests {
     }
 
     #[test]
-    fn error_display_index_full() {
-        assert_eq!(VaneError::IndexFull.to_string(), "index is full");
-    }
+    fn error_display_index_full() {}
 
     #[test]
     fn error_display_invalid_parameter() {

--- a/vanedb/src/index/mod.rs
+++ b/vanedb/src/index/mod.rs
@@ -20,6 +20,14 @@ use storage::ChunkedVectors;
 /// entry, but a hint of 10^9 should still not allocate gigabytes up front.
 const RESERVE_CAP: usize = 1 << 20;
 
+/// Largest number of vectors this engine will accept, from a builder hint or
+/// from a file. Mirrors `MAX_VEC_SIZE` in vanedb-cpp `src/core/index.h`.
+///
+/// Storage grows on demand, so this is not an allocation bound. It rejects
+/// values that can only be a mistake -- a capacity of `usize::MAX / 4096` is
+/// a bug in the caller, not a plan.
+pub(super) const MAX_ELEMENTS: usize = 100_000_000;
+
 mod persistence;
 mod storage;
 
@@ -470,8 +478,6 @@ impl Index {
         level.min(MAX_LEVEL)
     }
 
-    /// Get a vector slice by internal ID.
-
     /// Beam search on a single graph layer.
     /// Returns results sorted by distance ascending.
     ///
@@ -665,6 +671,11 @@ impl IndexBuilder {
             .ok_or(VaneError::InvalidParameter(
                 "capacity * dim overflows usize",
             ))?;
+        if self.capacity > MAX_ELEMENTS {
+            return Err(VaneError::InvalidParameter(
+                "capacity exceeds the maximum this engine accepts",
+            ));
+        }
         let vectors = ChunkedVectors::with_capacity(self.dim, self.capacity);
 
         Ok(Index {

--- a/vanedb/src/index/mod.rs
+++ b/vanedb/src/index/mod.rs
@@ -13,6 +13,12 @@ use crate::distance::{distance_fn, DistanceFn, Metric};
 use crate::error::{Result, VaneError};
 use crate::store::SearchResult;
 use crate::validation::{compare_distances, validate_finite};
+use storage::ChunkedVectors;
+
+/// Upper bound on how many sibling-array slots a capacity hint pre-reserves.
+/// The vectors themselves grow chunk by chunk; these arrays are small per
+/// entry, but a hint of 10^9 should still not allocate gigabytes up front.
+const RESERVE_CAP: usize = 1 << 20;
 
 mod persistence;
 mod storage;
@@ -125,7 +131,7 @@ pub struct Index {
 }
 
 pub(super) struct Inner {
-    pub(super) vectors: Vec<f32>,
+    pub(super) vectors: ChunkedVectors,
     pub(super) ext_ids: Vec<u64>,
     pub(super) id_map: HashMap<u64, usize>,
     pub(super) levels: Vec<i32>,
@@ -137,9 +143,6 @@ pub(super) struct Inner {
 }
 
 /// Configures an [`Index`] before construction.
-///
-/// Capacity is fixed once built, because the graph's storage is allocated up
-/// front.
 pub struct IndexBuilder {
     dim: usize,
     metric: Metric,
@@ -172,8 +175,11 @@ impl Index {
         self.size() == 0
     }
 
-    /// Vectors this index can hold; adding beyond it fails with
-    /// [`crate::VaneError::IndexFull`].
+    /// The capacity this index reserved for.
+    ///
+    /// A hint, not a limit: storage grows as vectors arrive, so adding beyond
+    /// this succeeds. It exists so a known-size bulk load can avoid growth
+    /// pauses.
     pub fn capacity(&self) -> usize {
         self.max_elements
     }
@@ -197,8 +203,7 @@ impl Index {
     pub fn get_vector(&self, id: u64) -> Result<Vec<f32>> {
         let inner = self.inner.read();
         let &iid = inner.id_map.get(&id).ok_or(VaneError::NotFound { id })?;
-        let start = iid * self.dim;
-        Ok(inner.vectors[start..start + self.dim].to_vec())
+        Ok(inner.vectors.get(iid).to_vec())
     }
 
     /// Sets the search beam width: higher recovers more true neighbours and
@@ -224,9 +229,6 @@ impl Index {
 
         let mut inner = self.inner.write();
 
-        if inner.count >= self.max_elements {
-            return Err(VaneError::IndexFull);
-        }
         if inner.id_map.contains_key(&id) {
             return Err(VaneError::DuplicateId { id });
         }
@@ -251,9 +253,6 @@ impl Index {
 
         let mut inner = self.inner.write();
 
-        if inner.count + ids.len() > self.max_elements {
-            return Err(VaneError::IndexFull);
-        }
         let mut seen = HashSet::with_capacity(ids.len());
         for &id in ids {
             if inner.id_map.contains_key(&id) || !seen.insert(id) {
@@ -274,18 +273,25 @@ impl Index {
         let iid = inner.count;
         inner.count += 1;
 
-        // Copy vector data
-        let start = iid * self.dim;
-        inner.vectors[start..start + self.dim].copy_from_slice(vector);
-        inner.ext_ids[iid] = id;
+        // Storage grows here rather than being pre-sized to capacity, so an
+        // empty index costs nothing and there is no ceiling to hit (#90).
+        inner.vectors.push(vector);
+        debug_assert_eq!(
+            inner.vectors.len(),
+            inner.count,
+            "storage and count diverged"
+        );
+        inner.ext_ids.push(id);
         inner.id_map.insert(id, iid);
 
         // Generate random level
         let level = Self::get_level(&mut inner.rng, self.mult);
-        inner.levels[iid] = level;
+        inner.levels.push(level);
 
         // Allocate neighbor lists for each layer
-        inner.neighbors[iid] = (0..=level as usize).map(|_| Vec::new()).collect();
+        inner
+            .neighbors
+            .push((0..=level as usize).map(|_| Vec::new()).collect());
 
         // First vector: set as entry point and return
         if iid == 0 {
@@ -299,7 +305,7 @@ impl Index {
 
         // Greedy descent through upper layers (above new node's level)
         for lev in (((level + 1) as usize)..=(cur_max_level as usize)).rev() {
-            let d = (self.dist_fn)(Self::get_vec(&inner.vectors, cur_ep, self.dim), vector);
+            let d = (self.dist_fn)(inner.vectors.get(cur_ep), vector);
             let mut cur_dist = d;
 
             let mut changed = true;
@@ -310,8 +316,7 @@ impl Index {
                     .cloned()
                     .unwrap_or_default();
                 for &nb in &neighbor_list {
-                    let nb_dist =
-                        (self.dist_fn)(Self::get_vec(&inner.vectors, nb, self.dim), vector);
+                    let nb_dist = (self.dist_fn)(inner.vectors.get(nb), vector);
                     if nb_dist < cur_dist {
                         cur_dist = nb_dist;
                         cur_ep = nb;
@@ -329,7 +334,6 @@ impl Index {
             let results = Self::search_layer(
                 &inner.vectors,
                 self.dist_fn,
-                self.dim,
                 &inner.neighbors,
                 vector,
                 ep_for_layer,
@@ -343,7 +347,7 @@ impl Index {
             // vanedb-cpp add() / hnswlib semantics.
             let m_for_layer = if lev == 0 { self.m_max0 } else { self.m_max };
             let neighbors_to_add =
-                Self::select_neighbors(&inner.vectors, self.dist_fn, self.dim, &results, self.m);
+                Self::select_neighbors(&inner.vectors, self.dist_fn, &results, self.m);
 
             // Set neighbors for the new node at this layer
             if lev < inner.neighbors[iid].len() {
@@ -357,14 +361,11 @@ impl Index {
                     inner.neighbors[nb][lev].push(iid);
                     // Prune if over capacity
                     if inner.neighbors[nb][lev].len() > m_for_layer {
-                        let nb_vec = Self::get_vec(&inner.vectors, nb, self.dim);
+                        let nb_vec = inner.vectors.get(nb);
                         let mut candidates: Vec<(f32, usize)> = inner.neighbors[nb][lev]
                             .iter()
                             .map(|&n| {
-                                let d = (self.dist_fn)(
-                                    nb_vec,
-                                    Self::get_vec(&inner.vectors, n, self.dim),
-                                );
+                                let d = (self.dist_fn)(nb_vec, inner.vectors.get(n));
                                 (d, n)
                             })
                             .collect();
@@ -414,7 +415,7 @@ impl Index {
         }
 
         let mut curr = inner.entry_point.unwrap();
-        let mut d = (self.dist_fn)(query, Self::get_vec(&inner.vectors, curr, self.dim));
+        let mut d = (self.dist_fn)(query, inner.vectors.get(curr));
 
         // Greedy descent through upper layers
         for l in (1..=inner.max_level).rev() {
@@ -424,7 +425,7 @@ impl Index {
                 changed = false;
                 if lu < inner.neighbors[curr].len() {
                     for &n in &inner.neighbors[curr][lu] {
-                        let nd = (self.dist_fn)(query, Self::get_vec(&inner.vectors, n, self.dim));
+                        let nd = (self.dist_fn)(query, inner.vectors.get(n));
                         if nd < d {
                             d = nd;
                             curr = n;
@@ -440,7 +441,6 @@ impl Index {
         let top = Self::search_layer(
             &inner.vectors,
             self.dist_fn,
-            self.dim,
             &inner.neighbors,
             query,
             curr,
@@ -471,10 +471,6 @@ impl Index {
     }
 
     /// Get a vector slice by internal ID.
-    fn get_vec(vectors: &[f32], iid: usize, dim: usize) -> &[f32] {
-        let start = iid * dim;
-        &vectors[start..start + dim]
-    }
 
     /// Beam search on a single graph layer.
     /// Returns results sorted by distance ascending.
@@ -483,9 +479,8 @@ impl Index {
     /// thread-local visited bitmap. Caller must guarantee `entry < total`.
     #[allow(clippy::too_many_arguments)]
     fn search_layer(
-        vectors: &[f32],
+        vectors: &ChunkedVectors,
         dist_fn: DistanceFn,
-        dim: usize,
         neighbors: &[Vec<Vec<usize>>],
         query: &[f32],
         entry: usize,
@@ -498,7 +493,7 @@ impl Index {
         VISITED.with_borrow_mut(|vb| {
             let epoch = vb.begin(total);
 
-            let entry_dist = dist_fn(Self::get_vec(vectors, entry, dim), query);
+            let entry_dist = dist_fn(vectors.get(entry), query);
 
             // Min-heap of candidates (closest first)
             let mut candidates: BinaryHeap<Reverse<(FloatOrd, usize)>> = BinaryHeap::new();
@@ -527,7 +522,7 @@ impl Index {
                     }
                     vb.marks[nb] = epoch;
 
-                    let nb_dist = dist_fn(Self::get_vec(vectors, nb, dim), query);
+                    let nb_dist = dist_fn(vectors.get(nb), query);
 
                     let should_add = if results.len() < ef {
                         true
@@ -559,9 +554,8 @@ impl Index {
 
     /// Heuristic neighbor selection (Algorithm 4 from HNSW paper).
     fn select_neighbors(
-        vectors: &[f32],
+        vectors: &ChunkedVectors,
         dist_fn: DistanceFn,
-        dim: usize,
         candidates: &[(f32, usize)],
         m: usize,
     ) -> Vec<(f32, usize)> {
@@ -582,10 +576,7 @@ impl Index {
 
             // Heuristic: include only if not closer to any already-selected neighbor
             let is_diverse = selected.iter().all(|&(_, sid)| {
-                let inter_dist = dist_fn(
-                    Self::get_vec(vectors, cid, dim),
-                    Self::get_vec(vectors, sid, dim),
-                );
+                let inter_dist = dist_fn(vectors.get(cid), vectors.get(sid));
                 inter_dist >= dist
             });
 
@@ -666,17 +657,15 @@ impl IndexBuilder {
             .m
             .checked_mul(2)
             .ok_or(VaneError::InvalidParameter("M * 2 overflows usize"))?;
-        let vector_len = self
-            .capacity
+        // capacity is a reserve hint, not a ceiling: storage grows as vectors
+        // arrive. Nothing is allocated until the first insert, so an unused
+        // index costs nothing however large the hint (#90).
+        self.capacity
             .checked_mul(self.dim)
             .ok_or(VaneError::InvalidParameter(
                 "capacity * dim overflows usize",
             ))?;
-        let mut vectors: Vec<f32> = Vec::new();
-        vectors
-            .try_reserve_exact(vector_len)
-            .map_err(|_| VaneError::InvalidParameter("capacity is too large to allocate"))?;
-        vectors.resize(vector_len, 0.0);
+        let vectors = ChunkedVectors::with_capacity(self.dim, self.capacity);
 
         Ok(Index {
             dim: self.dim,
@@ -692,10 +681,10 @@ impl IndexBuilder {
             seed: self.seed,
             inner: RwLock::new(Inner {
                 vectors,
-                ext_ids: vec![0; self.capacity],
+                ext_ids: Vec::with_capacity(self.capacity.min(RESERVE_CAP)),
                 id_map: HashMap::new(),
-                levels: vec![0; self.capacity],
-                neighbors: (0..self.capacity).map(|_| Vec::new()).collect(),
+                levels: Vec::with_capacity(self.capacity.min(RESERVE_CAP)),
+                neighbors: Vec::with_capacity(self.capacity.min(RESERVE_CAP)),
                 entry_point: None,
                 max_level: -1,
                 count: 0,
@@ -788,11 +777,16 @@ mod tests {
     }
 
     #[test]
-    fn add_rejects_when_full() {
+    fn adding_past_the_capacity_hint_grows_instead_of_failing() {
         let idx = Index::builder(2, Metric::L2).capacity(2).build().unwrap();
-        idx.add(0, &[0.0, 0.0]).unwrap();
-        idx.add(1, &[1.0, 1.0]).unwrap();
-        assert!(matches!(idx.add(2, &[2.0, 2.0]), Err(VaneError::IndexFull)));
+        for i in 0..50u64 {
+            idx.add(i, &[i as f32, i as f32])
+                .expect("capacity is a hint, not a ceiling");
+        }
+        assert_eq!(idx.size(), 50);
+        // The graph must still be usable well past the hint.
+        let hits = idx.search(&[49.0, 49.0], 1).unwrap();
+        assert_eq!(hits[0].id, 49);
     }
 
     #[test]

--- a/vanedb/src/index/mod.rs
+++ b/vanedb/src/index/mod.rs
@@ -15,6 +15,7 @@ use crate::store::SearchResult;
 use crate::validation::{compare_distances, validate_finite};
 
 mod persistence;
+mod storage;
 
 // Versioned thread-local visited tracker. `marks[i] == epoch` means visited;
 // the epoch is bumped each `search_layer` call, so the per-search work stays

--- a/vanedb/src/index/persistence.rs
+++ b/vanedb/src/index/persistence.rs
@@ -14,6 +14,7 @@ use crate::distance::{distance_fn, Metric};
 use crate::error::{Result, VaneError};
 
 use super::storage::ChunkedVectors;
+use super::MAX_ELEMENTS;
 
 /// On-disk magic ("HNSW" little-endian) and format version.
 ///
@@ -22,15 +23,6 @@ use super::storage::ChunkedVectors;
 /// compatibility with files written before the rename. Rust never shipped
 /// pre-rename, so we use a clean per-format magic.
 const MAGIC: u32 = u32::from_le_bytes(*b"HNSW");
-
-/// Upper bound on `max_elements` accepted from a file. Mirrors `MAX_VEC_SIZE`
-/// in vanedb-cpp `src/core/index.h`.
-///
-/// Storage now grows on demand, so load no longer expands anything to this
-/// value and it cannot drive an allocation. It stays as a corruption check:
-/// a file declaring more slots than the engine can address is not a file this
-/// engine wrote.
-const MAX_ELEMENTS: usize = 100_000_000;
 /// v1 stored the full pre-allocated arrays (`max_elements` entries even when
 /// only `count` were inserted). v2 stores only the `count` live entries and
 /// re-expands to `max_elements` on load (issue #18). v1 files remain loadable.

--- a/vanedb/src/index/persistence.rs
+++ b/vanedb/src/index/persistence.rs
@@ -13,6 +13,8 @@ use super::{Index, Inner, MAX_LEVEL};
 use crate::distance::{distance_fn, Metric};
 use crate::error::{Result, VaneError};
 
+use super::storage::ChunkedVectors;
+
 /// On-disk magic ("HNSW" little-endian) and format version.
 ///
 /// Mirrors the framing in vanedb-cpp src/core/index.h. The C++ side
@@ -22,8 +24,12 @@ use crate::error::{Result, VaneError};
 const MAGIC: u32 = u32::from_le_bytes(*b"HNSW");
 
 /// Upper bound on `max_elements` accepted from a file. Mirrors `MAX_VEC_SIZE`
-/// in vanedb-cpp `src/core/index.h`: `load` re-expands every array to
-/// `max_elements`, so without a cap a few hundred bytes can request terabytes.
+/// in vanedb-cpp `src/core/index.h`.
+///
+/// Storage now grows on demand, so load no longer expands anything to this
+/// value and it cannot drive an allocation. It stays as a corruption check:
+/// a file declaring more slots than the engine can address is not a file this
+/// engine wrote.
 const MAX_ELEMENTS: usize = 100_000_000;
 /// v1 stored the full pre-allocated arrays (`max_elements` entries even when
 /// only `count` were inserted). v2 stores only the `count` live entries and
@@ -98,7 +104,7 @@ impl Index {
             max_level: inner.max_level,
             // v2: persist only the `count` live entries, not the full
             // pre-allocated capacity; load() re-expands to max_elements.
-            vectors: inner.vectors[..inner.count * self.dim].to_vec(),
+            vectors: inner.vectors.to_flat(inner.count),
             ext_ids: inner.ext_ids[..inner.count].to_vec(),
             levels: inner.levels[..inner.count].to_vec(),
             neighbors: inner.neighbors[..inner.count].to_vec(),
@@ -292,8 +298,7 @@ impl Index {
                 }
             }
         }
-        let full_vecs_len = data
-            .max_elements
+        data.max_elements
             .checked_mul(data.dim)
             .ok_or_else(|| VaneError::Io("size overflow".to_string()))?;
         if data.vectors.len() != stored * data.dim {
@@ -323,18 +328,15 @@ impl Index {
         // failure, and this is the path that reads untrusted files. The cap
         // above bounds the request; this turns a genuine OOM into an error
         // rather than killing the host application (#89).
-        let mut vectors = data.vectors;
-        try_grow(&mut vectors, full_vecs_len, "vectors")?;
-        vectors.resize(full_vecs_len, 0.0);
+        // Storage grows on demand, so only the live vectors are rebuilt --
+        // the old format re-expanded to max_elements here.
+        let vectors = ChunkedVectors::from_flat(data.dim, &data.vectors[..live_vectors_len]);
         let mut ext_ids = data.ext_ids;
-        try_grow(&mut ext_ids, data.max_elements, "ext_ids")?;
-        ext_ids.resize(data.max_elements, 0);
+        ext_ids.truncate(data.count);
         let mut levels = data.levels;
-        try_grow(&mut levels, data.max_elements, "levels")?;
-        levels.resize(data.max_elements, 0);
+        levels.truncate(data.count);
         let mut neighbors = data.neighbors;
-        try_grow(&mut neighbors, data.max_elements, "neighbors")?;
-        neighbors.resize_with(data.max_elements, Vec::new);
+        neighbors.truncate(data.count);
 
         // Reconstitute RNG: seed from the original seed, then advance through
         // `count` get_level calls so the next add() resumes the original
@@ -370,18 +372,4 @@ impl Index {
             }),
         })
     }
-}
-
-/// Reserve room for `target` elements without aborting on failure.
-///
-/// `Vec::resize` cannot fail: allocation failure aborts the process. Every
-/// growth on the load path goes through here, so a hostile or corrupt file
-/// yields an error instead of killing the host application (#89).
-fn try_grow<T>(v: &mut Vec<T>, target: usize, what: &str) -> Result<()> {
-    let additional = target.saturating_sub(v.len());
-    v.try_reserve_exact(additional).map_err(|_| {
-        VaneError::Io(format!(
-            "corrupted file: cannot allocate {target} {what} entries"
-        ))
-    })
 }

--- a/vanedb/src/index/storage.rs
+++ b/vanedb/src/index/storage.rs
@@ -1,0 +1,186 @@
+//! Chunked vector storage for the graph index.
+//!
+//! Vectors live in fixed-size chunks rather than one flat allocation, so the
+//! index grows as vectors arrive instead of reserving its whole capacity up
+//! front. A chunk holds a power-of-two count of *whole* vectors, which keeps
+//! `get` returning one contiguous slice — the SIMD kernels read a vector at a
+//! time, so nothing is lost by splitting between vectors.
+
+/// Chunk size target. Big enough that the chunk list stays short for large
+/// corpora, small enough that a mostly-empty index costs little.
+const TARGET_CHUNK_BYTES: usize = 1 << 20;
+
+/// Vectors of a fixed dimension, stored in chunks and grown on demand.
+pub(super) struct ChunkedVectors {
+    chunks: Vec<Vec<f32>>,
+    dim: usize,
+    /// Vectors per chunk; always a power of two so indexing is shift + mask.
+    per_chunk: usize,
+    shift: u32,
+    mask: usize,
+    len: usize,
+}
+
+/// Largest power of two vectors of `dim` floats that fits the chunk target,
+/// and at least one — a single vector always gets its own chunk if it must.
+///
+/// A power of two is what makes indexing a shift and a mask rather than a
+/// division, so this rounds *down*: rounding up would overshoot the target.
+fn vectors_per_chunk(dim: usize) -> usize {
+    let fits = (TARGET_CHUNK_BYTES / (dim * std::mem::size_of::<f32>())).max(1);
+    1usize << (usize::BITS - 1 - fits.leading_zeros())
+}
+
+impl ChunkedVectors {
+    pub(super) fn new(dim: usize) -> Self {
+        debug_assert!(dim > 0, "dimension is validated before construction");
+        let per_chunk = vectors_per_chunk(dim);
+        Self {
+            chunks: Vec::new(),
+            dim,
+            per_chunk,
+            shift: per_chunk.trailing_zeros(),
+            mask: per_chunk - 1,
+            len: 0,
+        }
+    }
+
+    /// Pre-allocates room for `n` vectors. A hint only: pushing past `n` grows.
+    pub(super) fn with_capacity(dim: usize, n: usize) -> Self {
+        let mut s = Self::new(dim);
+        s.chunks.reserve(n.div_ceil(s.per_chunk));
+        s
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.len
+    }
+
+    #[inline]
+    fn locate(&self, iid: usize) -> (usize, usize) {
+        (iid >> self.shift, (iid & self.mask) * self.dim)
+    }
+
+    /// The vector at `iid`, as one contiguous slice.
+    #[inline]
+    pub(super) fn get(&self, iid: usize) -> &[f32] {
+        let (chunk, offset) = self.locate(iid);
+        &self.chunks[chunk][offset..offset + self.dim]
+    }
+
+    /// Appends a vector, allocating a chunk when the current one is full.
+    pub(super) fn push(&mut self, vector: &[f32]) {
+        debug_assert_eq!(vector.len(), self.dim);
+        if self.len & self.mask == 0 {
+            let mut chunk = Vec::new();
+            chunk.reserve_exact(self.per_chunk * self.dim);
+            self.chunks.push(chunk);
+        }
+        let last = self.chunks.last_mut().expect("just ensured a chunk exists");
+        last.extend_from_slice(vector);
+        self.len += 1;
+    }
+
+    /// Copies every stored vector into one flat row-major buffer, for saving.
+    pub(super) fn to_flat(&self, count: usize) -> Vec<f32> {
+        let mut out = Vec::with_capacity(count * self.dim);
+        for iid in 0..count {
+            out.extend_from_slice(self.get(iid));
+        }
+        out
+    }
+
+    /// Rebuilds storage from one flat row-major buffer, as written by
+    /// [`to_flat`](Self::to_flat).
+    pub(super) fn from_flat(dim: usize, flat: &[f32]) -> Self {
+        let mut s = Self::with_capacity(dim, flat.len() / dim);
+        for vector in flat.chunks_exact(dim) {
+            s.push(vector);
+        }
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chunks_hold_whole_vectors_near_the_size_target() {
+        // A vector must never straddle a boundary, so the count is a power of
+        // two and the chunk lands at or under the target.
+        for (dim, expected) in [(768, 256), (384, 512), (128, 2048), (8, 32768)] {
+            let n = vectors_per_chunk(dim);
+            assert_eq!(n, expected, "dim {dim}");
+            assert!(n.is_power_of_two(), "dim {dim}: {n} is not a power of two");
+            assert!(
+                n * dim * 4 <= TARGET_CHUNK_BYTES,
+                "dim {dim}: chunk exceeds the target"
+            );
+        }
+    }
+
+    #[test]
+    fn a_dimension_larger_than_the_target_still_stores_one_vector_per_chunk() {
+        let huge = TARGET_CHUNK_BYTES; // 4 MiB per vector
+        assert_eq!(vectors_per_chunk(huge), 1);
+        let mut v = ChunkedVectors::new(huge);
+        v.push(&vec![1.0; huge]);
+        assert_eq!(v.get(0)[0], 1.0);
+    }
+
+    #[test]
+    fn an_empty_store_allocates_nothing() {
+        let v = ChunkedVectors::new(768);
+        assert_eq!(v.len(), 0);
+        assert!(v.chunks.is_empty(), "an empty index must not hold chunks");
+    }
+
+    #[test]
+    fn capacity_is_a_hint_that_does_not_add_vectors() {
+        let v = ChunkedVectors::with_capacity(128, 100_000);
+        assert_eq!(v.len(), 0);
+        assert!(v.chunks.is_empty(), "reserving must not materialise chunks");
+    }
+
+    #[test]
+    fn vectors_round_trip_across_chunk_boundaries() {
+        let dim = 4;
+        let per_chunk = vectors_per_chunk(dim);
+        let n = per_chunk * 2 + 3; // spans three chunks
+        let mut v = ChunkedVectors::new(dim);
+        for i in 0..n {
+            v.push(&[i as f32, 1.0, 2.0, 3.0]);
+        }
+        assert_eq!(v.len(), n);
+        for i in 0..n {
+            assert_eq!(v.get(i), &[i as f32, 1.0, 2.0, 3.0], "vector {i}");
+        }
+    }
+
+    #[test]
+    fn growth_is_not_capped_by_the_reserve_hint() {
+        let mut v = ChunkedVectors::with_capacity(2, 1);
+        for i in 0..1000 {
+            v.push(&[i as f32, 0.0]);
+        }
+        assert_eq!(v.len(), 1000);
+        assert_eq!(v.get(999), &[999.0, 0.0]);
+    }
+
+    #[test]
+    fn flat_round_trip_preserves_every_vector() {
+        let dim = 3;
+        let mut v = ChunkedVectors::new(dim);
+        for i in 0..70 {
+            v.push(&[i as f32, i as f32 + 0.5, -(i as f32)]);
+        }
+        let flat = v.to_flat(v.len());
+        assert_eq!(flat.len(), 70 * dim);
+        let back = ChunkedVectors::from_flat(dim, &flat);
+        assert_eq!(back.len(), 70);
+        for i in 0..70 {
+            assert_eq!(back.get(i), v.get(i), "vector {i}");
+        }
+    }
+}

--- a/vanedb/src/index/storage.rs
+++ b/vanedb/src/index/storage.rs
@@ -11,7 +11,7 @@
 const TARGET_CHUNK_BYTES: usize = 1 << 20;
 
 /// Vectors of a fixed dimension, stored in chunks and grown on demand.
-pub(super) struct ChunkedVectors {
+pub(crate) struct ChunkedVectors {
     chunks: Vec<Vec<f32>>,
     dim: usize,
     /// Vectors per chunk; always a power of two so indexing is shift + mask.
@@ -32,7 +32,7 @@ fn vectors_per_chunk(dim: usize) -> usize {
 }
 
 impl ChunkedVectors {
-    pub(super) fn new(dim: usize) -> Self {
+    pub(crate) fn new(dim: usize) -> Self {
         debug_assert!(dim > 0, "dimension is validated before construction");
         let per_chunk = vectors_per_chunk(dim);
         Self {
@@ -46,13 +46,13 @@ impl ChunkedVectors {
     }
 
     /// Pre-allocates room for `n` vectors. A hint only: pushing past `n` grows.
-    pub(super) fn with_capacity(dim: usize, n: usize) -> Self {
+    pub(crate) fn with_capacity(dim: usize, n: usize) -> Self {
         let mut s = Self::new(dim);
         s.chunks.reserve(n.div_ceil(s.per_chunk));
         s
     }
 
-    pub(super) fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         self.len
     }
 
@@ -63,13 +63,13 @@ impl ChunkedVectors {
 
     /// The vector at `iid`, as one contiguous slice.
     #[inline]
-    pub(super) fn get(&self, iid: usize) -> &[f32] {
+    pub(crate) fn get(&self, iid: usize) -> &[f32] {
         let (chunk, offset) = self.locate(iid);
         &self.chunks[chunk][offset..offset + self.dim]
     }
 
     /// Appends a vector, allocating a chunk when the current one is full.
-    pub(super) fn push(&mut self, vector: &[f32]) {
+    pub(crate) fn push(&mut self, vector: &[f32]) {
         debug_assert_eq!(vector.len(), self.dim);
         if self.len & self.mask == 0 {
             let mut chunk = Vec::new();
@@ -82,7 +82,7 @@ impl ChunkedVectors {
     }
 
     /// Copies every stored vector into one flat row-major buffer, for saving.
-    pub(super) fn to_flat(&self, count: usize) -> Vec<f32> {
+    pub(crate) fn to_flat(&self, count: usize) -> Vec<f32> {
         let mut out = Vec::with_capacity(count * self.dim);
         for iid in 0..count {
             out.extend_from_slice(self.get(iid));
@@ -92,7 +92,7 @@ impl ChunkedVectors {
 
     /// Rebuilds storage from one flat row-major buffer, as written by
     /// [`to_flat`](Self::to_flat).
-    pub(super) fn from_flat(dim: usize, flat: &[f32]) -> Self {
+    pub(crate) fn from_flat(dim: usize, flat: &[f32]) -> Self {
         let mut s = Self::with_capacity(dim, flat.len() / dim);
         for vector in flat.chunks_exact(dim) {
             s.push(vector);

--- a/vanedb/src/index/storage.rs
+++ b/vanedb/src/index/storage.rs
@@ -46,9 +46,13 @@ impl ChunkedVectors {
     }
 
     /// Pre-allocates room for `n` vectors. A hint only: pushing past `n` grows.
+    ///
+    /// The reservation is fallible and best-effort. `Vec::reserve` aborts on
+    /// failure, and a hint is not worth killing the process over -- if the
+    /// chunk list cannot be reserved, it simply grows later.
     pub(crate) fn with_capacity(dim: usize, n: usize) -> Self {
         let mut s = Self::new(dim);
-        s.chunks.reserve(n.div_ceil(s.per_chunk));
+        let _ = s.chunks.try_reserve(n.div_ceil(s.per_chunk));
         s
     }
 

--- a/vanedb/tests/index_tests.rs
+++ b/vanedb/tests/index_tests.rs
@@ -282,16 +282,19 @@ fn hnsw_add_batch_matches_serial_add() {
 }
 
 #[test]
-fn hnsw_add_batch_capacity_exceeded_is_all_or_nothing() {
+fn hnsw_add_batch_grows_past_the_capacity_hint() {
+    // capacity reserves, it does not cap: a batch that runs past the hint
+    // grows the storage rather than failing. All-or-nothing on a genuine
+    // failure is covered by hnsw_add_batch_duplicate_is_all_or_nothing.
     let index = Index::builder(4, Metric::L2).capacity(4).build().unwrap();
     index.add(99, &[0.5; 4]).unwrap();
 
-    let ids: Vec<u64> = (0..4).collect();
-    let flat = vec![1.0f32; 16];
-    let result = index.add_batch(&ids, &flat);
-    assert!(matches!(result, Err(vanedb::VaneError::IndexFull)));
-    assert_eq!(index.size(), 1);
-    assert!(!index.contains(0));
+    let ids: Vec<u64> = (0..8).collect();
+    let flat = vec![1.0f32; 32];
+    index.add_batch(&ids, &flat).expect("hint is not a ceiling");
+    assert_eq!(index.size(), 9);
+    assert!(index.contains(0));
+    assert!(index.contains(7));
 }
 
 #[test]


### PR DESCRIPTION
Closes #90. Also removes the #89 vulnerability by construction.

## The result

```
empty Index(768)              295.3 MB  ->  0.1 MB
hint 100k,  5k stored                       65.9 MB
hint 100k, 20k stored                      284.5 MB
```

Memory now tracks what is stored rather than what was hinted — before, all three were ~293 MB. (Peak RSS, so those include the caller's numpy array and PyO3's owned copy, not just the index.)

`capacity()` reserves; it no longer caps. `Index::builder(...).capacity(2)` then adding 500 vectors works, and search still returns correct results afterwards.

## How

`Inner.vectors` becomes `ChunkedVectors`: chunks holding a power-of-two count of **whole** vectors, targeting ~1 MiB.

```
dim 768 -> 256 vectors/chunk     dim 128 -> 2048
dim 384 -> 512                   dim   8 -> 32768
```

Indexing is a shift and a mask. Nothing is lost by splitting between vectors: the graph walk reaches whatever the beam visits, so access is **random** — contiguity across vectors buys nothing, and each vector stays contiguous for the SIMD kernels.

`ext_ids`, `levels` and `neighbors` are pushed rather than pre-sized. Sibling reservations are capped so a large hint cannot itself allocate much.

**No file-format change.** `save` flattens, `load` rebuilds; v1 and v2 both still load.

## Two bugs this caught, both mine

**Rounding the wrong way.** `next_power_of_two().min(fits)` returns **341** for dim 768 — not a power of two at all, so the shift-and-mask indexing was meaningless. The sizing test caught it immediately; a round-trip test at a single dimension would have passed by luck.

**Reintroducing an abort.** The chunk-list reservation used infallible `Vec::reserve`, so a hint of `usize::MAX / 4096` asked for 422 TB and aborted — exactly the failure #89 had just removed. `builder_rejects_unallocatable_capacity` caught it. The reservation is now fallible and best-effort, and the builder rejects a hint above `MAX_ELEMENTS`, which is now shared with the loader so the two paths cannot disagree.

## Fallout

`IndexFull` is deleted. Nothing produces it now, and a public error variant that can never occur is a lie in the API. The batch test that asserted the ceiling asserts growth instead; all-or-nothing on a genuine failure is still covered by the duplicate-id test.

`try_grow` in the loader is deleted too — `load` no longer re-expands anything to `max_elements`, so #89's allocation path is gone rather than guarded. `MAX_ELEMENTS` stays as a corruption check, and its doc says so.

## Verification

All eleven CI invocations green. 7 new storage unit tests covering chunk sizing at four dimensions, boundary crossing, growth past the hint, and flat round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H