### PR TITLE
fix(distance): bound SIMD kernels by both slices, not just the first

### DIFF
--- a/vanedb/src/distance/avx2.rs
+++ b/vanedb/src/distance/avx2.rs
@@ -3,6 +3,9 @@
 //!
 //! Every function here requires AVX2 and FMA; callers reach them through
 //! [`distance_fn`](super::distance_fn), which checks at runtime.
+//!
+//! Each compares `a.len().min(b.len())` elements, matching
+//! [`scalar`](super::scalar); the lengths themselves need not agree.
 
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
@@ -26,8 +29,7 @@ unsafe fn hsum_avx2(v: __m256) -> f32 {
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2,fma")]
 pub unsafe fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
-    debug_assert_eq!(a.len(), b.len());
-    let n = a.len();
+    let n = a.len().min(b.len());
     let mut i = 0;
     // Four independent accumulators hide the FMA latency; a single-acc
     // loop is latency-bound. Mirrors vanedb-cpp src/core/distance.h.
@@ -75,8 +77,7 @@ pub unsafe fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2,fma")]
 pub unsafe fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
-    debug_assert_eq!(a.len(), b.len());
-    let n = a.len();
+    let n = a.len().min(b.len());
     let mut i = 0;
     // Two-way unroll on top of the three naturally independent chains.
     let mut vdot0 = _mm256_setzero_ps();
@@ -144,8 +145,7 @@ pub unsafe fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2,fma")]
 pub unsafe fn dot_distance(a: &[f32], b: &[f32]) -> f32 {
-    debug_assert_eq!(a.len(), b.len());
-    let n = a.len();
+    let n = a.len().min(b.len());
     let mut i = 0;
     // Same latency-hiding unroll as l2_squared.
     let mut acc0 = _mm256_setzero_ps();

--- a/vanedb/src/distance/mod.rs
+++ b/vanedb/src/distance/mod.rs
@@ -1,4 +1,9 @@
 //! Distance metrics and their SIMD implementations.
+//!
+//! Every kernel compares `a.len().min(b.len())` elements: mismatched
+//! lengths truncate to the shorter slice rather than reading past its
+//! end. The index types reject a dimension mismatch before they get
+//! here, so this governs only direct callers of [`distance_fn`].
 
 /// AVX2 kernels, compiled on x86-64.
 #[cfg(target_arch = "x86_64")]
@@ -24,7 +29,8 @@ pub enum Metric {
     Dot,
 }
 
-/// Function type for distance computation.
+/// Function type for distance computation. Compares the first
+/// `a.len().min(b.len())` elements; see the module documentation.
 pub type DistanceFn = fn(&[f32], &[f32]) -> f32;
 
 /// Returns the distance function for the given metric.

--- a/vanedb/src/distance/neon.rs
+++ b/vanedb/src/distance/neon.rs
@@ -8,12 +8,12 @@ use std::arch::aarch64::*;
 /// Squared Euclidean distance. The square root is skipped: it does not
 /// change the ordering, and every caller here only ranks.
 pub fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
-    debug_assert_eq!(a.len(), b.len());
-    let n = a.len();
+    let n = a.len().min(b.len());
     let mut i = 0;
 
-    // SAFETY: NEON is always available on aarch64.
-    // Pointer arithmetic stays within slice bounds (i + 4 <= n).
+    // SAFETY: NEON is always available on aarch64. Every load is bounded
+    // by `n`, which is the shorter of the two lengths, so neither pointer
+    // walks off its own slice.
     let mut sum = unsafe {
         // Four independent accumulators hide the fused multiply-add latency
         // (~4 cycles); a single-accumulator loop is latency-bound at one
@@ -59,8 +59,7 @@ pub fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
 /// when a norm is zero or overflows to infinity, so a degenerate input
 /// ranks as orthogonal rather than as NaN.
 pub fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
-    debug_assert_eq!(a.len(), b.len());
-    let n = a.len();
+    let n = a.len().min(b.len());
     let mut i = 0;
 
     let (mut dot, mut norm_a, mut norm_b) = unsafe {
@@ -123,8 +122,7 @@ pub fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
 /// Negated dot product, so that lower still means nearer as it does for
 /// the other metrics.
 pub fn dot_distance(a: &[f32], b: &[f32]) -> f32 {
-    debug_assert_eq!(a.len(), b.len());
-    let n = a.len();
+    let n = a.len().min(b.len());
     let mut i = 0;
 
     let mut sum = unsafe {

--- a/vanedb/src/distance/scalar.rs
+++ b/vanedb/src/distance/scalar.rs
@@ -1,9 +1,11 @@
 //! Portable reference kernels. The SIMD paths must agree with these.
+//!
+//! `zip` stops at the shorter iterator, so a length mismatch truncates.
+//! That is the contract the SIMD kernels bound themselves to.
 
 /// Squared Euclidean distance. The square root is skipped: it does not
 /// change the ordering, and every caller here only ranks.
 pub fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
-    debug_assert_eq!(a.len(), b.len());
     a.iter()
         .zip(b.iter())
         .map(|(x, y)| {
@@ -17,7 +19,6 @@ pub fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
 /// when a norm is zero or overflows to infinity, so a degenerate input
 /// ranks as orthogonal rather than as NaN.
 pub fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
-    debug_assert_eq!(a.len(), b.len());
     let mut dot = 0.0f32;
     let mut norm_a = 0.0f32;
     let mut norm_b = 0.0f32;
@@ -47,7 +48,6 @@ pub fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
 /// Negated dot product, so that lower still means nearer as it does for
 /// the other metrics.
 pub fn dot_distance(a: &[f32], b: &[f32]) -> f32 {
-    debug_assert_eq!(a.len(), b.len());
     -a.iter().zip(b.iter()).map(|(x, y)| x * y).sum::<f32>()
 }
 

--- a/vanedb/tests/distance_kernels.rs
+++ b/vanedb/tests/distance_kernels.rs
@@ -1,0 +1,74 @@
+//! The dispatched kernel must agree with the scalar reference at every length.
+//!
+//! A single dimension cannot reach every loop tier: the widest unrolled loop
+//! consumes its multiple and the scalar remainder takes the rest, so a length
+//! like 33 skips the intermediate loops entirely. Sweeping the lengths is what
+//! makes the "keep NEON, AVX2 and scalar in sync" invariant checkable.
+
+use vanedb::distance::{distance_fn, scalar};
+use vanedb::Metric;
+
+type Kernel = fn(&[f32], &[f32]) -> f32;
+
+const METRICS: [(&str, Metric, Kernel); 3] = [
+    ("l2", Metric::L2, scalar::l2_squared),
+    ("cosine", Metric::Cosine, scalar::cosine_distance),
+    ("dot", Metric::Dot, scalar::dot_distance),
+];
+
+/// Values with mixed signs and magnitudes, so a dropped lane changes the sum.
+/// Relative bound: an absolute epsilon shrinks in headroom as `n` grows,
+/// and the AVX2 tiers accumulate in a different order from NEON's.
+fn close(got: f32, want: f32) -> bool {
+    (got - want).abs() <= 1e-5 * want.abs().max(1.0)
+}
+
+fn ramp(n: usize, phase: f32) -> Vec<f32> {
+    (0..n)
+        .map(|i| ((i as f32) * 0.37 + phase).sin() * 3.0)
+        .collect()
+}
+
+#[test]
+fn dispatched_kernels_match_scalar_at_every_length() {
+    // 0..=80 crosses every tier boundary of both the NEON (16/4) and the
+    // AVX2 (32/8) kernels, for the metrics that halve those widths too.
+    for n in 0..=80 {
+        let a = ramp(n, 0.0);
+        let b = ramp(n, 1.7);
+        for (name, metric, reference) in METRICS {
+            let got = distance_fn(metric)(&a, &b);
+            let want = reference(&a, &b);
+            assert!(
+                close(got, want),
+                "{name} n={n}: dispatched={got}, scalar={want}"
+            );
+        }
+    }
+}
+
+#[test]
+fn mismatched_lengths_truncate_to_the_shorter_slice() {
+    // These are safe public functions, so every input has to be defined
+    // behaviour. The scalar reference zips, which truncates; the SIMD paths
+    // took their trip count from `a` alone and read past the end of `b`.
+    for (long, short) in [(64, 4), (33, 1), (16, 15), (40, 8), (8, 0)] {
+        let a = ramp(long, 0.0);
+        let b = ramp(short, 1.7);
+        for (name, metric, reference) in METRICS {
+            let got = distance_fn(metric)(&a, &b);
+            let want = reference(&a[..short], &b);
+            assert!(
+                close(got, want),
+                "{name} a={long} b={short}: dispatched={got}, truncated-scalar={want}"
+            );
+            // And symmetrically, with the short slice first.
+            let got = distance_fn(metric)(&b, &a);
+            let want = reference(&b, &a[..short]);
+            assert!(
+                close(got, want),
+                "{name} a={short} b={long}: dispatched={got}, truncated-scalar={want}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Unsoundness: the NEON and AVX2 kernels took their trip count from `a.len()` while the scalar reference uses `zip`, which stops at the shorter iterator. With a shorter `b`, every loop tier that runs reads past its end — for `a[64], b[4]` the **widest** tier does so on its first iteration. The only guard was `debug_assert_eq!`, compiled out in release — the build where the read happens.

`distance` is a public module and the kernels are safe `pub fn`, so this was reachable from safe code with no `unsafe` at the call site.

**Before**, 100% safe code, documented API only:
```
L2      distance_fn(a[64], b[4]) = inf       correct = 0
Cosine  distance_fn(a[64], b[4]) = 1         correct = 0
Dot     distance_fn(a[64], b[4]) = 1.99e37   correct = -4
```
The Dot value varied between runs on identical input — adjacent heap read as floats.

**After:** `0`, `0`, `-4`.

### Why no test caught it
No pre-existing test passed unequal-length slices at all. Reverting the fix with the new test in place fails **that test and nothing else** in the workspace.

### A separate coverage gap, found while fixing
All six kernel parity tests use dimension 33. The widest loop consumes 32 and the scalar remainder takes 1, so the **intermediate** tier never executes. Gutting that tier leaves all six parity tests green — the tests written to catch kernel divergence do not reach it. (It does trip three unrelated tests that happen to use affected dimensions: `compaction_keeps_the_index_searchable`, `concurrent_saves_sharing_a_stem_both_succeed`, and capi `distance`.)

This is a coverage gap adjacent to the bug, not where the bug lives. The new sweep covers every length 0..=80, crossing every tier boundary of both kernel families, and fails when that tier is broken.

### Notes
- Multi-accumulator unrolling untouched (AGENTS.md invariant): 4 accumulators for l2/dot, 2-way for cosine. The added `min` is one comparison outside every loop.
- Truncation is now the documented contract rather than a precondition that only existed in debug.
- Tolerance is relative rather than a fixed `1e-4`, which had only ~1.6× headroom at n=40 and shrinks as l2 magnitude grows.
- This host is aarch64, so AVX2 is compile-checked here and exercised by CI's Linux/Windows x86_64 jobs.

206 tests pass; fmt and clippy -D warnings clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H