### PR TITLE
feat(py): expose DiskStore and DiskStoreBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ only and is rebuilt on each run.
 `Index` allocates its full `capacity` up front, so size it to the corpus:
 100k x 768 floats reserves roughly 300 MB before the first insert.
 
+All three types are reachable from every binding except wasm, which has no
+filesystem to map and so omits `DiskStore`.
+
 The Rust crate spells enum variants in Rust style (`Metric::Cosine`); the
 Python and JavaScript packages use `Metric.COSINE`. Type names are identical
 in every binding, so switching engines is an import change.

--- a/vanedb-py/Cargo.toml
+++ b/vanedb-py/Cargo.toml
@@ -10,4 +10,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.29", features = ["extension-module"] }
-vanedb = { path = "../vanedb" }
+vanedb = { path = "../vanedb", features = ["disk"] }

--- a/vanedb-py/src/lib.rs
+++ b/vanedb-py/src/lib.rs
@@ -6,6 +6,7 @@ use ::vanedb::distance::Metric;
 use ::vanedb::index::Index;
 use ::vanedb::store::Store;
 use ::vanedb::VaneError;
+use ::vanedb::{DiskStore, DiskStoreBuilder};
 
 fn to_pyerr(e: VaneError) -> PyErr {
     PyValueError::new_err(e.to_string())
@@ -334,6 +335,100 @@ impl PyIndex {
     }
 }
 
+/// Builds a `DiskStore` file. Vectors are held in memory until `save`; the
+/// memory saving is on the reading side.
+#[pyclass(name = "DiskStoreBuilder")]
+struct PyDiskStoreBuilder {
+    inner: DiskStoreBuilder,
+}
+
+#[pymethods]
+impl PyDiskStoreBuilder {
+    #[new]
+    #[pyo3(signature = (dim, metric=PyMetric::L2))]
+    fn new(dim: usize, metric: PyMetric) -> PyResult<Self> {
+        Ok(Self {
+            inner: DiskStoreBuilder::new(dim, metric.into()).map_err(to_pyerr)?,
+        })
+    }
+
+    fn add(&mut self, id: u64, vector: &Bound<'_, PyAny>) -> PyResult<()> {
+        let v = vec_f32(vector)?;
+        self.inner.add(id, &v).map_err(to_pyerr)
+    }
+
+    /// Writes the store to `path`, atomically: built beside the destination
+    /// and renamed in after an fsync.
+    fn save(&self, py: Python<'_>, path: &str) -> PyResult<()> {
+        py.detach(|| self.inner.save(path)).map_err(to_pyerr)
+    }
+
+    fn __len__(&self) -> usize {
+        self.inner.size()
+    }
+
+    fn size(&self) -> usize {
+        self.inner.size()
+    }
+
+    #[getter]
+    fn dimension(&self) -> usize {
+        self.inner.dimension()
+    }
+}
+
+/// Exact search over a memory-mapped file. Read-only; build one with
+/// `DiskStoreBuilder`.
+#[pyclass(name = "DiskStore")]
+struct PyDiskStore {
+    inner: DiskStore,
+}
+
+#[pymethods]
+impl PyDiskStore {
+    /// Maps the store at `path`.
+    ///
+    /// Validates the header and every stored value, so this is linear in the
+    /// corpus rather than a constant-cost mapping.
+    #[staticmethod]
+    fn open(py: Python<'_>, path: &str) -> PyResult<Self> {
+        let inner = py.detach(|| DiskStore::open(path)).map_err(to_pyerr)?;
+        Ok(Self { inner })
+    }
+
+    fn search(
+        &self,
+        py: Python<'_>,
+        query: &Bound<'_, PyAny>,
+        k: usize,
+    ) -> PyResult<Vec<(u64, f32)>> {
+        let q = vec_f32(query)?;
+        let results = py.detach(|| self.inner.search(&q, k)).map_err(to_pyerr)?;
+        Ok(results.into_iter().map(|r| (r.id, r.distance)).collect())
+    }
+
+    fn get(&self, id: u64) -> PyResult<Vec<f32>> {
+        self.inner.get(id).map(<[f32]>::to_vec).map_err(to_pyerr)
+    }
+
+    fn contains(&self, id: u64) -> bool {
+        self.inner.contains(id)
+    }
+
+    fn __len__(&self) -> usize {
+        self.inner.size()
+    }
+
+    fn size(&self) -> usize {
+        self.inner.size()
+    }
+
+    #[getter]
+    fn dimension(&self) -> usize {
+        self.inner.dimension()
+    }
+}
+
 #[pymodule]
 fn vanedb(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // From Cargo.toml, never a literal: a hardcoded string silently
@@ -343,9 +438,21 @@ fn vanedb(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyMetric>()?;
     m.add_class::<PyStore>()?;
     m.add_class::<PyIndex>()?;
+    m.add_class::<PyDiskStore>()?;
+    m.add_class::<PyDiskStoreBuilder>()?;
     // maturin's generated __init__ does `from .vanedb import *` and copies
     // __all__ verbatim, so this list is the package's entire public surface --
     // omitting __version__ here removes it from the package altogether.
-    m.add("__all__", vec!["Metric", "Store", "Index", "__version__"])?;
+    m.add(
+        "__all__",
+        vec![
+            "Metric",
+            "Store",
+            "Index",
+            "DiskStore",
+            "DiskStoreBuilder",
+            "__version__",
+        ],
+    )?;
     Ok(())
 }

--- a/vanedb-py/tests/test_vanedb.py
+++ b/vanedb-py/tests/test_vanedb.py
@@ -186,7 +186,44 @@ def test_public_surface_is_declared():
         "Metric",
         "Store",
         "Index",
+        "DiskStore",
+        "DiskStoreBuilder",
         "__version__",
     }
     for name in vanedb.__all__:
         assert hasattr(vanedb, name), f"{name} is exported but missing"
+
+
+# --- DiskStore ---
+
+
+def test_disk_store_round_trip(tmp_path):
+    """The memory-mapped store must be reachable from Python at all (#84)."""
+    path = str(tmp_path / "store.vndb")
+    builder = vanedb.DiskStoreBuilder(3, vanedb.Metric.L2)
+    for i in range(20):
+        builder.add(i, [float(i), 1.0, 2.0])
+    assert len(builder) == 20
+    assert builder.dimension == 3
+    builder.save(path)
+
+    store = vanedb.DiskStore.open(path)
+    assert len(store) == store.size() == 20
+    assert store.dimension == 3
+    assert store.contains(7)
+    assert not store.contains(999)
+    assert store.get(7) == [7.0, 1.0, 2.0]
+    hits = store.search([7.0, 1.0, 2.0], 1)
+    assert hits[0][0] == 7
+
+
+def test_disk_store_rejects_a_bad_file(tmp_path):
+    path = tmp_path / "not-a-store.vndb"
+    path.write_bytes(b"nonsense" * 8)
+    with pytest.raises(ValueError):
+        vanedb.DiskStore.open(str(path))
+
+
+def test_disk_store_is_in_the_public_surface():
+    assert "DiskStore" in vanedb.__all__
+    assert "DiskStoreBuilder" in vanedb.__all__

--- a/vanedb/src/disk.rs
+++ b/vanedb/src/disk.rs
@@ -87,6 +87,13 @@ impl DiskStoreBuilder {
         Ok(())
     }
 
+    /// Component count of every vector this builder accepts.
+    ///
+    /// The C++ `DiskStoreBuilder` exposes the same accessor.
+    pub fn dimension(&self) -> usize {
+        self.dim
+    }
+
     /// Number of vectors collected so far.
     /// Number of vectors in the mapped file.
     pub fn size(&self) -> usize {


### PR DESCRIPTION
Closes #84.

`vanedb-py` did not enable the `disk` feature on the core crate, so the memory-mapped store — one of the three types the root README advertises — was not merely unbound, it **was not compiled in**. Python users could only reach it through the C++ package, inverting the canonical/supplementary relationship for a headline capability.

An independent product review reached the same conclusion from the outside: *"`DiskStore` in the Rust wheel — the single strongest argument for C++ — is a `features = ["disk"]` line plus a pyclass wrapper."*

## What it looks like now

```python
b = vanedb.DiskStoreBuilder(3, vanedb.Metric.COSINE)
for i in range(10):
    b.add(i, [float(i), 1.0, 2.0])
b.save(path)

s = vanedb.DiskStore.open(path)
s.search([5.0, 1.0, 2.0], 2)   # [(5, 5.96e-08), (6, 0.00203)]
s.get(5), s.contains(5)        # [5.0, 1.0, 2.0], True
```

Same shape as the existing bindings: buffer-protocol input, GIL released around `open`, `search` and `save`, and both `__len__` and `size()` so either spelling works on either engine.

`DiskStoreBuilder` gains `dimension()` in the core — the C++ builder already had it, so this is also a parity fix.

## The guard did its job

Adding two classes failed `test_public_surface_is_declared`, which asserts `__all__` is exactly the package surface. That test exists because omitting a name from `__all__` silently deletes it from the package under maturin's generated `__init__`. Updated deliberately rather than by accident.

## Verification

41 Python tests against a built and installed wheel, including a `DiskStore` round-trip, a corrupt-file rejection, and the surface assertion. All eleven CI invocations green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H