### PR TITLE
fix(approx)!: search returned a fraction of k on a tombstoned index

### DIFF
--- a/vanedb/src/approx/mod.rs
+++ b/vanedb/src/approx/mod.rs
@@ -654,10 +654,26 @@ impl ApproxIndex {
             vb.marks[entry] = epoch;
 
             while let Some(Reverse((FloatOrd(c_dist), c_id))) = candidates.pop() {
-                // Stop if closest candidate is farther than farthest result
-                if let Some(&(FloatOrd(f_dist), _)) = results.peek() {
-                    if c_dist > f_dist {
-                        break;
+                // Stop only once the result set is FULL and the closest
+                // remaining candidate is farther than the farthest result.
+                //
+                // The `results.len() >= ef` conjunct is load-bearing when
+                // tombstones are present: `results` holds live nodes only,
+                // while `candidates` still holds deleted ones, so a popped
+                // tombstone can be farther than the farthest live result while
+                // the result set is nowhere near full. Breaking there abandons
+                // exactly the traversal tombstones are kept for, and search
+                // silently returns a fraction of `k`.
+                //
+                // On the build path `deleted` is empty, so every candidate is
+                // also a result; an unfull `results` therefore holds every
+                // visited node and `c_dist > f_dist` cannot hold. Construction
+                // is unchanged.
+                if results.len() >= ef {
+                    if let Some(&(FloatOrd(f_dist), _)) = results.peek() {
+                        if c_dist > f_dist {
+                            break;
+                        }
                     }
                 }
 

--- a/vanedb/tests/delete.rs
+++ b/vanedb/tests/delete.rs
@@ -223,3 +223,49 @@ fn upsert_inserts_when_the_id_is_new() {
     assert_eq!(idx.len(), 11);
     assert_eq!(idx.search(&[999.0, 0.0], 1).unwrap()[0].id, 999);
 }
+
+/// A sparse survivor set must still return `k` results.
+///
+/// `results` holds only live nodes while `candidates` holds tombstones too, so
+/// when most of the graph is deleted the result set fills slowly. If the
+/// traversal stops as soon as the nearest candidate is farther than the
+/// farthest *live* result, it abandons the very path the tombstones exist to
+/// preserve — and search returns a fraction of what it should, silently.
+#[test]
+fn a_mostly_tombstoned_index_still_returns_k_results() {
+    const N: u64 = 3000;
+    const KEEP_EVERY: u64 = 400;
+
+    let idx = ApproxIndex::builder(1, Metric::L2)
+        .capacity(N as usize)
+        .m(8)
+        .ef_construction(100)
+        .seed(1)
+        .build()
+        .unwrap();
+    for i in 0..N {
+        idx.add(i, &[i as f32]).unwrap();
+    }
+    for i in (0..N).filter(|i| i % KEEP_EVERY != 0) {
+        idx.remove(i).unwrap();
+    }
+
+    let survivors = (0..N).filter(|i| i % KEEP_EVERY == 0).count();
+    assert_eq!(idx.len(), survivors);
+    idx.set_ef_search(200);
+
+    // Every one of these has at least `k` live vectors to find, and ef_search
+    // is far larger than the number of survivors.
+    for query in [0.0f32, 800.0, 1400.0, 2000.0] {
+        let hits = idx.search(&[query], 5).unwrap();
+        assert_eq!(
+            hits.len(),
+            5,
+            "query {query} returned {} of 5 with {survivors} live vectors and ef_search=200",
+            hits.len()
+        );
+        for hit in &hits {
+            assert_eq!(hit.id % KEEP_EVERY, 0, "returned tombstoned id {}", hit.id);
+        }
+    }
+}


### PR DESCRIPTION
Found during the post-merge review. **Silent wrong results** — not an error, not a panic.

## The bug

`search_layer` broke out of traversal as soon as the nearest remaining candidate was farther than the farthest result. That is only valid once the result set is **full**.

`results` holds live nodes only; `candidates` still holds tombstoned ones. With most of the graph deleted, the result set fills slowly, so a popped tombstone is routinely farther than the farthest live hit while `results` is nowhere near `ef`. The loop broke there — abandoning exactly the traversal that tombstones are retained to preserve.

## Reproduced

3000 nodes, all but 8 removed, `ef_search=200`, `k=5`:

| query | returned | |
|---|---|---|
| 0 | `[0]` | 1 of 5 |
| 800 | `[800]` | 1 of 5 |
| 1400 | `[1200, 1600]` | 2 of 5 |
| 2000 | `[2000]` | 1 of 5 |

All four are correct after `compact()` — the graph was intact the whole time.

## The fix

One conjunct: break only when `results.len() >= ef`. This is the condition hnswlib uses.

**Construction is provably unaffected.** On the build path `deleted` is empty, so every candidate is also pushed into `results`; an unfull `results` therefore contains every visited node, and `c_dist > f_dist` cannot hold. So the new conjunct can never change a build-path decision — which matters, because `AGENTS.md` makes HNSW construction an invariant.

Confirmed empirically as well: the recall-vs-`ef` sweep is byte-identical before and after, on both uniform and clustered data.

| data | ef10 | ef25 | ef50 | ef100 | ef200 | ef400 |
|---|---|---|---|---|---|---|
| uniform | 0.417 | 0.633 | 0.808 | 0.933 | 0.983 | 0.998 |
| clustered | 0.955 | 0.980 | 1.000 | 1.000 | 1.000 | 1.000 |

## Why the existing tests missed it

`delete.rs` uses a 50-node collinear layout where `ef_search` exceeds the entire graph, so the break never fires. The new test uses 3000 nodes with 8 survivors, which is the shape that exposes it. It fails on the old code with `query 0 returned 1 of 5 with 8 live vectors and ef_search=200`.

## Verification

191 tests pass (190 + the new one), `fmt` and `clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H