### PR TITLE
api(errors)!: classify failures instead of stringifying them

### DIFF
--- a/vanedb-py/src/lib.rs
+++ b/vanedb-py/src/lib.rs
@@ -1,5 +1,5 @@
 use pyo3::buffer::PyBuffer;
-use pyo3::exceptions::{PyTypeError, PyValueError};
+use pyo3::exceptions::{PyFileNotFoundError, PyOSError, PyTypeError, PyValueError};
 use pyo3::prelude::*;
 
 use ::vanedb::approx::ApproxIndex;
@@ -9,7 +9,28 @@ use ::vanedb::VaneError;
 use ::vanedb::{DiskIndex, DiskIndexBuilder};
 
 fn to_pyerr(e: VaneError) -> PyErr {
-    PyValueError::new_err(e.to_string())
+    // A missing file and a corrupt one call for different handling, so they
+    // must not share an exception class. FileNotFoundError is checked first
+    // because it is a subclass of OSError.
+    match &e {
+        VaneError::FileNotFound { .. } => PyFileNotFoundError::new_err(e.to_string()),
+        VaneError::Io { .. } => PyOSError::new_err(e.to_string()),
+        // Corrupt data and every validation failure stay ValueError.
+        _ => PyValueError::new_err(e.to_string()),
+    }
+}
+
+/// Converts a Python int to an id.
+///
+/// PyO3's own `u64` conversion raises `OverflowError` for a negative value,
+/// and `OverflowError` is not a `ValueError` subclass -- so `except ValueError`
+/// silently missed negative ids. Every method taking an id goes through this.
+fn one_id(obj: &Bound<'_, PyAny>) -> PyResult<u64> {
+    if let Ok(id) = obj.extract::<u64>() {
+        return Ok(id);
+    }
+    let signed: i64 = obj.extract()?;
+    u64::try_from(signed).map_err(|_| PyValueError::new_err(format!("negative id: {signed}")))
 }
 
 /// Extract a single vector. Fast paths: any 1-D float32 or float64 buffer
@@ -106,7 +127,20 @@ fn ids_u64(obj: &Bound<'_, PyAny>) -> PyResult<Vec<u64>> {
             })
             .collect();
     }
-    obj.extract()
+    match obj.extract::<Vec<u64>>() {
+        Ok(ids) => Ok(ids),
+        Err(_) => {
+            // Retry as signed so a negative id in a plain list reports as
+            // ValueError, matching the buffer path above.
+            let signed: Vec<i64> = obj.extract()?;
+            signed
+                .into_iter()
+                .map(|x| {
+                    u64::try_from(x).map_err(|_| PyValueError::new_err(format!("negative id: {x}")))
+                })
+                .collect()
+        }
+    }
 }
 
 fn check_batch_len(ids: &[u64], rows: usize) -> PyResult<()> {
@@ -161,7 +195,11 @@ impl PyStore {
     }
 
     /// Add one vector. Accepts a 1-D float32 buffer (numpy) or any float sequence.
-    fn add(&self, id: u64, vector: &Bound<'_, PyAny>) -> PyResult<()> {
+    fn add(
+        &self,
+        #[pyo3(from_py_with = one_id)] id: u64,
+        vector: &Bound<'_, PyAny>,
+    ) -> PyResult<()> {
         let v = vec_f32(vector)?;
         self.inner.add(id, &v).map_err(to_pyerr)
     }
@@ -194,15 +232,15 @@ impl PyStore {
         Ok(results.into_iter().map(|r| (r.id, r.distance)).collect())
     }
 
-    fn get(&self, id: u64) -> PyResult<Vec<f32>> {
+    fn get(&self, #[pyo3(from_py_with = one_id)] id: u64) -> PyResult<Vec<f32>> {
         self.inner.get(id).map_err(to_pyerr)
     }
 
-    fn remove(&self, id: u64) -> PyResult<()> {
+    fn remove(&self, #[pyo3(from_py_with = one_id)] id: u64) -> PyResult<()> {
         self.inner.remove(id).map_err(to_pyerr)
     }
 
-    fn contains(&self, id: u64) -> bool {
+    fn contains(&self, #[pyo3(from_py_with = one_id)] id: u64) -> bool {
         self.inner.contains(id)
     }
 
@@ -254,7 +292,12 @@ impl PyIndex {
     }
 
     /// Add one vector. Accepts a 1-D float32 buffer (numpy) or any float sequence.
-    fn add(&self, py: Python<'_>, id: u64, vector: &Bound<'_, PyAny>) -> PyResult<()> {
+    fn add(
+        &self,
+        py: Python<'_>,
+        #[pyo3(from_py_with = one_id)] id: u64,
+        vector: &Bound<'_, PyAny>,
+    ) -> PyResult<()> {
         let v = vec_f32(vector)?;
         py.detach(|| self.inner.add(id, &v)).map_err(to_pyerr)
     }
@@ -287,11 +330,11 @@ impl PyIndex {
         Ok(results.into_iter().map(|r| (r.id, r.distance)).collect())
     }
 
-    fn get_vector(&self, id: u64) -> PyResult<Vec<f32>> {
+    fn get_vector(&self, #[pyo3(from_py_with = one_id)] id: u64) -> PyResult<Vec<f32>> {
         self.inner.get_vector(id).map_err(to_pyerr)
     }
 
-    fn contains(&self, id: u64) -> bool {
+    fn contains(&self, #[pyo3(from_py_with = one_id)] id: u64) -> bool {
         self.inner.contains(id)
     }
 
@@ -324,7 +367,11 @@ impl PyIndex {
     /// Both halves happen under one write lock, so a concurrent reader never
     /// observes the id missing. The old slot is tombstoned, so a long upsert
     /// loop still needs `compact()`.
-    fn upsert(&self, id: u64, vector: &Bound<'_, PyAny>) -> PyResult<()> {
+    fn upsert(
+        &self,
+        #[pyo3(from_py_with = one_id)] id: u64,
+        vector: &Bound<'_, PyAny>,
+    ) -> PyResult<()> {
         let v = vec_f32(vector)?;
         self.inner.upsert(id, &v).map_err(to_pyerr)
     }
@@ -349,7 +396,7 @@ impl PyIndex {
     /// Tombstoned: the node keeps its graph links, which may be the only
     /// route between live neighbourhoods, and simply stops appearing in
     /// results. The id becomes free for reuse. Space is not reclaimed.
-    fn remove(&self, id: u64) -> PyResult<()> {
+    fn remove(&self, #[pyo3(from_py_with = one_id)] id: u64) -> PyResult<()> {
         self.inner.remove(id).map_err(to_pyerr)
     }
 
@@ -386,7 +433,11 @@ impl PyDiskStoreBuilder {
         })
     }
 
-    fn add(&mut self, id: u64, vector: &Bound<'_, PyAny>) -> PyResult<()> {
+    fn add(
+        &mut self,
+        #[pyo3(from_py_with = one_id)] id: u64,
+        vector: &Bound<'_, PyAny>,
+    ) -> PyResult<()> {
         let v = vec_f32(vector)?;
         self.inner.add(id, &v).map_err(to_pyerr)
     }
@@ -441,11 +492,11 @@ impl PyDiskStore {
         Ok(results.into_iter().map(|r| (r.id, r.distance)).collect())
     }
 
-    fn get(&self, id: u64) -> PyResult<Vec<f32>> {
+    fn get(&self, #[pyo3(from_py_with = one_id)] id: u64) -> PyResult<Vec<f32>> {
         self.inner.get(id).map(<[f32]>::to_vec).map_err(to_pyerr)
     }
 
-    fn contains(&self, id: u64) -> bool {
+    fn contains(&self, #[pyo3(from_py_with = one_id)] id: u64) -> bool {
         self.inner.contains(id)
     }
 

--- a/vanedb-py/tests/test_errors.py
+++ b/vanedb-py/tests/test_errors.py
@@ -1,0 +1,85 @@
+"""The Python error contract.
+
+Every failure used to surface as ValueError, so "the index file isn't there
+yet" was indistinguishable from "the vector had the wrong length" without
+reading the message. And negative ids escaped as OverflowError, which is not
+a ValueError subclass, so `except ValueError` silently missed them.
+"""
+
+import pathlib
+
+import pytest
+
+import vanedb
+
+
+def test_missing_index_file_raises_filenotfounderror(tmp_path):
+    missing = tmp_path / "does-not-exist.vane"
+    with pytest.raises(FileNotFoundError):
+        vanedb.ApproxIndex.load(str(missing))
+
+
+def test_load_or_build_is_expressible_with_ordinary_python(tmp_path):
+    # The motivating pattern, written the way a user would write it.
+    path = str(tmp_path / "index.vane")
+    try:
+        index = vanedb.ApproxIndex.load(path)
+    except FileNotFoundError:
+        index = vanedb.ApproxIndex(dim=4)
+    index.add(1, [1.0, 0.0, 0.0, 0.0])
+    assert len(index) == 1
+
+
+def test_corrupt_index_file_raises_valueerror_not_filenotfound(tmp_path):
+    path = tmp_path / "garbage.vane"
+    path.write_bytes(b"this is not a vanedb file")
+    with pytest.raises(ValueError) as excinfo:
+        vanedb.ApproxIndex.load(str(path))
+    assert not isinstance(excinfo.value, FileNotFoundError)
+
+
+def test_a_dimension_mismatch_is_still_a_valueerror():
+    index = vanedb.ApproxIndex(dim=4)
+    with pytest.raises(ValueError):
+        index.add(1, [1.0, 2.0])
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda idx: idx.add(-1, [1.0, 0.0, 0.0, 0.0]),
+        lambda idx: idx.get_vector(-1),
+        lambda idx: idx.remove(-1),
+        lambda idx: idx.upsert(-1, [1.0, 0.0, 0.0, 0.0]),
+    ],
+    ids=["add", "get_vector", "remove", "upsert"],
+)
+def test_a_negative_id_is_a_valueerror_everywhere(call):
+    # OverflowError is not a ValueError subclass, so `except ValueError`
+    # used to miss these entirely.
+    index = vanedb.ApproxIndex(dim=4)
+    with pytest.raises(ValueError):
+        call(index)
+
+
+def test_a_negative_id_in_a_plain_list_batch_is_a_valueerror():
+    # Only the numpy path was checked; a plain list went through a different
+    # conversion and raised OverflowError.
+    index = vanedb.ApproxIndex(dim=2)
+    with pytest.raises(ValueError):
+        index.add_batch([1, -1], [[1.0, 0.0], [0.0, 1.0]])
+
+
+def test_a_negative_id_in_a_numpy_batch_is_a_valueerror():
+    numpy = pytest.importorskip("numpy")
+    index = vanedb.ApproxIndex(dim=2)
+    ids = numpy.array([1, -1], dtype=numpy.int64)
+    vectors = numpy.array([[1.0, 0.0], [0.0, 1.0]], dtype=numpy.float32)
+    with pytest.raises(ValueError):
+        index.add_batch(ids, vectors)
+
+
+def test_contains_rejects_a_negative_id_consistently():
+    index = vanedb.ApproxIndex(dim=4)
+    with pytest.raises(ValueError):
+        index.contains(-1)

--- a/vanedb/src/approx/mod.rs
+++ b/vanedb/src/approx/mod.rs
@@ -796,9 +796,15 @@ impl ApproxIndexBuilder {
     }
 
     /// Allocates the graph and returns the index.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VaneError::ZeroDimension`] if `dim` is zero, or
+    /// [`VaneError::InvalidParameter`] if a graph parameter is out of range or
+    /// implies an allocation that would overflow.
     pub fn build(self) -> Result<ApproxIndex> {
         if self.dim == 0 {
-            return Err(VaneError::EmptyVector);
+            return Err(VaneError::ZeroDimension);
         }
         if self.capacity == 0 {
             return Err(VaneError::InvalidParameter("capacity must be > 0"));

--- a/vanedb/src/approx/persistence.rs
+++ b/vanedb/src/approx/persistence.rs
@@ -69,7 +69,7 @@ fn u32_to_metric(v: u32) -> Result<Metric> {
         0 => Ok(Metric::L2),
         1 => Ok(Metric::Cosine),
         2 => Ok(Metric::Dot),
-        _ => Err(VaneError::Io("invalid metric in file".to_string())),
+        _ => Err(VaneError::corrupt("invalid metric in file")),
     }
 }
 
@@ -104,23 +104,21 @@ impl ApproxIndex {
         };
 
         let payload = bincode::serde::encode_to_vec(&data, bincode::config::legacy())
-            .map_err(|e| VaneError::Io(format!("serialize: {e}")))?;
+            .map_err(|e| VaneError::from_io("serialize", std::io::Error::other(e)))?;
 
         let path = path.as_ref();
         let temp = crate::atomic_write::AtomicFile::new(path);
-        let mut f =
-            fs::File::create(temp.path()).map_err(|e| VaneError::Io(format!("create: {e}")))?;
+        let mut f = fs::File::create(temp.path()).map_err(|e| VaneError::from_io("create", e))?;
         f.write_all(&MAGIC.to_le_bytes())
-            .map_err(|e| VaneError::Io(format!("write: {e}")))?;
+            .map_err(|e| VaneError::from_io("write", e))?;
         f.write_all(&VERSION.to_le_bytes())
-            .map_err(|e| VaneError::Io(format!("write: {e}")))?;
+            .map_err(|e| VaneError::from_io("write", e))?;
         f.write_all(&payload)
-            .map_err(|e| VaneError::Io(format!("write: {e}")))?;
+            .map_err(|e| VaneError::from_io("write", e))?;
         // Durability: fsync data + metadata before rename so a crash mid-write
         // can't leave a half-written file in place. Mirrors fsync_file in
         // vanedb-cpp src/core/detail/file_utils.h.
-        f.sync_all()
-            .map_err(|e| VaneError::Io(format!("sync: {e}")))?;
+        f.sync_all().map_err(|e| VaneError::from_io("sync", e))?;
         drop(f);
 
         temp.commit(path)
@@ -132,24 +130,26 @@ impl ApproxIndex {
     /// invariants are checked on the way in, so a corrupt file is rejected
     /// rather than producing wrong search results.
     pub fn load(path: impl AsRef<Path>) -> Result<Self> {
-        let bytes = fs::read(path.as_ref()).map_err(|e| VaneError::Io(format!("read: {e}")))?;
+        let bytes = fs::read(path.as_ref()).map_err(|e| VaneError::from_io("read", e))?;
         if bytes.len() < HEADER_LEN {
-            return Err(VaneError::Io("file too small for header".to_string()));
+            return Err(VaneError::corrupt("file too small for header"));
         }
         let magic = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
         if magic != MAGIC {
-            return Err(VaneError::Io("invalid magic".to_string()));
+            return Err(VaneError::corrupt("invalid magic"));
         }
         let version = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
         if version != V1 && version != VERSION {
-            return Err(VaneError::Io(format!("unsupported version: {version}")));
+            return Err(VaneError::corrupt(format!(
+                "unsupported version: {version}"
+            )));
         }
 
         // config::legacy() is bincode 1's wire format (fixint, little-endian),
         // so files written before the bincode 2 migration load unchanged.
         let (data, _): (HnswData, usize) =
             bincode::serde::decode_from_slice(&bytes[HEADER_LEN..], bincode::config::legacy())
-                .map_err(|e| VaneError::Io(format!("deserialize: {e}")))?;
+                .map_err(|e| VaneError::corrupt(format!("deserialize: {e}")))?;
 
         // Validate semantic invariants. bincode catches schema mismatches but
         // never validates values, so a corrupt or hostile file could otherwise
@@ -158,17 +158,17 @@ impl ApproxIndex {
         // to one in the C++ load() path (vanedb-cpp src/core/index.h).
         let metric = u32_to_metric(data.metric)?;
         if data.dim == 0 {
-            return Err(VaneError::Io("invalid dim: 0".to_string()));
+            return Err(VaneError::corrupt("invalid dim: 0"));
         }
         if data.max_elements == 0 {
-            return Err(VaneError::Io("invalid max_elements: 0".to_string()));
+            return Err(VaneError::corrupt("invalid max_elements: 0"));
         }
         // A file declares max_elements; load re-expands every array to it. Cap
         // it so a few hundred bytes cannot request terabytes. vanedb-cpp caps
         // every deserialized array the same way (MAX_VEC_SIZE in
         // src/core/index.h).
         if data.max_elements > MAX_ELEMENTS {
-            return Err(VaneError::Io(format!(
+            return Err(VaneError::corrupt(format!(
                 "corrupted file: max_elements {} exceeds the {MAX_ELEMENTS} limit",
                 data.max_elements
             )));
@@ -176,30 +176,28 @@ impl ApproxIndex {
         // C++ validates these on load; Rust checked them only at build time,
         // so a hostile file could set m = 0 and make the level maths degenerate.
         if data.m < 2 {
-            return Err(VaneError::Io(format!(
+            return Err(VaneError::corrupt(format!(
                 "corrupted file: m {} is below 2",
                 data.m
             )));
         }
         if data.ef_construction == 0 {
-            return Err(VaneError::Io(
-                "corrupted file: ef_construction is 0".to_string(),
-            ));
+            return Err(VaneError::corrupt("corrupted file: ef_construction is 0"));
         }
         if data.m_max0 != data.m * 2 || data.m_max != data.m {
-            return Err(VaneError::Io(format!(
+            return Err(VaneError::corrupt(format!(
                 "corrupted file: m_max {} / m_max0 {} disagree with m {}",
                 data.m_max, data.m_max0, data.m
             )));
         }
         if data.count > data.max_elements {
-            return Err(VaneError::Io(format!(
+            return Err(VaneError::corrupt(format!(
                 "corrupted file: count {} exceeds max_elements {}",
                 data.count, data.max_elements
             )));
         }
         if data.max_level > MAX_LEVEL {
-            return Err(VaneError::Io(format!(
+            return Err(VaneError::corrupt(format!(
                 "corrupted file: max_level {} exceeds bound {}",
                 data.max_level, MAX_LEVEL
             )));
@@ -207,21 +205,21 @@ impl ApproxIndex {
         match data.entry_point {
             Some(ep) => {
                 if ep >= data.count {
-                    return Err(VaneError::Io(format!(
+                    return Err(VaneError::corrupt(format!(
                         "corrupted file: entry point {ep} >= count {}",
                         data.count
                     )));
                 }
                 if data.max_level < 0 {
-                    return Err(VaneError::Io(
-                        "corrupted file: entry point set but max_level < 0".to_string(),
+                    return Err(VaneError::corrupt(
+                        "corrupted file: entry point set but max_level < 0",
                     ));
                 }
             }
             None => {
                 if data.count > 0 {
-                    return Err(VaneError::Io(
-                        "corrupted file: count > 0 with no entry point".to_string(),
+                    return Err(VaneError::corrupt(
+                        "corrupted file: count > 0 with no entry point",
                     ));
                 }
             }
@@ -230,7 +228,7 @@ impl ApproxIndex {
         // smaller than count. More than count is still corrupt: every entry
         // must name a distinct slot.
         if data.id_map.len() > data.count {
-            return Err(VaneError::Io(format!(
+            return Err(VaneError::corrupt(format!(
                 "corrupted file: id_map size {} exceeds count {}",
                 data.id_map.len(),
                 data.count
@@ -248,13 +246,13 @@ impl ApproxIndex {
         // carrying that id, and a slot absent from id_map is simply deleted.
         for (&ext_id, &mapped) in &data.id_map {
             if mapped >= data.count {
-                return Err(VaneError::Io(format!(
+                return Err(VaneError::corrupt(format!(
                     "corrupted file: id_map[{ext_id}] is {mapped}, beyond count {}",
                     data.count
                 )));
             }
             if data.ext_ids[mapped] != ext_id {
-                return Err(VaneError::Io(format!(
+                return Err(VaneError::corrupt(format!(
                     "corrupted file: id_map[{ext_id}] is {mapped}, whose ext_id is {}",
                     data.ext_ids[mapped]
                 )));
@@ -263,8 +261,8 @@ impl ApproxIndex {
         {}
         for &iid in data.id_map.values() {
             if iid >= data.count {
-                return Err(VaneError::Io(
-                    "corrupted file: id_map value out of range".to_string(),
+                return Err(VaneError::corrupt(
+                    "corrupted file: id_map value out of range",
                 ));
             }
         }
@@ -276,22 +274,22 @@ impl ApproxIndex {
             data.count
         };
         if data.neighbors.len() != stored {
-            return Err(VaneError::Io(format!(
+            return Err(VaneError::corrupt(format!(
                 "corrupted file: neighbors length {} != expected {stored}",
                 data.neighbors.len()
             )));
         }
         for nbs in data.neighbors.iter().take(data.count) {
             if nbs.len() > (MAX_LEVEL as usize) + 1 {
-                return Err(VaneError::Io(
-                    "corrupted file: too many neighbor levels".to_string(),
+                return Err(VaneError::corrupt(
+                    "corrupted file: too many neighbor levels",
                 ));
             }
             for layer in nbs {
                 for &n in layer {
                     if n >= data.count {
-                        return Err(VaneError::Io(
-                            "corrupted file: neighbor index out of range".to_string(),
+                        return Err(VaneError::corrupt(
+                            "corrupted file: neighbor index out of range",
                         ));
                     }
                 }
@@ -299,10 +297,10 @@ impl ApproxIndex {
         }
         data.max_elements
             .checked_mul(data.dim)
-            .ok_or_else(|| VaneError::Io("size overflow".to_string()))?;
+            .ok_or_else(|| VaneError::corrupt("size overflow"))?;
         if data.vectors.len() != stored * data.dim {
-            return Err(VaneError::Io(
-                "corrupted file: vectors length != expected * dim".to_string(),
+            return Err(VaneError::corrupt(
+                "corrupted file: vectors length != expected * dim",
             ));
         }
         let live_vectors_len = data.count * data.dim;
@@ -310,13 +308,13 @@ impl ApproxIndex {
             .iter()
             .any(|value| !value.is_finite())
         {
-            return Err(VaneError::Io(
-                "corrupted file: vector values must be finite".to_string(),
+            return Err(VaneError::corrupt(
+                "corrupted file: vector values must be finite",
             ));
         }
         if data.ext_ids.len() != stored || data.levels.len() != stored {
-            return Err(VaneError::Io(
-                "corrupted file: ext_ids/levels length != expected".to_string(),
+            return Err(VaneError::corrupt(
+                "corrupted file: ext_ids/levels length != expected",
             ));
         }
 

--- a/vanedb/src/atomic_write.rs
+++ b/vanedb/src/atomic_write.rs
@@ -46,7 +46,7 @@ impl AtomicFile {
 
     /// Publish the finished temporary file at `dest`.
     pub(crate) fn commit(mut self, dest: &Path) -> Result<()> {
-        fs::rename(&self.temp, dest).map_err(|e| VaneError::Io(format!("rename: {e}")))?;
+        fs::rename(&self.temp, dest).map_err(|e| VaneError::from_io("rename", e))?;
         self.committed = true;
         Ok(())
     }

--- a/vanedb/src/disk.rs
+++ b/vanedb/src/disk.rs
@@ -39,7 +39,7 @@ fn u32_to_metric(v: u32) -> Result<Metric> {
         0 => Ok(Metric::L2),
         1 => Ok(Metric::Cosine),
         2 => Ok(Metric::Dot),
-        _ => Err(VaneError::Io("invalid metric in file".to_string())),
+        _ => Err(VaneError::corrupt("invalid metric in file")),
     }
 }
 
@@ -67,9 +67,13 @@ impl std::fmt::Debug for DiskIndexBuilder {
 
 impl DiskIndexBuilder {
     /// Starts a store for vectors of `dim` components.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VaneError::ZeroDimension`] if `dim` is zero.
     pub fn new(dim: usize, metric: Metric) -> Result<Self> {
         if dim == 0 {
-            return Err(VaneError::EmptyVector);
+            return Err(VaneError::ZeroDimension);
         }
         Ok(Self {
             dim,
@@ -124,45 +128,45 @@ impl DiskIndexBuilder {
     pub fn save(&self, path: impl AsRef<Path>) -> Result<()> {
         let path = path.as_ref();
         let temp = crate::atomic_write::AtomicFile::new(path);
-        let file =
-            fs::File::create(temp.path()).map_err(|e| VaneError::Io(format!("create: {e}")))?;
+        let file = fs::File::create(temp.path()).map_err(|e| VaneError::from_io("create", e))?;
         let mut f = BufWriter::with_capacity(WRITE_BUFFER_BYTES, file);
 
         // Header
         f.write_all(&MAGIC.to_le_bytes())
-            .map_err(|e| VaneError::Io(format!("write: {e}")))?;
+            .map_err(|e| VaneError::from_io("write", e))?;
         f.write_all(&VERSION.to_le_bytes())
-            .map_err(|e| VaneError::Io(format!("write: {e}")))?;
+            .map_err(|e| VaneError::from_io("write", e))?;
         f.write_all(&(self.dim as u64).to_le_bytes())
-            .map_err(|e| VaneError::Io(format!("write: {e}")))?;
+            .map_err(|e| VaneError::from_io("write", e))?;
         f.write_all(&(self.ids.len() as u64).to_le_bytes())
-            .map_err(|e| VaneError::Io(format!("write: {e}")))?;
+            .map_err(|e| VaneError::from_io("write", e))?;
         f.write_all(&metric_to_u32(self.metric).to_le_bytes())
-            .map_err(|e| VaneError::Io(format!("write: {e}")))?;
+            .map_err(|e| VaneError::from_io("write", e))?;
         f.write_all(&0u32.to_le_bytes())
-            .map_err(|e| VaneError::Io(format!("write: {e}")))?; // reserved
+            .map_err(|e| VaneError::from_io("write", e))?; // reserved
 
         // IDs
         for &id in &self.ids {
             f.write_all(&id.to_le_bytes())
-                .map_err(|e| VaneError::Io(format!("write: {e}")))?;
+                .map_err(|e| VaneError::from_io("write", e))?;
         }
 
         // Vectors
         for &v in &self.vectors {
             f.write_all(&v.to_le_bytes())
-                .map_err(|e| VaneError::Io(format!("write: {e}")))?;
+                .map_err(|e| VaneError::from_io("write", e))?;
         }
 
         // into_inner flushes the buffer; the fsync below must see every byte.
+        // into_inner yields an IntoInnerError wrapping the writer; take the
+        // io::Error out of it so the classification and source chain work.
         let f = f
             .into_inner()
-            .map_err(|e| VaneError::Io(format!("flush: {e}")))?;
+            .map_err(|e| VaneError::from_io("flush", e.into_error()))?;
         // Durability: fsync data + metadata before rename so a crash mid-write
         // can't leave a half-written file in place. Mirrors fsync_file in
         // vanedb-cpp src/core/detail/file_utils.h.
-        f.sync_all()
-            .map_err(|e| VaneError::Io(format!("sync: {e}")))?;
+        f.sync_all().map_err(|e| VaneError::from_io("sync", e))?;
         drop(f);
 
         temp.commit(path)
@@ -202,21 +206,22 @@ impl DiskIndex {
     /// constant-cost mapping. A corrupt or truncated file is rejected here
     /// rather than surfacing as a wrong answer later.
     pub fn open(path: impl AsRef<Path>) -> Result<Self> {
-        let file =
-            fs::File::open(path.as_ref()).map_err(|e| VaneError::Io(format!("open: {e}")))?;
-        let mmap = unsafe { Mmap::map(&file) }.map_err(|e| VaneError::Io(format!("mmap: {e}")))?;
+        let file = fs::File::open(path.as_ref()).map_err(|e| VaneError::from_io("open", e))?;
+        let mmap = unsafe { Mmap::map(&file) }.map_err(|e| VaneError::from_io("mmap", e))?;
 
         if mmap.len() < HEADER_SIZE {
-            return Err(VaneError::Io("file too small".to_string()));
+            return Err(VaneError::corrupt("file too small"));
         }
 
         let magic = u32::from_le_bytes(mmap[0..4].try_into().unwrap());
         if magic != MAGIC {
-            return Err(VaneError::Io("invalid magic".to_string()));
+            return Err(VaneError::corrupt("invalid magic"));
         }
         let version = u32::from_le_bytes(mmap[4..8].try_into().unwrap());
         if version != VERSION {
-            return Err(VaneError::Io(format!("unsupported version: {version}")));
+            return Err(VaneError::corrupt(format!(
+                "unsupported version: {version}"
+            )));
         }
 
         let dim = u64::from_le_bytes(mmap[8..16].try_into().unwrap()) as usize;
@@ -225,23 +230,23 @@ impl DiskIndex {
         let metric = u32_to_metric(metric_raw)?;
 
         if dim == 0 && num_vectors > 0 {
-            return Err(VaneError::Io("zero dimension with vectors".to_string()));
+            return Err(VaneError::corrupt("zero dimension with vectors"));
         }
 
         let ids_size = num_vectors
             .checked_mul(8)
-            .ok_or_else(|| VaneError::Io("size overflow".to_string()))?;
+            .ok_or_else(|| VaneError::corrupt("size overflow"))?;
         let vecs_size = num_vectors
             .checked_mul(dim)
             .and_then(|n| n.checked_mul(4))
-            .ok_or_else(|| VaneError::Io("size overflow".to_string()))?;
+            .ok_or_else(|| VaneError::corrupt("size overflow"))?;
         let expected = HEADER_SIZE
             .checked_add(ids_size)
             .and_then(|n| n.checked_add(vecs_size))
-            .ok_or_else(|| VaneError::Io("size overflow".to_string()))?;
+            .ok_or_else(|| VaneError::corrupt("size overflow"))?;
 
         if mmap.len() < expected {
-            return Err(VaneError::Io("file truncated".to_string()));
+            return Err(VaneError::corrupt("file truncated"));
         }
 
         let ids_offset = HEADER_SIZE;
@@ -249,8 +254,8 @@ impl DiskIndex {
 
         for offset in (vectors_offset..expected).step_by(4) {
             if !f32::from_le_bytes(mmap[offset..offset + 4].try_into().unwrap()).is_finite() {
-                return Err(VaneError::Io(
-                    "corrupted file: vector values must be finite".to_string(),
+                return Err(VaneError::corrupt(
+                    "corrupted file: vector values must be finite",
                 ));
             }
         }

--- a/vanedb/src/distance/mod.rs
+++ b/vanedb/src/distance/mod.rs
@@ -10,7 +10,11 @@ pub mod neon;
 pub mod scalar;
 
 /// Distance metric for vector comparison.
+///
+/// `#[non_exhaustive]`: matching on a `Metric` needs a `_` arm, so a new
+/// metric can be added without a breaking release.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Metric {
     /// Squared Euclidean distance
     L2,

--- a/vanedb/src/error.rs
+++ b/vanedb/src/error.rs
@@ -1,7 +1,25 @@
 //! The error type returned by every fallible operation.
 
+use std::io;
+
 /// Everything that can go wrong in this crate.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// # Matching
+///
+/// This enum is `#[non_exhaustive]`, so a `match` over it needs a `_` arm.
+/// That is deliberate: distinguishing a corrupt file from a missing one was
+/// itself a late addition, and the next variant should not need a major
+/// release either.
+///
+/// # Comparing
+///
+/// `VaneError` is deliberately not `PartialEq`. It used to be, which made
+/// `err == VaneError::InvalidParameter("M must be >= 2")` compile and pass —
+/// turning every diagnostic string into public API that could never be
+/// reworded. Match on the variant instead. It is also not `Clone`, because
+/// [`io::Error`] is not.
+#[derive(Debug)]
+#[non_exhaustive]
 pub enum VaneError {
     /// A vector's length did not match the dimension the store was created with.
     DimensionMismatch {
@@ -10,9 +28,14 @@ pub enum VaneError {
         /// The length actually supplied.
         got: usize,
     },
-    /// A zero-length vector was supplied.
-    EmptyVector,
+    /// A dimension of zero was requested when creating a store or index.
+    ///
+    /// This is a constructor error. A zero-length vector passed to `add`
+    /// reports [`VaneError::DimensionMismatch`] with `got: 0` instead.
+    ZeroDimension,
     /// No vector is stored under this id.
+    ///
+    /// This is a lookup miss, unrelated to [`VaneError::FileNotFound`].
     NotFound {
         /// The id that was looked up.
         id: u64,
@@ -32,8 +55,74 @@ pub enum VaneError {
     /// A parameter was outside its valid range, or an allocation it implies
     /// would overflow.
     InvalidParameter(&'static str),
-    /// A filesystem or serialisation failure, with the underlying message.
-    Io(String),
+    /// The file does not exist.
+    ///
+    /// Separate from every other I/O failure because "load it, or build it if
+    /// it isn't there" is the most common thing an application does with a
+    /// persisted index, and it should not require inspecting a message.
+    FileNotFound {
+        /// The operation that failed, such as `"open"`.
+        context: &'static str,
+        /// The underlying failure, whose [`io::Error::kind`] is
+        /// [`io::ErrorKind::NotFound`].
+        source: io::Error,
+    },
+    /// The file was readable but does not hold a valid vanedb structure.
+    ///
+    /// Retrying will not help; the file has to be rebuilt.
+    Corrupt {
+        /// What was wrong with it, for diagnostics only. Not stable API.
+        detail: String,
+    },
+    /// A compute backend (Metal, CUDA) could not be initialised or used.
+    ///
+    /// Callers that can run on the CPU should fall back rather than retry.
+    Backend {
+        /// What failed, for diagnostics only. Not stable API.
+        detail: String,
+    },
+    /// Any other filesystem or serialisation failure — a full disk, a
+    /// permission problem, a failing device. Retrying may help.
+    Io {
+        /// The operation that failed, such as `"write"` or `"sync"`.
+        context: &'static str,
+        /// The underlying failure.
+        source: io::Error,
+    },
+}
+
+impl VaneError {
+    /// Classifies an [`io::Error`], tagging it with the operation that failed.
+    ///
+    /// A missing file becomes [`VaneError::FileNotFound`]; everything else
+    /// becomes [`VaneError::Io`].
+    pub fn from_io(context: &'static str, source: io::Error) -> Self {
+        if source.kind() == io::ErrorKind::NotFound {
+            Self::FileNotFound { context, source }
+        } else {
+            Self::Io { context, source }
+        }
+    }
+
+    /// Reports a file whose contents are not a valid vanedb structure.
+    pub fn corrupt(detail: impl Into<String>) -> Self {
+        Self::Corrupt {
+            detail: detail.into(),
+        }
+    }
+
+    /// Reports a compute backend that could not be initialised or used.
+    pub fn backend(detail: impl Into<String>) -> Self {
+        Self::Backend {
+            detail: detail.into(),
+        }
+    }
+}
+
+impl From<io::Error> for VaneError {
+    fn from(source: io::Error) -> Self {
+        Self::from_io("io", source)
+    }
 }
 
 impl std::fmt::Display for VaneError {
@@ -42,7 +131,7 @@ impl std::fmt::Display for VaneError {
             Self::DimensionMismatch { expected, got } => {
                 write!(f, "dimension mismatch: expected {expected}, got {got}")
             }
-            Self::EmptyVector => write!(f, "empty vector"),
+            Self::ZeroDimension => write!(f, "dimension must be > 0"),
             Self::NotFound { id } => write!(f, "vector not found: {id}"),
             Self::DuplicateId { id } => write!(f, "duplicate id: {id}"),
             Self::InvalidK => write!(f, "k must be > 0"),
@@ -50,12 +139,23 @@ impl std::fmt::Display for VaneError {
                 write!(f, "{input} must contain only finite values")
             }
             Self::InvalidParameter(msg) => write!(f, "invalid parameter: {msg}"),
-            Self::Io(msg) => write!(f, "I/O error: {msg}"),
+            Self::FileNotFound { context, source } | Self::Io { context, source } => {
+                write!(f, "{context}: {source}")
+            }
+            Self::Corrupt { detail } => write!(f, "corrupt file: {detail}"),
+            Self::Backend { detail } => write!(f, "compute backend unavailable: {detail}"),
         }
     }
 }
 
-impl std::error::Error for VaneError {}
+impl std::error::Error for VaneError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::FileNotFound { source, .. } | Self::Io { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
 
 /// `Result` with this crate's error type.
 pub type Result<T> = std::result::Result<T, VaneError>;
@@ -63,6 +163,7 @@ pub type Result<T> = std::result::Result<T, VaneError>;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::error::Error as _;
 
     #[test]
     fn error_display_dimension_mismatch() {
@@ -86,9 +187,6 @@ mod tests {
     }
 
     #[test]
-    fn error_display_index_full() {}
-
-    #[test]
     fn error_display_invalid_parameter() {
         let err = VaneError::InvalidParameter("M must be >= 2");
         assert_eq!(err.to_string(), "invalid parameter: M must be >= 2");
@@ -98,5 +196,30 @@ mod tests {
     fn error_display_non_finite_value() {
         let err = VaneError::NonFiniteValue { input: "query" };
         assert_eq!(err.to_string(), "query must contain only finite values");
+    }
+
+    #[test]
+    fn io_display_keeps_the_operation_that_failed() {
+        let err = VaneError::from_io("write", io::Error::from(io::ErrorKind::StorageFull));
+        assert!(err.to_string().starts_with("write: "), "{err}");
+    }
+
+    #[test]
+    fn from_io_classifies_by_kind() {
+        assert!(matches!(
+            VaneError::from_io("open", io::Error::from(io::ErrorKind::NotFound)),
+            VaneError::FileNotFound { .. }
+        ));
+        assert!(matches!(
+            VaneError::from_io("open", io::Error::from(io::ErrorKind::PermissionDenied)),
+            VaneError::Io { .. }
+        ));
+    }
+
+    #[test]
+    fn corrupt_carries_its_detail_and_no_source() {
+        let err = VaneError::corrupt("invalid magic");
+        assert_eq!(err.to_string(), "corrupt file: invalid magic");
+        assert!(err.source().is_none());
     }
 }

--- a/vanedb/src/flat/mod.rs
+++ b/vanedb/src/flat/mod.rs
@@ -59,10 +59,12 @@ impl std::fmt::Debug for FlatIndex {
 impl FlatIndex {
     /// Creates an empty store for vectors of `dim` components.
     ///
-    /// Fails with [`VaneError::InvalidParameter`] if `dim` is zero.
+    /// # Errors
+    ///
+    /// Returns [`VaneError::ZeroDimension`] if `dim` is zero.
     pub fn new(dim: usize, metric: Metric) -> Result<Self> {
         if dim == 0 {
-            return Err(VaneError::EmptyVector);
+            return Err(VaneError::ZeroDimension);
         }
         Ok(Self {
             dim,

--- a/vanedb/src/gpu/cuda.rs
+++ b/vanedb/src/gpu/cuda.rs
@@ -22,14 +22,14 @@ pub struct CudaBuffer {
 impl CudaCompute {
     /// Initialize CUDA compute. Returns error if no CUDA device is available.
     pub fn new() -> Result<Self> {
-        Err(VaneError::Io(
-            "CUDA support requires NVIDIA GPU and CUDA toolkit".to_string(),
+        Err(VaneError::backend(
+            "CUDA support requires NVIDIA GPU and CUDA toolkit",
         ))
     }
 
     /// Upload vectors to GPU memory.
     pub fn upload(&self, _vectors: &[f32], _n: usize, _dim: usize) -> Result<CudaBuffer> {
-        Err(VaneError::Io("CUDA not available".to_string()))
+        Err(VaneError::backend("CUDA not available"))
     }
 
     /// Compute distances from query to all vectors.
@@ -39,7 +39,7 @@ impl CudaCompute {
         _buffer: &CudaBuffer,
         _metric: GpuMetric,
     ) -> Result<Vec<f32>> {
-        Err(VaneError::Io("CUDA not available".to_string()))
+        Err(VaneError::backend("CUDA not available"))
     }
 
     /// Search for k nearest neighbors using GPU.
@@ -51,6 +51,6 @@ impl CudaCompute {
         _k: usize,
         _metric: GpuMetric,
     ) -> Result<Vec<SearchResult>> {
-        Err(VaneError::Io("CUDA not available".to_string()))
+        Err(VaneError::backend("CUDA not available"))
     }
 }

--- a/vanedb/src/gpu/metal.rs
+++ b/vanedb/src/gpu/metal.rs
@@ -95,33 +95,33 @@ impl MetalCompute {
     /// Initialize Metal compute. Returns error if no Metal device is available.
     pub fn new() -> Result<Self> {
         let device = Device::system_default()
-            .ok_or_else(|| VaneError::Io("no Metal device available".to_string()))?;
+            .ok_or_else(|| VaneError::backend("no Metal device available"))?;
         let queue = device.new_command_queue();
 
         let options = CompileOptions::new();
         let library = device
             .new_library_with_source(MSL_SOURCE, &options)
-            .map_err(|e| VaneError::Io(format!("MSL compile error: {e}")))?;
+            .map_err(|e| VaneError::backend(format!("MSL compile error: {e}")))?;
 
         let l2_fn = library
             .get_function("l2", None)
-            .map_err(|e| VaneError::Io(format!("get l2 function: {e}")))?;
+            .map_err(|e| VaneError::backend(format!("get l2 function: {e}")))?;
         let dp_fn = library
             .get_function("dp", None)
-            .map_err(|e| VaneError::Io(format!("get dp function: {e}")))?;
+            .map_err(|e| VaneError::backend(format!("get dp function: {e}")))?;
         let cs_fn = library
             .get_function("cs", None)
-            .map_err(|e| VaneError::Io(format!("get cs function: {e}")))?;
+            .map_err(|e| VaneError::backend(format!("get cs function: {e}")))?;
 
         let l2_pipeline = device
             .new_compute_pipeline_state_with_function(&l2_fn)
-            .map_err(|e| VaneError::Io(format!("l2 pipeline: {e}")))?;
+            .map_err(|e| VaneError::backend(format!("l2 pipeline: {e}")))?;
         let dot_pipeline = device
             .new_compute_pipeline_state_with_function(&dp_fn)
-            .map_err(|e| VaneError::Io(format!("dot pipeline: {e}")))?;
+            .map_err(|e| VaneError::backend(format!("dot pipeline: {e}")))?;
         let cos_pipeline = device
             .new_compute_pipeline_state_with_function(&cs_fn)
-            .map_err(|e| VaneError::Io(format!("cos pipeline: {e}")))?;
+            .map_err(|e| VaneError::backend(format!("cos pipeline: {e}")))?;
 
         Ok(Self {
             device,

--- a/vanedb/tests/corruption_tests.rs
+++ b/vanedb/tests/corruption_tests.rs
@@ -6,7 +6,7 @@
 use std::fs;
 use std::io::Write;
 
-use vanedb::{ApproxIndex, Metric};
+use vanedb::{ApproxIndex, Metric, VaneError};
 
 #[cfg(feature = "disk")]
 use vanedb::{DiskIndex, DiskIndexBuilder};
@@ -173,7 +173,10 @@ fn hnsw_load_rejects_invalid_magic() {
         Ok(_) => panic!("load should have failed"),
         Err(e) => e,
     };
-    assert!(format!("{err}").contains("magic"), "got: {err}");
+    assert!(
+        matches!(&err, VaneError::Corrupt { detail } if detail.contains("magic")),
+        "got: {err:?}"
+    );
     let _ = fs::remove_file(&p);
 }
 
@@ -186,14 +189,20 @@ fn hnsw_load_rejects_unsupported_version() {
         Ok(_) => panic!("load should have failed"),
         Err(e) => e,
     };
-    assert!(format!("{err}").contains("version"), "got: {err}");
+    assert!(
+        matches!(&err, VaneError::Corrupt { detail } if detail.contains("version")),
+        "got: {err:?}"
+    );
     let _ = fs::remove_file(&p);
 }
 
 #[test]
 fn hnsw_load_rejects_truncated_header() {
     let p = write_tmp("trunc_header", b"HNS"); // 3 bytes — shorter than 8-byte header
-    assert!(ApproxIndex::load(&p).is_err());
+    assert!(matches!(
+        ApproxIndex::load(&p),
+        Err(VaneError::Corrupt { .. })
+    ));
     let _ = fs::remove_file(&p);
 }
 
@@ -204,7 +213,10 @@ fn hnsw_load_rejects_garbage_payload() {
     bytes.extend_from_slice(&HNSW_VERSION.to_le_bytes());
     bytes.extend_from_slice(&[0xFF; 32]);
     let p = write_tmp("garbage_payload", &bytes);
-    assert!(ApproxIndex::load(&p).is_err());
+    assert!(matches!(
+        ApproxIndex::load(&p),
+        Err(VaneError::Corrupt { .. })
+    ));
     let _ = fs::remove_file(&p);
 }
 
@@ -295,7 +307,10 @@ fn mmap_load_rejects_unsupported_version() {
     data.extend_from_slice(&0u32.to_le_bytes()); // metric
     data.extend_from_slice(&0u32.to_le_bytes()); // reserved
     fs::write(&path, &data).unwrap();
-    assert!(DiskIndex::open(&path).is_err());
+    assert!(matches!(
+        DiskIndex::open(&path),
+        Err(VaneError::Corrupt { .. })
+    ));
     let _ = fs::remove_file(&path);
 }
 
@@ -311,7 +326,10 @@ fn mmap_load_rejects_zero_dim_with_vectors() {
     data.extend_from_slice(&0u32.to_le_bytes());
     data.extend_from_slice(&0u32.to_le_bytes());
     fs::write(&path, &data).unwrap();
-    assert!(DiskIndex::open(&path).is_err());
+    assert!(matches!(
+        DiskIndex::open(&path),
+        Err(VaneError::Corrupt { .. })
+    ));
     let _ = fs::remove_file(&path);
 }
 
@@ -328,7 +346,10 @@ fn mmap_load_rejects_truncated_data() {
     data.extend_from_slice(&0u32.to_le_bytes());
     data.extend_from_slice(&0u32.to_le_bytes());
     fs::write(&path, &data).unwrap();
-    assert!(DiskIndex::open(&path).is_err());
+    assert!(matches!(
+        DiskIndex::open(&path),
+        Err(VaneError::Corrupt { .. })
+    ));
     let _ = fs::remove_file(&path);
 }
 
@@ -345,7 +366,10 @@ fn mmap_load_rejects_size_overflow() {
     data.extend_from_slice(&0u32.to_le_bytes());
     data.extend_from_slice(&0u32.to_le_bytes());
     fs::write(&path, &data).unwrap();
-    assert!(DiskIndex::open(&path).is_err());
+    assert!(matches!(
+        DiskIndex::open(&path),
+        Err(VaneError::Corrupt { .. })
+    ));
     let _ = fs::remove_file(&path);
 }
 
@@ -362,7 +386,10 @@ fn mmap_load_rejects_invalid_metric() {
     data.extend_from_slice(&99u32.to_le_bytes()); // bogus metric
     data.extend_from_slice(&0u32.to_le_bytes());
     fs::write(&path, &data).unwrap();
-    assert!(DiskIndex::open(&path).is_err());
+    assert!(matches!(
+        DiskIndex::open(&path),
+        Err(VaneError::Corrupt { .. })
+    ));
     let _ = fs::remove_file(&path);
 }
 
@@ -374,7 +401,10 @@ fn mmap_search_rejects_zero_k() {
     b.add(1, &[1.0, 2.0, 3.0]).unwrap();
     b.save(&path).unwrap();
     let store = DiskIndex::open(&path).unwrap();
-    assert!(store.search(&[1.0, 2.0, 3.0], 0).is_err());
+    assert!(matches!(
+        store.search(&[1.0, 2.0, 3.0], 0),
+        Err(VaneError::InvalidK)
+    ));
     let _ = fs::remove_file(&path);
 }
 
@@ -427,7 +457,7 @@ fn hnsw_load_rejects_invalid_graph_parameters() {
     let bytes = hnsw_file_bytes(2, &data);
     let p = write_tmp("bad_m", &bytes);
     assert!(
-        ApproxIndex::load(&p).is_err(),
+        matches!(ApproxIndex::load(&p), Err(VaneError::Corrupt { .. })),
         "m = 1 must be rejected on load"
     );
 
@@ -436,7 +466,7 @@ fn hnsw_load_rejects_invalid_graph_parameters() {
     let bytes = hnsw_file_bytes(2, &data);
     let p = write_tmp("bad_efc", &bytes);
     assert!(
-        ApproxIndex::load(&p).is_err(),
+        matches!(ApproxIndex::load(&p), Err(VaneError::Corrupt { .. })),
         "ef_construction = 0 must be rejected on load"
     );
 }

--- a/vanedb/tests/debug_impls.rs
+++ b/vanedb/tests/debug_impls.rs
@@ -7,9 +7,9 @@ use vanedb::{ApproxIndex, DiskIndexBuilder, FlatIndex, Metric};
 fn unwrap_err_compiles_against_the_public_types() {
     // The idiom the whole suite had to avoid: it requires Debug on the Ok type.
     let err = ApproxIndex::builder(0, Metric::L2).build().unwrap_err();
-    assert!(matches!(err, vanedb::VaneError::EmptyVector));
+    assert!(matches!(err, vanedb::VaneError::ZeroDimension));
     let err = FlatIndex::new(0, Metric::L2).unwrap_err();
-    assert!(matches!(err, vanedb::VaneError::EmptyVector));
+    assert!(matches!(err, vanedb::VaneError::ZeroDimension));
 }
 
 #[test]

--- a/vanedb/tests/error_model.rs
+++ b/vanedb/tests/error_model.rs
@@ -1,0 +1,135 @@
+//! The error model's public contract.
+//!
+//! The motivating use case is "load the index, build it if it isn't there".
+//! That needs a missing file, a corrupt file, and a failing disk to be three
+//! distinguishable things. Before this contract they were all `Io(String)`,
+//! and the only way to tell them apart was `msg.contains("No such file")`.
+
+use std::error::Error as _;
+use std::io;
+
+use vanedb::{ApproxIndex, FlatIndex, Metric, VaneError};
+
+/// The repo's convention for scratch paths: process-unique, no dev-dependency.
+fn scratch(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("vanedb-errors-{tag}-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+#[test]
+fn missing_file_is_its_own_variant_and_keeps_the_io_kind() {
+    let err = ApproxIndex::load("/nonexistent/directory/index.vane").unwrap_err();
+    assert!(matches!(err, VaneError::FileNotFound { .. }), "got {err:?}");
+
+    let source = err.source().expect("io-backed errors expose their source");
+    let io_err = source
+        .downcast_ref::<io::Error>()
+        .expect("the source is the original io::Error");
+    assert_eq!(io_err.kind(), io::ErrorKind::NotFound);
+}
+
+#[test]
+fn a_garbage_file_is_corrupt_not_io() {
+    let path = scratch("garbage").join("index.vane");
+    std::fs::write(&path, b"this is not a vanedb file").unwrap();
+
+    let err = ApproxIndex::load(&path).unwrap_err();
+    assert!(matches!(err, VaneError::Corrupt { .. }), "got {err:?}");
+    assert!(
+        err.source().is_none(),
+        "a corrupt file is a decoding failure, not an io failure"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn load_or_build_is_expressible_without_matching_on_strings() {
+    let path = scratch("load-or-build").join("index.vane");
+    let _ = std::fs::remove_file(&path);
+
+    // The whole point of the split: this match compiles, and the missing-file
+    // arm is reached without inspecting any message text.
+    let index = match ApproxIndex::load(&path) {
+        Ok(index) => index,
+        Err(VaneError::FileNotFound { .. }) => ApproxIndex::builder(4, Metric::L2).build().unwrap(),
+        Err(other) => panic!("expected a missing file, got {other:?}"),
+    };
+
+    index.add(1, &[1.0, 0.0, 0.0, 0.0]).unwrap();
+    assert_eq!(index.len(), 1);
+}
+
+#[test]
+fn a_zero_dimension_is_named_for_what_it_means() {
+    // Previously `EmptyVector`, which described neither the cause (dim == 0 at
+    // construction) nor the argument, and contradicted its own doc comment.
+    assert!(matches!(
+        FlatIndex::new(0, Metric::L2),
+        Err(VaneError::ZeroDimension)
+    ));
+}
+
+#[test]
+fn an_actually_empty_vector_still_reports_a_dimension_mismatch() {
+    // The name `EmptyVector` implied this case; it never produced it.
+    let index = FlatIndex::new(4, Metric::L2).unwrap();
+    assert!(matches!(
+        index.add(1, &[]),
+        Err(VaneError::DimensionMismatch {
+            expected: 4,
+            got: 0
+        })
+    ));
+}
+
+#[test]
+fn io_errors_convert_and_classify_themselves() {
+    let missing: VaneError = io::Error::from(io::ErrorKind::NotFound).into();
+    assert!(
+        matches!(missing, VaneError::FileNotFound { .. }),
+        "{missing:?}"
+    );
+
+    let denied: VaneError = io::Error::from(io::ErrorKind::PermissionDenied).into();
+    assert!(matches!(denied, VaneError::Io { .. }), "{denied:?}");
+}
+
+#[test]
+fn logical_errors_have_no_source() {
+    for err in [
+        VaneError::InvalidK,
+        VaneError::ZeroDimension,
+        VaneError::NotFound { id: 7 },
+        VaneError::DuplicateId { id: 7 },
+        VaneError::DimensionMismatch {
+            expected: 4,
+            got: 2,
+        },
+    ] {
+        assert!(err.source().is_none(), "{err:?} should have no source");
+    }
+}
+
+#[test]
+fn a_failing_disk_is_distinguishable_from_a_missing_one() {
+    // Saving into a path whose parent is a file, not a directory, is a real
+    // io failure that is not NotFound.
+    let dir = scratch("not-a-dir");
+    let blocker = dir.join("blocker");
+    std::fs::write(&blocker, b"x").unwrap();
+
+    let index = ApproxIndex::builder(4, Metric::L2).build().unwrap();
+    index.add(1, &[1.0, 0.0, 0.0, 0.0]).unwrap();
+    let err = index.save(blocker.join("index.vane")).unwrap_err();
+
+    assert!(
+        !matches!(err, VaneError::Corrupt { .. }),
+        "a write failure is not corruption: {err:?}"
+    );
+    assert!(
+        err.source().is_some(),
+        "io failures keep their source: {err:?}"
+    );
+    let _ = std::fs::remove_file(&blocker);
+}


### PR DESCRIPTION
Closes #93.

## Why

Every file failure collapsed into `Io(String)`:

```
load nonexistent file  -> Io("read: No such file or directory (os error 2)")
load garbage file      -> Io("invalid magic")
load truncated index   -> Io("deserialize: UnexpectedEnd { additional: 1 }")
save to unwritable path-> Io("create: No such file or directory (os error 2)")
```

No `source()`, no `From<io::Error>`, so the `io::Error` was gone. The most common thing an application does with a persisted index — **load it, or build it if it isn't there** — could only be written as `msg.contains("No such file")`.

## Split by recovery action

That's what a caller actually branches on:

| Variant | What you do about it |
|---|---|
| `FileNotFound` | build it |
| `Corrupt` | rebuild it — retrying won't help |
| `Io` | retry it — full disk, permissions, failing device |
| `Backend` | fall back to the CPU |

`Backend` is separate because calling an MSL compile error an "I/O error" is the same mislabeling this change exists to remove.

`from_io` classifies by `io::ErrorKind`; `source()` is implemented. bincode *encode* failure is neither filesystem I/O nor corruption — nothing on disk is wrong yet — so it's wrapped as `io::Error::other`, keeping the chain `VaneError::Io → io::Error → EncodeError`.

## Three freezes closed while they're still free

- **`#[non_exhaustive]`** on `VaneError` and `Metric`. `Corrupt` was itself a late addition; the next variant shouldn't need a major release. No binding needed changes — `#[non_exhaustive]` restricts *matching*, and all three bindings only *construct* `Metric`.
- **`PartialEq` dropped.** It made `err == VaneError::InvalidParameter("M must be >= 2")` compile *and pass*, turning every diagnostic string into public API that could never be reworded. `Clone` goes with it (`io::Error` has neither). Nothing outside tests relied on either.
- **`EmptyVector` → `ZeroDimension`.** It never meant an empty vector — that reports `DimensionMismatch { got: 0 }`, now covered by a test — and its own doc comment named a *third* variant it doesn't return. All three constructors now document what they actually return.

## Python

- Missing file → `FileNotFoundError`; other I/O → `OSError`; corrupt data stays `ValueError`. So `except FileNotFoundError` works.
- **Negative ids raised `OverflowError`**, which is not a `ValueError` subclass, so `except ValueError` missed them. The issue found this on the plain-list batch path; it was also true of **all twelve methods taking an id**, since PyO3's own `u64` conversion raises it. All now report `ValueError`.

The test for the numpy path passed before this change and the plain-list one failed — confirming only the numpy path was ever checked.

## The corruption suite was not testing what it claimed

It asserted `is_err()` or grepped the message, so it passed for *any* variant and pinned text that is explicitly not stable API. It now asserts the variant.

Falsified rather than assumed: reclassifying one site from `Corrupt` to `Io` fails `hnsw_load_rejects_invalid_magic` with `got: Io { context: "open", ... }`. The old `is_err()` assertions could not detect that at all. All 18 pass unchanged otherwise, which independently confirms every corruption path really does classify as `Corrupt`.

## Verification

`fmt`, `clippy -D warnings` (workspace and `vanedb-py`), the full Rust suite, the bench crate, and 54 Python tests against a `maturin develop` build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H