### PR TITLE
fix(format): make the shared DiskStore format real, and test it

### DIFF
--- a/bench/tests/cross_engine_format.rs
+++ b/bench/tests/cross_engine_format.rs
@@ -1,0 +1,112 @@
+//! Each engine must read the other's `DiskStore` file.
+//!
+//! The engines write byte-identical headers and payloads, and this is what
+//! keeps that true. Every other conformance fixture has each engine check
+//! itself against shared expectations; this is the only test where one engine
+//! consumes the other's output.
+
+use std::ffi::CString;
+use vanedb_bench::ffi;
+
+const DIM: usize = 8;
+const N: usize = 64;
+const K: usize = 5;
+
+fn workload() -> (Vec<u64>, Vec<f32>) {
+    let ids: Vec<u64> = (0..N as u64).collect();
+    let vectors: Vec<f32> = (0..N)
+        .flat_map(|i| (0..DIM).map(move |d| ((i * 7 + d * 3) % 23) as f32))
+        .collect();
+    (ids, vectors)
+}
+
+fn query() -> Vec<f32> {
+    (0..DIM).map(|d| (d * 3 % 23) as f32).collect()
+}
+
+fn agree(a_ids: &[u64], a_d: &[f32], b_ids: &[u64], b_d: &[f32], what: &str) {
+    assert_eq!(a_ids, b_ids, "{what}: neighbour ids differ across engines");
+    for (x, y) in a_d.iter().zip(b_d.iter()) {
+        assert!((x - y).abs() < 1e-5, "{what}: distances differ: {x} vs {y}");
+    }
+}
+
+#[test]
+fn cpp_reads_a_file_written_by_rust() {
+    let (ids, vectors) = workload();
+    let q = query();
+    let path = CString::new("cross_rs_to_cpp.vndb").unwrap();
+    let (mut rs_ids, mut rs_d) = ([0u64; K], [0f32; K]);
+    let (mut cpp_ids, mut cpp_d) = ([0u64; K], [0f32; K]);
+
+    unsafe {
+        assert_eq!(
+            ffi::vanedb_rs_disk_build(path.as_ptr(), DIM, 0, ids.as_ptr(), vectors.as_ptr(), N),
+            0,
+            "rust build failed"
+        );
+        let rs = ffi::vanedb_rs_disk_open(path.as_ptr());
+        assert!(!rs.is_null(), "rust cannot open its own file");
+        let n_rs =
+            ffi::vanedb_rs_disk_search(rs, q.as_ptr(), K, rs_ids.as_mut_ptr(), rs_d.as_mut_ptr());
+        ffi::vanedb_rs_disk_free(rs);
+
+        let cpp = ffi::vanedb_cpp_disk_open(path.as_ptr());
+        assert!(
+            !cpp.is_null(),
+            "C++ rejected a file written by Rust — the formats have diverged"
+        );
+        let n_cpp = ffi::vanedb_cpp_disk_search(
+            cpp,
+            q.as_ptr(),
+            K,
+            cpp_ids.as_mut_ptr(),
+            cpp_d.as_mut_ptr(),
+        );
+        ffi::vanedb_cpp_disk_free(cpp);
+
+        assert_eq!(n_rs, n_cpp, "result counts differ");
+        agree(&rs_ids, &rs_d, &cpp_ids, &cpp_d, "rust -> cpp");
+    }
+    let _ = std::fs::remove_file("cross_rs_to_cpp.vndb");
+}
+
+#[test]
+fn rust_reads_a_file_written_by_cpp() {
+    let (ids, vectors) = workload();
+    let q = query();
+    let path = CString::new("cross_cpp_to_rs.vndb").unwrap();
+    let (mut rs_ids, mut rs_d) = ([0u64; K], [0f32; K]);
+    let (mut cpp_ids, mut cpp_d) = ([0u64; K], [0f32; K]);
+
+    unsafe {
+        assert_eq!(
+            ffi::vanedb_cpp_disk_build(path.as_ptr(), DIM, 0, ids.as_ptr(), vectors.as_ptr(), N),
+            0,
+            "cpp build failed"
+        );
+        let cpp = ffi::vanedb_cpp_disk_open(path.as_ptr());
+        assert!(!cpp.is_null(), "C++ cannot open its own file");
+        let n_cpp = ffi::vanedb_cpp_disk_search(
+            cpp,
+            q.as_ptr(),
+            K,
+            cpp_ids.as_mut_ptr(),
+            cpp_d.as_mut_ptr(),
+        );
+        ffi::vanedb_cpp_disk_free(cpp);
+
+        let rs = ffi::vanedb_rs_disk_open(path.as_ptr());
+        assert!(
+            !rs.is_null(),
+            "Rust rejected a file written by C++ — the formats have diverged"
+        );
+        let n_rs =
+            ffi::vanedb_rs_disk_search(rs, q.as_ptr(), K, rs_ids.as_mut_ptr(), rs_d.as_mut_ptr());
+        ffi::vanedb_rs_disk_free(rs);
+
+        assert_eq!(n_cpp, n_rs, "result counts differ");
+        agree(&cpp_ids, &cpp_d, &rs_ids, &rs_d, "cpp -> rust");
+    }
+    let _ = std::fs::remove_file("cross_cpp_to_rs.vndb");
+}

--- a/cpp/src/core/disk_store.h
+++ b/cpp/src/core/disk_store.h
@@ -36,7 +36,11 @@ namespace vanedb {
 
 class DiskStore {
 public:
-  static constexpr uint32_t MAGIC = 0x42445651;
+  // Literal 'VNDB' on a little-endian host: 0x56='V', 0x4E='N', 0x44='D',
+  // 0x42='B'. Matches vanedb's disk.rs so either engine can read the other's
+  // file. The writer below emits native byte order, so this is little-endian
+  // hosts only -- the only ones either engine currently targets.
+  static constexpr uint32_t MAGIC = 0x42444E56;
   static constexpr uint32_t VERSION = 1;
   static constexpr size_t HEADER_SIZE = 32;
 

--- a/vanedb/README.md
+++ b/vanedb/README.md
@@ -26,9 +26,11 @@ Distance kernels dispatch to NEON or AVX2 at runtime and fall back to a
 portable scalar path. Index and mmap files are little-endian and stable across
 released versions.
 
-A header-only C++ implementation sharing these file formats and graph
-construction is maintained alongside this crate, along with a cross-engine
-benchmark harness, in the [repository](https://github.com/vanedb/vanedb).
+A header-only C++ implementation is maintained alongside this crate, with a
+cross-engine benchmark harness, in the
+[repository](https://github.com/vanedb/vanedb). The two share the `DiskStore`
+format — either engine reads the other's file — and share graph construction.
+The `Index` format is still engine-specific.
 
 ## License
 

--- a/vanedb/src/disk.rs
+++ b/vanedb/src/disk.rs
@@ -12,7 +12,11 @@ use crate::error::{Result, VaneError};
 use crate::store::SearchResult;
 use crate::validation::validate_finite;
 
-const MAGIC: u32 = 0x564E4442; // "VNDB"
+/// Literal `VNDB` as the first four bytes on disk, matching the contract in
+/// `conformance/README.md` and the C++ engine's `DiskStore::MAGIC`. Built from
+/// the bytes rather than hand-written hex: the previous constant claimed
+/// "VNDB" in a comment and actually wrote `BDNV`.
+const MAGIC: u32 = u32::from_le_bytes(*b"VNDB");
 const VERSION: u32 = 1;
 const HEADER_SIZE: usize = 32;
 
@@ -98,7 +102,8 @@ impl DiskStoreBuilder {
     /// The file is built beside the destination and renamed into place after
     /// an fsync, so an interrupted write cannot leave a half-written store
     /// where a reader would find it. The layout is little-endian and shared
-    /// with the C++ implementation.
+    /// with the C++ implementation, which reads and writes the same bytes
+    /// (bench/tests/cross_engine_format.rs).
     pub fn save(&self, path: impl AsRef<Path>) -> Result<()> {
         let path = path.as_ref();
         let temp = crate::atomic_write::AtomicFile::new(path);

--- a/vanedb/src/lib.rs
+++ b/vanedb/src/lib.rs
@@ -26,8 +26,10 @@
 //! Distance kernels dispatch to NEON or AVX2 at runtime and fall back to a
 //! portable scalar path, which is the reference the others must agree with.
 //!
-//! A header-only C++ implementation sharing these file formats and graph
-//! construction is maintained alongside this crate.
+//! A header-only C++ implementation is maintained alongside this crate. The two
+//! share the `DiskStore` format — either engine reads the other's file, checked
+//! by a cross-load test — and share graph construction. The `Index` format is
+//! still engine-specific.
 
 #![warn(missing_docs)]
 


### PR DESCRIPTION
Closes #92.

## The claim was false

The crate docs promised the C++ engine shared these file formats. Each rejected the other's file:

```
Rust  0x564E4442 -> bytes b'BDNV'
C++   0x42445651 -> bytes b'QVDB'
literal VNDB     -> 0x42444E56 -> bytes b'VNDB'
```

Neither wrote the literal `VNDB` that `conformance/README.md` requires. Both now do, built from the bytes rather than hand-written hex — which is how the `Index` format already does it, and why that one was right.

The headers were already byte-identical in field order and size, so the fix is one constant per engine.

## The test that keeps it true

`bench/tests/cross_engine_format.rs` builds with each engine and opens with the other, asserting identical neighbours and distances in both directions.

This is the **only** test in the repository where one engine consumes the other's output. Every existing conformance fixture has each engine check itself against shared expectations — which is exactly why nothing caught this.

Verified by falsification: restoring either old magic fails both directions with `the formats have diverged`.

## Docs now say what is true

The `DiskStore` format is shared; the `Index` format is still engine-specific. Previously `vanedb/src/lib.rs` and `vanedb/README.md` claimed both, while `vanedb-py/README.md` correctly said neither — two published front pages contradicting each other.

## Limitation, stated at the constant

The C++ writer emits native byte order, so this holds on little-endian hosts — the only ones either engine targets today.

## Verification

81 C++ tests, all eleven Rust CI invocations, and the two new cross-load tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H