### PR TITLE
fix(cpp): copy numpy buffers before releasing the GIL

### DIFF
--- a/cpp/python/vanedb.cpp
+++ b/cpp/python/vanedb.cpp
@@ -14,6 +14,38 @@
 namespace py = pybind11;
 using namespace vanedb;
 
+namespace {
+
+using FloatArray = py::array_t<float, py::array::c_style | py::array::forcecast>;
+
+/// Validates a 1-D float array's shape and copies it into owned storage.
+///
+/// The copy is the point. `py::array_t<..., c_style | forcecast>` does not
+/// copy an input that is already float32 and C-contiguous, so `buf.ptr`
+/// aliases the caller's numpy array. Reading through that pointer after
+/// `gil_scoped_release` lets another Python thread mutate the data part-way
+/// through a scan or graph walk -- and because the finite check runs inside
+/// the core, after the release, a value can pass validation and then become
+/// NaN before it is stored, defeating the invariant the non-finite
+/// conformance suite exists to protect (vanedb#95).
+///
+/// PyO3 copies into owned `Vec`s before `py.detach` at every site; this keeps
+/// the two Python packages on one memory-safety discipline.
+std::vector<float> owned_vector(const FloatArray& array, size_t expected_dim,
+                                const char* ndim_message, const char* dim_message) {
+  py::buffer_info buf = array.request();
+  if (buf.ndim != 1) {
+    throw std::runtime_error(ndim_message);
+  }
+  if (static_cast<size_t>(buf.size) != expected_dim) {
+    throw std::runtime_error(dim_message);
+  }
+  const float* first = static_cast<const float*>(buf.ptr);
+  return std::vector<float>(first, first + buf.size);
+}
+
+}  // namespace
+
 PYBIND11_MODULE(vanedb_cpp, m) {
     m.doc() = "VaneDB - Embeddable vector database for edge AI";
 
@@ -44,16 +76,11 @@ PYBIND11_MODULE(vanedb_cpp, m) {
              py::arg("ef_construction") = 200,
              py::arg("random_seed") = 42)
         .def("add", [](ApproxIndex& self, uint64_t id, py::array_t<float, py::array::c_style | py::array::forcecast> vector_array) {
-                py::buffer_info buf = vector_array.request();
-                if (buf.ndim != 1) {
-                    throw std::runtime_error("Vector must be a 1-dimensional array");
-                }
-                if (static_cast<size_t>(buf.size) != self.dimension()) {
-                    throw std::runtime_error("Vector dimension mismatch");
-                }
+                const std::vector<float> owned =
+                    owned_vector(vector_array, self.dimension(), "Vector must be a 1-dimensional array", "Vector dimension mismatch");
                 // Release GIL during potentially long C++ operation
                 py::gil_scoped_release release;
-                self.add(id, static_cast<const float*>(buf.ptr));
+                self.add(id, owned.data());
             },
             py::arg("id"), py::arg("vector"),
             "Adds a vector to the index")
@@ -74,19 +101,14 @@ PYBIND11_MODULE(vanedb_cpp, m) {
             py::arg("id"),
             "Retrieves the vector associated with the given ID as a numpy array")
         .def("search", [](const ApproxIndex& self, py::array_t<float, py::array::c_style | py::array::forcecast> query_array, size_t k) {
-                py::buffer_info buf = query_array.request();
-                if (buf.ndim != 1) {
-                    throw std::runtime_error("Query vector must be a 1-dimensional array");
-                }
-                if (static_cast<size_t>(buf.size) != self.dimension()) {
-                    throw std::runtime_error("Query dimension mismatch");
-                }
+                const std::vector<float> owned =
+                    owned_vector(query_array, self.dimension(), "Query vector must be a 1-dimensional array", "Query dimension mismatch");
 
                 std::vector<HNSWSearchResult> results;
                 {
                     // Release GIL during search
                     py::gil_scoped_release release;
-                    results = self.search(static_cast<const float*>(buf.ptr), k);
+                    results = self.search(owned.data(), k);
                 }
 
                 // Create numpy arrays for IDs and distances (requires GIL)
@@ -130,15 +152,10 @@ PYBIND11_MODULE(vanedb_cpp, m) {
              py::arg("metric") = Metric::L2,
              "Creates a new in-memory vector store")
         .def("add", [](FlatIndex& self, uint64_t id, py::array_t<float, py::array::c_style | py::array::forcecast> vector_array) {
-                py::buffer_info buf = vector_array.request();
-                if (buf.ndim != 1) {
-                    throw std::runtime_error("Vector must be a 1-dimensional array");
-                }
-                if (static_cast<size_t>(buf.size) != self.dimension()) {
-                    throw std::runtime_error("Vector dimension mismatch");
-                }
+                const std::vector<float> owned =
+                    owned_vector(vector_array, self.dimension(), "Vector must be a 1-dimensional array", "Vector dimension mismatch");
                 py::gil_scoped_release release;
-                self.add(id, static_cast<const float*>(buf.ptr));
+                self.add(id, owned.data());
             },
             py::arg("id"), py::arg("vector"),
             "Adds a vector to the store")
@@ -163,18 +180,13 @@ PYBIND11_MODULE(vanedb_cpp, m) {
             py::arg("id"),
             "Gets a vector by ID, returns None if not found")
         .def("search", [](const FlatIndex& self, py::array_t<float, py::array::c_style | py::array::forcecast> query_array, size_t k) {
-                py::buffer_info buf = query_array.request();
-                if (buf.ndim != 1) {
-                    throw std::runtime_error("Query vector must be a 1-dimensional array");
-                }
-                if (static_cast<size_t>(buf.size) != self.dimension()) {
-                    throw std::runtime_error("Query dimension mismatch");
-                }
+                const std::vector<float> owned =
+                    owned_vector(query_array, self.dimension(), "Query vector must be a 1-dimensional array", "Query dimension mismatch");
 
                 std::vector<SearchResult> results;
                 {
                     py::gil_scoped_release release;
-                    results = self.search(static_cast<const float*>(buf.ptr), k);
+                    results = self.search(owned.data(), k);
                 }
 
                 py::array_t<uint64_t> ids(static_cast<py::ssize_t>(results.size()));
@@ -193,15 +205,10 @@ PYBIND11_MODULE(vanedb_cpp, m) {
             "Searches for k nearest neighbors. Returns (ids, distances).")
         .def("remove", &FlatIndex::remove, py::arg("id"), "Removes a vector by ID")
         .def("update", [](FlatIndex& self, uint64_t id, py::array_t<float, py::array::c_style | py::array::forcecast> vector_array) {
-                py::buffer_info buf = vector_array.request();
-                if (buf.ndim != 1) {
-                    throw std::runtime_error("Vector must be a 1-dimensional array");
-                }
-                if (static_cast<size_t>(buf.size) != self.dimension()) {
-                    throw std::runtime_error("Vector dimension mismatch");
-                }
+                const std::vector<float> owned =
+                    owned_vector(vector_array, self.dimension(), "Vector must be a 1-dimensional array", "Vector dimension mismatch");
                 py::gil_scoped_release release;
-                return self.update(id, static_cast<const float*>(buf.ptr));
+                return self.update(id, owned.data());
             },
             py::arg("id"), py::arg("vector"),
             "Updates an existing vector")
@@ -218,14 +225,9 @@ PYBIND11_MODULE(vanedb_cpp, m) {
              py::arg("metric") = Metric::L2,
              "Creates a new builder for memory-mapped vector store")
         .def("add", [](DiskIndexBuilder& self, uint64_t id, py::array_t<float, py::array::c_style | py::array::forcecast> vector_array) {
-                py::buffer_info buf = vector_array.request();
-                if (buf.ndim != 1) {
-                    throw std::runtime_error("Vector must be a 1-dimensional array");
-                }
-                if (static_cast<size_t>(buf.size) != self.dimension()) {
-                    throw std::runtime_error("Vector dimension mismatch");
-                }
-                self.add(id, static_cast<const float*>(buf.ptr));
+                const std::vector<float> owned =
+                    owned_vector(vector_array, self.dimension(), "Vector must be a 1-dimensional array", "Vector dimension mismatch");
+                self.add(id, owned.data());
             },
             py::arg("id"), py::arg("vector"),
             "Adds a vector to the builder")
@@ -265,18 +267,13 @@ PYBIND11_MODULE(vanedb_cpp, m) {
             "Gets a read-only zero-copy vector from the mapped file, or None if not found. "
             "The array keeps the mapping alive; use .copy() for an editable array.")
         .def("search", [](const DiskIndex& self, py::array_t<float, py::array::c_style | py::array::forcecast> query_array, size_t k) {
-                py::buffer_info buf = query_array.request();
-                if (buf.ndim != 1) {
-                    throw std::runtime_error("Query vector must be a 1-dimensional array");
-                }
-                if (static_cast<size_t>(buf.size) != self.dimension()) {
-                    throw std::runtime_error("Query dimension mismatch");
-                }
+                const std::vector<float> owned =
+                    owned_vector(query_array, self.dimension(), "Query vector must be a 1-dimensional array", "Query dimension mismatch");
 
                 std::vector<SearchResult> results;
                 {
                     py::gil_scoped_release release;
-                    results = self.search(static_cast<const float*>(buf.ptr), k);
+                    results = self.search(owned.data(), k);
                 }
 
                 py::array_t<uint64_t> ids(static_cast<py::ssize_t>(results.size()));

--- a/cpp/tests/test_python_bindings.py
+++ b/cpp/tests/test_python_bindings.py
@@ -667,3 +667,96 @@ def test_mmap_writes_raise_without_crashing(tmp_path, operation):
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestBufferAliasing:
+    """A released GIL must not expose the caller's numpy buffer to the core.
+
+    `py::array_t<..., c_style | forcecast>` does not copy an input that is
+    already float32 and C-contiguous, so the buffer pointer aliases the
+    caller's array. Reading through it after `gil_scoped_release` let another
+    Python thread mutate the data mid-operation — and because the finite check
+    runs inside the core, after the release, a value could pass validation and
+    then become NaN before it was stored (vanedb#95).
+
+    A vector that is already NaN when the call is made is a legitimate
+    rejection, so these tests allow that. What must never happen is a *torn*
+    read: a value that was finite at validation time and NaN by the time the
+    core consumed it.
+    """
+
+    def test_add_never_stores_a_torn_vector(self):
+        import threading
+
+        import vanedb_cpp
+
+        dim = 4096
+        index = vanedb_cpp.FlatIndex(dim, vanedb_cpp.Metric.L2)
+        stop = threading.Event()
+        stored_ids = []
+
+        def scribble(vec):
+            # Both writers hold the GIL for these assignments, so the only
+            # window in which this can interleave with add() is the one add()
+            # opens by releasing the GIL.
+            while not stop.is_set():
+                vec[:] = np.nan
+                vec[:] = 1.0
+
+        for i in range(300):
+            vec = np.ones(dim, dtype=np.float32)
+            writer = threading.Thread(target=scribble, args=(vec,), daemon=True)
+            writer.start()
+            try:
+                index.add(i, vec)
+                stored_ids.append(i)
+            except ValueError:
+                pass  # the array was NaN at call time: a correct rejection
+            finally:
+                stop.set()
+                writer.join()
+                stop.clear()
+
+        for i in stored_ids:
+            stored = index.get(i)
+            assert stored is not None
+            assert not np.isnan(stored).any(), (
+                f"id {i} stored a torn vector: validated finite, then mutated"
+            )
+
+    def test_search_never_scans_a_torn_query(self):
+        import threading
+
+        import vanedb_cpp
+
+        dim = 4096
+        index = vanedb_cpp.FlatIndex(dim, vanedb_cpp.Metric.L2)
+        for i in range(32):
+            v = np.zeros(dim, dtype=np.float32)
+            v[i] = 1.0
+            index.add(i, v)
+
+        query = np.zeros(dim, dtype=np.float32)
+        query[0] = 1.0
+        stop = threading.Event()
+
+        def scribble():
+            while not stop.is_set():
+                query[:] = np.nan
+                query[:] = 0.0
+                query[0] = 1.0
+
+        writer = threading.Thread(target=scribble, daemon=True)
+        writer.start()
+        try:
+            for _ in range(300):
+                try:
+                    _ids, dists = index.search(query, 4)
+                except ValueError:
+                    continue  # NaN at call time: a correct rejection
+                assert not np.isnan(dists).any(), (
+                    "search scanned a query that changed under it"
+                )
+        finally:
+            stop.set()
+            writer.join()


### PR DESCRIPTION
Closes #95.

## The defect

`py::array_t<..., c_style | forcecast>` does **not** copy an input that is already float32 and C-contiguous — `buf.ptr` aliases the caller's numpy array. Six sites released the GIL and then read through that pointer for the duration of a scan or graph walk:

```cpp
py::gil_scoped_release release;
self.add(id, static_cast<const float*>(buf.ptr));
```

Another Python thread can mutate that array mid-operation. And because the finite check runs **inside the core, after the release**, a value could pass validation and then become NaN before being stored — defeating the invariant the entire `non_finite_conformance` suite exists to protect.

## Reproduced, not assumed

The new test passes with the fix. Injecting the old aliasing back (taking `buffer_info` before the release and reading its pointer after, exactly as before) fails it:

```
array([ 1.,  1.,  1., ..., nan, nan, nan], shape=(4096,), dtype=float32)
```

A textbook torn read — the head copied before the mutation, the tail after, having already passed the finite check.

The tests allow the legitimate case (array already NaN at call time → correct `ValueError`) and assert only that nothing **torn** is ever stored or scanned. Without that distinction the test would fail for the wrong reason.

## The fix

All **seven** buffer sites now validate and copy in one helper while the GIL is held, so the core never sees Python-owned memory. That includes the one site that doesn't release the GIL — the invariant is easier to keep when it has no exceptions, and it costs one memcpy the core was going to do anyway.

Error messages are preserved exactly (the helper takes both message strings), so no existing assertion changes.

PyO3 already copies into owned `Vec`s before `py.detach` at every site; this puts both Python packages on one memory-safety discipline, rather than leaving the weaker one in the package the docs call supplementary.

## Scope

Permitted under the C++ freeze as a **defect fix**, not a feature port.

## Verification

81 C++ tests and 70 Python tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H