### PR TITLE
build(ci): ship ARM and musl Linux wheels, and test them

### DIFF
--- a/.github/requirements-release.txt
+++ b/.github/requirements-release.txt
@@ -5,4 +5,5 @@ build==1.6.0
 cibuildwheel==4.2.0
 packaging==26.3
 pip==26.2.1
+PyYAML==6.0.3
 twine==7.0.0

--- a/.github/scripts/check_wheel_matrix.py
+++ b/.github/scripts/check_wheel_matrix.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Assert the release validator's wheel tripwires match the build matrices.
+
+The tripwires exist to catch matrix drift and have themselves drifted twice --
+once claiming 24 wheels while asserting 16, and once asserting 32 when the
+matrices produce 28. Deriving the expected total from the workflow removes the
+chance to get it wrong by hand.
+
+A build job produces (matrix combinations) x (interpreters in its maturin args)
+wheels: the Linux legs pass four `-i python3.N` flags each, while macOS and
+Windows pass a single `-i python` and vary the interpreter through the matrix.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+WORKFLOW = Path(__file__).resolve().parents[1] / "workflows" / "publish-rust.yml"
+BUILD_JOBS = ("linux", "macos", "windows")
+
+
+def combinations(matrix: dict) -> int:
+    """Number of legs a matrix expands to."""
+    axes = [v for k, v in matrix.items() if k not in ("include", "exclude") and isinstance(v, list)]
+    if axes:
+        # `include` entries that only add keys (a runner per arch) refine legs
+        # rather than adding them, so they do not multiply the count.
+        return math.prod(len(a) for a in axes)
+    return len(matrix.get("include", []))
+
+
+def interpreters(job: dict) -> int:
+    """How many wheels one leg of this job builds."""
+    for step in job.get("steps", []):
+        args = step.get("with", {}).get("args", "")
+        if "-i " in args:
+            return len(re.findall(r"-i \S+", args))
+    raise SystemExit(f"no maturin args found in job: {job.get('name')}")
+
+
+def main() -> int:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    jobs = yaml.safe_load(text)["jobs"]
+
+    per_job = {}
+    for name in BUILD_JOBS:
+        job = jobs[name]
+        per_job[name] = combinations(job["strategy"]["matrix"]) * interpreters(job)
+    total = sum(per_job.values())
+
+    declared = int(re.search(r"--wheel-count (\d+)", text).group(1))
+    tags = {m[0]: int(m[1]) for m in re.findall(r"--python-tag (cp\d+)=(\d+)", text)}
+    prefixes = {m[0]: int(m[1]) for m in re.findall(r"--platform-prefix (\w+)=(\d+)", text)}
+
+    breakdown = ", ".join(f"{n} {c}" for n, c in per_job.items())
+    failures = []
+    if declared != total:
+        failures.append(f"--wheel-count is {declared}; the matrices build {total} ({breakdown})")
+    # Every wheel carries exactly one Python tag and one platform prefix, so
+    # each set of tripwires must partition the same total.
+    if sum(tags.values()) != total:
+        failures.append(f"--python-tag counts sum to {sum(tags.values())}, expected {total}")
+    if sum(prefixes.values()) != total:
+        failures.append(f"--platform-prefix counts sum to {sum(prefixes.values())}, expected {total}")
+
+    for line in failures:
+        print(f"wheel matrix drift: {line}", file=sys.stderr)
+    if failures:
+        return 1
+    print(f"wheel tripwires match the matrices: {total} wheels ({breakdown})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,14 @@ jobs:
           echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
       - name: Lint GitHub Actions workflows
         run: actionlint -color
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.14'
+      - name: Check release wheel tripwires against the build matrices
+        shell: bash
+        run: |
+          python -m pip install --constraint .github/requirements-release.txt PyYAML
+          python .github/scripts/check_wheel_matrix.py
 
   rust:
     name: Rust component

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -78,37 +78,69 @@ jobs:
           fi
 
   linux:
-    name: Linux wheels (x86_64, Python 3.11–3.14)
+    # "Edge" is mostly ARM Linux — Raspberry Pi, Jetson, Graviton, and Docker
+    # on Apple Silicon, which defaults to linux/arm64. musl covers Alpine.
+    # Each leg builds natively; no emulation.
+    name: Linux wheels (${{ matrix.libc }} ${{ matrix.arch }}, Python 3.11–3.14)
     needs: validate-version
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            libc: manylinux
+            runner: ubuntu-latest
+            manylinux: '2_17'
+          - arch: aarch64
+            libc: manylinux
+            runner: ubuntu-24.04-arm
+            manylinux: '2_17'
+          - arch: x86_64
+            libc: musllinux
+            runner: ubuntu-latest
+            manylinux: musllinux_1_2
+          - arch: aarch64
+            libc: musllinux
+            runner: ubuntu-24.04-arm
+            manylinux: musllinux_1_2
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.14'
-      - name: Build manylinux wheels
+      - name: Build Linux wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
-          target: x86_64
-          manylinux: '2_17'
+          target: ${{ matrix.arch }}
+          manylinux: ${{ matrix.manylinux }}
           args: >-
             --release --locked --compatibility pypi --out dist
             --manifest-path vanedb-py/Cargo.toml
             -i python3.11 -i python3.12 -i python3.13 -i python3.14
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: vanedb-linux-x86_64
+          name: vanedb-linux-${{ matrix.libc }}-${{ matrix.arch }}
           path: dist/*.whl
           if-no-files-found: error
 
   linux-test:
-    name: Test Linux wheel (Python ${{ matrix.python-version }})
+    name: Test Linux wheel (${{ matrix.arch }}, Python ${{ matrix.python-version }})
     needs: linux
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
+        # arch is a real matrix axis so it crosses with python-version;
+        # include only supplies the runner for each arch. Putting arch solely
+        # in include would overwrite rather than cross-product.
         python-version: ['3.11', '3.12', '3.13', '3.14']
+        arch: [x86_64, aarch64]
+        include:
+          - arch: x86_64
+            runner: ubuntu-latest
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -116,7 +148,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: vanedb-linux-x86_64
+          name: vanedb-linux-manylinux-${{ matrix.arch }}
           path: dist
       - name: Install and test wheel
         shell: bash
@@ -127,6 +159,53 @@ jobs:
           python -m pip check
           python scripts/check_wheel_install.py vanedb
           python -m pytest vanedb-py/tests -v
+
+  musl-test:
+    # Alpine/musl is a shipped target, so it must be exercised before release.
+    # The wheel is tested inside an Alpine container driven from the host:
+    # running the job *in* a container instead would break the JS-based
+    # actions, whose bundled Node is glibc-linked and cannot start on musl.
+    name: Test musl wheel (${{ matrix.arch }})
+    needs: linux
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-latest
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: vanedb-linux-musllinux-${{ matrix.arch }}
+          path: dist
+      - name: Confirm the artifact really is musl-tagged
+        shell: bash
+        run: |
+          set -euo pipefail
+          ls dist/*.whl
+          if ls dist/*.whl | grep -qv musllinux; then
+            echo "non-musllinux wheel in the musl artifact" >&2
+            exit 1
+          fi
+      - name: Install and test the wheel under Alpine
+        shell: bash
+        run: |
+          set -euo pipefail
+          # pip selects the wheel matching the container's interpreter, so the
+          # Alpine image pins which cp3XX wheel this leg covers.
+          docker run --rm --volume "$PWD:/work" --workdir /work alpine:3.22 sh -euc '
+            apk add --no-cache python3 py3-pip
+            python3 -m venv /venv
+            /venv/bin/python -m pip install --disable-pip-version-check --quiet \
+              --no-index --no-deps --find-links dist vanedb
+            /venv/bin/python -m pip install --disable-pip-version-check --quiet pytest numpy
+            /venv/bin/python scripts/check_wheel_install.py vanedb
+            /venv/bin/python -m pytest vanedb-py/tests -v
+          '
 
   macos:
     name: macOS wheels (${{ matrix.target }}, Python ${{ matrix.python-version }})
@@ -244,7 +323,7 @@ jobs:
 
   validate-artifacts:
     name: Validate release artifacts
-    needs: [linux-test, macos, windows, sdist-test]
+    needs: [linux-test, musl-test, macos, windows, sdist-test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -261,20 +340,23 @@ jobs:
           python -m pip install --upgrade --constraint "${{ github.workspace }}/.github/requirements-release.txt" pip
           python -m pip install --constraint "${{ github.workspace }}/.github/requirements-release.txt" packaging twine
           python -m twine check --strict dist/*
-          # Matrix contract: 6 Linux + (2 macOS architectures x 6) +
-          # 6 Windows wheels = 24. Keep these tripwires aligned with the
-          # linux, macos, and windows build matrices above.
+          # Matrix contract: Linux (2 libc x 2 arch x 4 Python) = 16,
+          # macOS (2 arch x 4) = 8, Windows 4. Total 28, and each cpXXX tag
+          # appears 7 times (4 Linux legs + 2 macOS + 1 Windows). Keep these
+          # aligned with the build matrices above -- they exist to catch drift
+          # and had themselves drifted, claiming 24 while asserting 16.
           python .github/scripts/validate_python_release.py \
             --directory dist \
             --distribution vanedb \
             --pyproject vanedb-py/pyproject.toml \
-            --wheel-count 16 \
+            --wheel-count 28 \
             --sdist-count 1 \
-            --python-tag cp311=4 \
-            --python-tag cp312=4 \
-            --python-tag cp313=4 \
-            --python-tag cp314=4 \
-            --platform-prefix manylinux=4 \
+            --python-tag cp311=7 \
+            --python-tag cp312=7 \
+            --python-tag cp313=7 \
+            --python-tag cp314=7 \
+            --platform-prefix manylinux=8 \
+            --platform-prefix musllinux=8 \
             --platform-prefix macosx=8 \
             --platform-prefix win=4
 

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -186,11 +186,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ls dist/*.whl
-          if ls dist/*.whl | grep -qv musllinux; then
-            echo "non-musllinux wheel in the musl artifact" >&2
-            exit 1
-          fi
+          for wheel in dist/*.whl; do
+            echo "$wheel"
+            case "$wheel" in
+              *musllinux*) ;;
+              *)
+                echo "non-musllinux wheel in the musl artifact: $wheel" >&2
+                exit 1
+                ;;
+            esac
+          done
       - name: Install and test the wheel under Alpine
         shell: bash
         run: |


### PR DESCRIPTION
Closes #104.

## Why

Edge deployment is mostly **ARM Linux** — Raspberry Pi, Jetson, Graviton, and Docker on Apple Silicon (which defaults to `linux/arm64`) — and Alpine images need **musl**. The release built only manylinux x86_64, so the platform this project exists to target could not `pip install` a wheel at all.

## What

**Linux build matrix: 2 libc × 2 arch, every leg native (no emulation).**

| | x86_64 | aarch64 |
|---|---|---|
| manylinux 2_17 | `ubuntu-latest` | `ubuntu-24.04-arm` |
| musllinux 1_2 | `ubuntu-latest` | `ubuntu-24.04-arm` |

Linux goes from 4 wheels to 16; the release from 16 to 28.

**musl wheels are now tested, not just built.** A shipped target has to be exercised, so `musl-test` installs the musl wheel inside Alpine and runs the Python suite against it, and `validate-artifacts` now `needs` it — so a musl failure blocks publication. The container is driven from the host rather than the job running *in* it, because the JS-based actions bundle a glibc-linked Node that cannot start on musl.

`linux-test` gained an `aarch64` leg. `arch` is a real matrix axis there rather than an `include`-only key, so it crosses with `python-version` instead of overwriting it.

## The tripwires had drifted twice

`validate_python_release.py` takes expected wheel counts whose whole purpose is to catch matrix drift. They had already drifted once (a comment claiming 24 wheels above an assertion of 16), and drifted again *during this change* — I updated them to 32 against matrices that produce 28.

So they are no longer maintained by hand. `check_wheel_matrix.py` derives the total from the workflow itself — combinations × interpreters per leg — and asserts the tripwires agree; `workflow-lint` runs it on every PR.

It was falsified before being trusted, and catches all four:

| Reintroduced fault | Caught |
|---|---|
| `--wheel-count 32` (the drift I made) | ✅ |
| `--wheel-count 16` (the original drift) | ✅ |
| musl aarch64 leg deleted | ✅ |
| `-i python3.14` dropped from Linux args | ✅ |

## Verification

`actionlint` passes. Matrix expansion was checked by parsing the YAML rather than by reading it. The Rust suite is untouched — no test reads these files.

**Not verified locally:** the Alpine recipe in `musl-test`. Docker was unavailable on this machine, and `publish-rust.yml` only runs on tags and `workflow_dispatch`, so this PR will not exercise it. Worth a build-only rehearsal run before any real publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H