### PR TITLE
fix: Debug on the public types, and run conformance tests when fixtures change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           filters: |
             rust:
+              - 'conformance/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'vanedb/**'
@@ -37,6 +38,7 @@ jobs:
               - '.github/requirements-release.txt'
               - '.github/workflows/**'
             cpp:
+              - 'conformance/**'
               - 'cpp/**'
               - '.github/requirements-release.txt'
               - '.github/workflows/**'

--- a/vanedb/src/disk.rs
+++ b/vanedb/src/disk.rs
@@ -51,6 +51,16 @@ pub struct DiskStoreBuilder {
     id_set: HashSet<u64>,
 }
 
+impl std::fmt::Debug for DiskStoreBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DiskStoreBuilder")
+            .field("dim", &self.dim)
+            .field("metric", &self.metric)
+            .field("len", &self.ids.len())
+            .finish()
+    }
+}
+
 impl DiskStoreBuilder {
     /// Starts a store for vectors of `dim` components.
     pub fn new(dim: usize, metric: Metric) -> Result<Self> {
@@ -160,6 +170,16 @@ pub struct DiskStore {
     ids_offset: usize,
     vectors_offset: usize,
     id_map: HashMap<u64, usize>,
+}
+
+impl std::fmt::Debug for DiskStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DiskStore")
+            .field("dim", &self.dim)
+            .field("metric", &self.metric)
+            .field("len", &self.num_vectors)
+            .finish()
+    }
 }
 
 impl DiskStore {

--- a/vanedb/src/index/mod.rs
+++ b/vanedb/src/index/mod.rs
@@ -148,6 +148,19 @@ pub struct IndexBuilder {
     seed: u64,
 }
 
+impl std::fmt::Debug for Index {
+    /// Identity and size only; the graph sits behind a lock.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Index")
+            .field("dim", &self.dim)
+            .field("metric", &self.metric)
+            .field("size", &self.size())
+            .field("m", &self.m)
+            .field("ef_construction", &self.ef_construction)
+            .finish()
+    }
+}
+
 impl Index {
     /// Starts configuring an index over vectors of `dim` components.
     pub fn builder(dim: usize, metric: Metric) -> IndexBuilder {
@@ -609,6 +622,19 @@ impl Index {
         }
 
         selected
+    }
+}
+
+impl std::fmt::Debug for IndexBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IndexBuilder")
+            .field("dim", &self.dim)
+            .field("metric", &self.metric)
+            .field("capacity", &self.capacity)
+            .field("m", &self.m)
+            .field("ef_construction", &self.ef_construction)
+            .field("seed", &self.seed)
+            .finish()
     }
 }
 

--- a/vanedb/src/store/mod.rs
+++ b/vanedb/src/store/mod.rs
@@ -43,6 +43,18 @@ struct Inner {
     id_to_index: HashMap<u64, usize>,
 }
 
+impl std::fmt::Debug for Store {
+    /// Prints identity and size, not contents: the vectors sit behind a lock
+    /// and can be gigabytes.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Store")
+            .field("dim", &self.dim)
+            .field("metric", &self.metric)
+            .field("len", &self.len())
+            .finish()
+    }
+}
+
 impl Store {
     /// Creates an empty store for vectors of `dim` components.
     ///

--- a/vanedb/tests/corruption_tests.rs
+++ b/vanedb/tests/corruption_tests.rs
@@ -410,7 +410,7 @@ fn hnsw_load_rejects_an_unallocatable_max_elements() {
     // terabytes. Must be an error, not an abort.
     let bytes = hnsw_file_bytes(2, &v2_huge_max_elements(1 << 40));
     let p = write_tmp("huge_max_elements", &bytes);
-    let err = Index::load(&p).err().expect("must reject, not allocate");
+    let err = Index::load(&p).expect_err("must reject, not allocate");
     let msg = err.to_string();
     assert!(
         msg.contains("max_elements") || msg.contains("too large"),

--- a/vanedb/tests/debug_impls.rs
+++ b/vanedb/tests/debug_impls.rs
@@ -1,0 +1,50 @@
+//! `.unwrap_err()` and `#[derive(Debug)]` on a user struct both need `Debug`
+//! on the public types, and neither compiled before these impls existed.
+
+use vanedb::{DiskStoreBuilder, Index, Metric, Store};
+
+#[test]
+fn unwrap_err_compiles_against_the_public_types() {
+    // The idiom the whole suite had to avoid: it requires Debug on the Ok type.
+    let err = Index::builder(0, Metric::L2).build().unwrap_err();
+    assert!(matches!(err, vanedb::VaneError::EmptyVector));
+    let err = Store::new(0, Metric::L2).unwrap_err();
+    assert!(matches!(err, vanedb::VaneError::EmptyVector));
+}
+
+#[test]
+fn a_user_struct_holding_one_can_derive_debug() {
+    #[derive(Debug)]
+    #[allow(dead_code)]
+    struct App {
+        store: Store,
+        index: Index,
+    }
+    let app = App {
+        store: Store::new(2, Metric::L2).unwrap(),
+        index: Index::builder(2, Metric::Cosine)
+            .capacity(4)
+            .build()
+            .unwrap(),
+    };
+    let shown = format!("{app:?}");
+    assert!(shown.contains("Store"), "{shown}");
+    assert!(shown.contains("Index"), "{shown}");
+}
+
+#[test]
+fn debug_shows_identity_not_contents() {
+    let store = Store::new(3, Metric::Dot).unwrap();
+    store.add(1, &[1.0, 2.0, 3.0]).unwrap();
+    let shown = format!("{store:?}");
+    assert!(shown.contains("dim: 3"), "{shown}");
+    assert!(shown.contains("len: 1"), "{shown}");
+    // The vectors themselves must not be dumped.
+    assert!(
+        !shown.contains("1.0"),
+        "contents leaked into Debug: {shown}"
+    );
+
+    let builder = DiskStoreBuilder::new(4, Metric::L2).unwrap();
+    assert!(format!("{builder:?}").contains("DiskStoreBuilder"));
+}


### PR DESCRIPTION
Closes #94 and #96.

## Debug

No public type implemented `Debug`, so this did not compile:

```
error[E0277]: `vanedb::Index` doesn't implement `Debug`
   |     let e = Index::builder(0, Metric::L2).build().unwrap_err();
   = note: required by a bound in `Result::<T, E>::unwrap_err`
```

`.unwrap_err()` is the ordinary way to write a negative test, and no user struct holding a `Store` could derive `Debug` either. Our own suite used `matches!` and `.is_err()` everywhere for exactly this reason.

The impls are **manual**, not derived: the state sits behind an `RwLock` and can be gigabytes, so they print identity and size. A test asserts contents do not leak into the output.

Adopting the idiom paid immediately — clippy could finally see `.err().expect()` in `corruption_tests` and suggest `expect_err`, a lint that could not fire while `Index` had no `Debug`.

## Conformance CI

`conformance/**` appeared in the `integration` path filter only. Since the integration job never reads a fixture, **editing the cross-engine contract ran neither engine's conformance tests.** Now in the `rust` and `cpp` filters too.

Worth noting alongside #102, which adds the first test where one engine reads the other's file — the gap this filter left open is why the format divergence went unnoticed.

## Verification

All eleven CI invocations green. 3 new tests covering the compile idiom, derive-through, and non-leakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H