### PR TITLE
fix(cpp): F_FULLFSYNC on Darwin so save paths are comparable

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -110,11 +110,16 @@ engines build different graphs from the same seed (`StdRng` versus
 queries the mean is 0.97 with a 41% spread — Rust is ahead on average. Fixing
 the bench to sweep a query set is vanedb#111.
 
-**¶ Not a speed comparison.** The engines call different durability
-primitives: Rust `sync_all()` (`F_FULLFSYNC` on macOS, a media barrier,
-8.1 ms for this payload) versus C++ `fsync(2)` (write cache only, 0.95 ms).
-Nearly the whole gap is that difference, so C++ is less durable here rather
-than faster (vanedb#110).
+**¶ Measured against mismatched durability; awaiting a re-run.** When this
+snapshot was taken the engines called different primitives: Rust `sync_all()`
+(`F_FULLFSYNC` on macOS, a media barrier) versus C++ `fsync(2)` (write cache
+only). Nearly the whole gap was that difference, so C++ was less durable here
+rather than faster. Both engines now issue `F_FULLFSYNC` on Darwin
+(vanedb#110), so this row is replaced by the next snapshot taken on dedicated
+hardware.
+
+Any save-path comparison requires both engines to use the same durability
+primitive; otherwise the faster row is only the weaker guarantee.
 
 Rust leads the largest scan after moving both brute-force paths to a bounded
 top-k heap (vanedb#32). The remaining honest gaps are on write paths and are

--- a/cpp/src/core/detail/file_utils.h
+++ b/cpp/src/core/detail/file_utils.h
@@ -16,8 +16,15 @@
 namespace vanedb {
 namespace detail {
 
-/// Reopen a file by path, fsync to disk, close. Best-effort durability:
-/// silently no-ops if the file cannot be opened.
+/// Reopen a file by path, flush it to persistent media, close.
+///
+/// On macOS `fsync(2)` only pushes to the drive's write cache and returns, so
+/// it does not guarantee the data reached the media. `F_FULLFSYNC` issues the
+/// full barrier, which is what Rust's `File::sync_all()` does — the two
+/// engines' save paths are only comparable if both wait for the same
+/// guarantee (vanedb#110).
+///
+/// Silently no-ops if the file cannot be opened.
 ///
 /// Caller must close any other writer (e.g. std::ofstream) for the same path
 /// before calling — Windows CreateFileA fails on an exclusively-held file.
@@ -28,7 +35,15 @@ inline void fsync_file(const std::string& path) noexcept {
   if (hFile != INVALID_HANDLE_VALUE) { FlushFileBuffers(hFile); CloseHandle(hFile); }
 #elif defined(__unix__) || defined(__APPLE__)
   int fd = open(path.c_str(), O_WRONLY);
-  if (fd >= 0) { fsync(fd); close(fd); }
+  if (fd >= 0) {
+#if defined(F_FULLFSYNC)
+    // Some filesystems refuse F_FULLFSYNC (ENOTSUP); fsync is the fallback.
+    if (fcntl(fd, F_FULLFSYNC) == -1) { fsync(fd); }
+#else
+    fsync(fd);
+#endif
+    close(fd);
+  }
 #endif
 }
 


### PR DESCRIPTION
Closes #110.

## The C++ engine was not faster on save — it was less durable

`fsync_file` called `fsync(2)`. On macOS that only pushes to the drive's write cache and returns; it does not guarantee the data reached the media. Rust's `File::sync_all()` issues `F_FULLFSYNC`, a full media barrier.

So every save-path row compared a weaker guarantee against a stronger one.

## Measured

Same 5.2 MB payload, this machine, three runs:

| | time |
|---|---|
| `fsync(2)` | 0.001 ms |
| `F_FULLFSYNC` | 7.4 – 8.2 ms |

`fsync` is effectively free here precisely because it doesn't wait for the media. Rust's `sync_all()` was measured at 8.1 ms in the issue — the same order as `F_FULLFSYNC`, confirming the two now do the same work.

That gap is nearly all of `disk_build`'s reported 2.40× on a ~10 ms operation.

## Scope

Permitted under the C++ freeze as a fix that **keeps the comparison honest**, not a feature port.

Guarded on `#if defined(F_FULLFSYNC)` rather than `__APPLE__`, so any platform defining it participates, with `fsync` as the fallback where the filesystem refuses it (`ENOTSUP`).

## Snapshot

The `disk_build` row was measured before this change, so its annotation now says it awaits a re-run rather than reporting a ratio, and states the general rule: **a save-path comparison needs both engines on the same durability primitive, or the faster row is just the weaker guarantee.**

**Action needed after merge:** re-run `bench/` on dedicated hardware to refresh `disk_build`.

## Verification

`cmake --build` clean, all **81 C++ tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H