### PR TITLE
chore(release): declare an MSRV, gate advisories, stop shipping a stale header

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
               - 'conformance/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
+              - 'deny.toml'
               - 'vanedb/**'
               - 'vanedb-capi/**'
               - 'vanedb-py/**'

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -22,6 +22,37 @@ jobs:
           components: clippy, rustfmt
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --exclude vanedb-py --all-targets --features disk --locked -- -D warnings
+      # build.rs regenerates the C header into the source tree. An ABI change
+      # plus a forgotten header commit would ship a header that lies about the
+      # ABI, and consumers vendor that file by hand.
+      - name: C header is in sync with the ABI
+        run: |
+          cargo build -p vanedb-capi --locked
+          git diff --exit-code -- vanedb-capi/include
+
+  msrv:
+    name: MSRV (1.85)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # The version declared in every Cargo.toml. Bound by bincode 2.x, the
+      # newest runtime dependency. `check`, not `test`: criterion is a
+      # dev-dependency and needs a newer toolchain than consumers do.
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        with:
+          toolchain: 1.85.0
+      - run: cargo check --workspace --exclude vanedb-py --features disk --locked
+
+  deny:
+    name: Advisories & licenses
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
+        with:
+          command: check
+          # deny.toml documents every exception with a reason and a way out.
+          arguments: --all-features
 
   check-py:
     name: Check (Python bindings)

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,44 @@
+# Supply-chain gate. Runs in CI on every change to Rust sources or manifests.
+#
+# The point is that a new advisory fails the build rather than waiting to be
+# noticed out of band. Everything ignored below is ignored with a reason and a
+# way out, not silenced.
+
+[graph]
+all-features = true
+
+[advisories]
+version = 2
+yanked = "deny"
+ignore = [
+    { id = "RUSTSEC-2025-0141", reason = "bincode unmaintained. It carries the ApproxIndex persistence format and is deliberately pinned to 2.x with config::legacy() (see AGENTS.md); the 3.x major is intentionally uncompilable and Dependabot ignores it. Not a vulnerability. The exit is the VNDB graph payload, which removes bincode from the runtime dependency set entirely." },
+  { id = "RUSTSEC-2024-0436", reason = "paste unmaintained, via metal, reachable only through the optional gpu-metal feature and never in a default build. No safe upgrade exists. Not a vulnerability. Revisit if gpu-metal moves toward being a shipped default." },
+]
+
+[licenses]
+version = 2
+# Exactly the licences the current graph resolves to — nothing speculative.
+# A dependency that introduces a new one fails the check and gets looked at,
+# which is the point; a permissive list that anticipates licences we do not
+# use would let that land unnoticed.
+allow = [
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "ISC",
+  "MPL-2.0",       # cbindgen, a build-dependency only; nothing links it
+  "Unicode-3.0",
+  "Unlicense",
+]
+
+[bans]
+# Duplicate versions are noise in a graph this size, not a defect.
+multiple-versions = "warn"
+wildcards = "deny"
+# The binding crates depend on `vanedb` by path with no version, which is
+# correct for unpublished crates in this workspace and not a supply-chain risk.
+allow-wildcard-paths = true
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"

--- a/vanedb-capi/Cargo.toml
+++ b/vanedb-capi/Cargo.toml
@@ -2,6 +2,9 @@
 name = "vanedb-capi"
 version = "0.1.0-rc.1"
 edition = "2021"
+# Bound by bincode 2.x, the newest runtime dependency. CI checks it.
+rust-version = "1.85"
+license = "MIT"
 # Not published: the vanedb dependency is a path without a version, and the
 # crate carries no description or license, so `cargo publish` rejects it. The
 # C ABI ships as a built artifact, not a crates.io package. Give it real

--- a/vanedb-capi/build.rs
+++ b/vanedb-capi/build.rs
@@ -1,9 +1,16 @@
 fn main() {
     let crate_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let out = format!("{crate_dir}/include/vanedb_rs_capi.h");
-    if let Ok(bindings) = cbindgen::generate(&crate_dir) {
-        bindings.write_to_file(&out);
-    }
+
+    // Fail loudly. Swallowing this left the previously committed header in
+    // place and the build green, so an ABI change plus a forgotten header
+    // commit would ship a header that lies about the ABI. The C ABI has no
+    // registry release path, so consumers vendor this file by hand and have
+    // no way to notice.
+    let bindings = cbindgen::generate(&crate_dir)
+        .expect("cbindgen failed to generate the C header from src/lib.rs");
+    bindings.write_to_file(&out);
+
     println!("cargo:rerun-if-changed=src/lib.rs");
     println!("cargo:rerun-if-changed=cbindgen.toml");
 }

--- a/vanedb-py/Cargo.toml
+++ b/vanedb-py/Cargo.toml
@@ -2,6 +2,9 @@
 name = "vanedb-py"
 version = "0.1.0-rc.1"
 edition = "2021"
+# Bound by bincode 2.x, the newest runtime dependency. CI checks it.
+rust-version = "1.85"
+license = "MIT"
 publish = false
 
 [lib]

--- a/vanedb-wasm/Cargo.toml
+++ b/vanedb-wasm/Cargo.toml
@@ -2,6 +2,9 @@
 name = "vanedb-wasm"
 version = "0.1.0-rc.1"
 edition = "2021"
+# Bound by bincode 2.x, the newest runtime dependency. CI checks it.
+rust-version = "1.85"
+license = "MIT"
 publish = false
 
 [lib]

--- a/vanedb/Cargo.toml
+++ b/vanedb/Cargo.toml
@@ -2,6 +2,8 @@
 name = "vanedb"
 version = "0.1.0-rc.1"
 edition = "2021"
+# Bound by bincode 2.x, the newest runtime dependency. CI checks it.
+rust-version = "1.85"
 description = "Embeddable vector database for edge AI"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Three release-hygiene gaps, each silent today.

### MSRV
No crate declared `rust-version` and CI tested stable only. For a crate pitched at embedded and edge use — where consumers are frequently pinned to a vendor or distro toolchain — an undeclared MSRV means a dependency bump can break a downstream build with no warning.

Declared **1.85**, bound by bincode 2.x (the newest runtime dependency), and verified on that exact toolchain:
```
$ rustup run 1.85.0 cargo check --workspace --exclude vanedb-py --features disk --locked
    Finished `dev` profile
```
The job runs `check`, not `test`: criterion is a dev-dependency needing 1.86, which consumers never build.

### Supply chain
No `cargo-deny`/`cargo-audit` anywhere, so a RUSTSEC advisory surfaced only through out-of-band Dependabot alerts. `deny.toml` gates advisories, licenses, bans and sources; the allow-list is **derived from the actual graph**, not copied from a template.

Both current advisories are ignored with a reason and an exit, not silenced:

| advisory | why | exit |
|---|---|---|
| RUSTSEC-2025-0141 — bincode unmaintained | carries the ApproxIndex format, deliberately pinned to 2.x with `config::legacy()` per AGENTS.md; not a vulnerability | the VNDB graph payload drops bincode from the runtime set |
| RUSTSEC-2024-0436 — paste unmaintained | via `metal`, reachable only through optional `gpu-metal`, never in a default build; no safe upgrade exists | revisit if gpu-metal becomes a default |

Verified load-bearing — removing either ignore fails the check:
```
with config:        advisories ok, bans ok, licenses ok, sources ok
ignore removed:     advisories FAILED
```

### The C header could ship stale
`build.rs` swallowed a cbindgen failure and let the build succeed against whatever header was last committed, while writing into the source tree with no CI drift check. An ABI change plus a forgotten header commit ships a header that lies about the ABI — and the C ABI has **no registry release path**, so consumers vendor that file by hand and cannot notice.

Now fails loudly, verified on the path it guards:
```
thread 'main' panicked at vanedb-capi/build.rs:11:10:
cbindgen failed to generate the C header from src/lib.rs: ParseSyntaxError { ... }
```
CI additionally rebuilds the header and requires `git diff --exit-code -- vanedb-capi/include`.

Also declares `license = "MIT"` on the three binding crates, which had none.

210 tests pass; fmt, clippy `-D warnings`, actionlint and cargo-deny all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H