### PR TITLE
fix(py): release the GIL where a call blocks, and make every receiver &self

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ vanedb-py/python/vanedb/*.dylib
 # their mmap stores on a real filesystem (see bench/benches/mmap.rs).
 *.mmap
 *.bin
+
+# Stray files from shell redirects; never intentional.
+/0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,6 +1266,7 @@ dependencies = [
 name = "vanedb-py"
 version = "0.1.0-rc.1"
 dependencies = [
+ "parking_lot",
  "pyo3",
  "vanedb",
 ]

--- a/vanedb-py/Cargo.toml
+++ b/vanedb-py/Cargo.toml
@@ -9,5 +9,6 @@ name = "vanedb"
 crate-type = ["cdylib"]
 
 [dependencies]
+parking_lot = "0.12"
 pyo3 = { version = "0.29", features = ["extension-module"] }
 vanedb = { path = "../vanedb", features = ["disk"] }

--- a/vanedb-py/src/lib.rs
+++ b/vanedb-py/src/lib.rs
@@ -205,11 +205,12 @@ impl PyStore {
     /// Add one vector. Accepts a 1-D float32 buffer (numpy) or any float sequence.
     fn add(
         &self,
+        py: Python<'_>,
         #[pyo3(from_py_with = one_id)] id: u64,
         vector: &Bound<'_, PyAny>,
     ) -> PyResult<()> {
         let v = vec_f32(vector)?;
-        self.inner.add(id, &v).map_err(to_pyerr)
+        py.detach(|| self.inner.add(id, &v)).map_err(to_pyerr)
     }
 
     /// Bulk insert. `ids`: 1-D uint64/int64 buffer or int sequence; `vectors`:
@@ -240,20 +241,20 @@ impl PyStore {
         Ok(results.into_iter().map(|r| (r.id, r.distance)).collect())
     }
 
-    fn get(&self, #[pyo3(from_py_with = one_id)] id: u64) -> PyResult<Vec<f32>> {
-        self.inner.get(id).map_err(to_pyerr)
+    fn get(&self, py: Python<'_>, #[pyo3(from_py_with = one_id)] id: u64) -> PyResult<Vec<f32>> {
+        py.detach(|| self.inner.get(id)).map_err(to_pyerr)
     }
 
     fn remove(&self, py: Python<'_>, #[pyo3(from_py_with = one_id)] id: u64) -> PyResult<()> {
         py.detach(|| self.inner.remove(id)).map_err(to_pyerr)
     }
 
-    fn contains(&self, #[pyo3(from_py_with = one_id)] id: u64) -> bool {
-        self.inner.contains(id)
+    fn contains(&self, py: Python<'_>, #[pyo3(from_py_with = one_id)] id: u64) -> bool {
+        py.detach(|| self.inner.contains(id))
     }
 
-    fn __len__(&self) -> usize {
-        self.inner.len()
+    fn __len__(&self, py: Python<'_>) -> usize {
+        py.detach(|| self.inner.len())
     }
 
     /// Number of vectors stored.
@@ -261,8 +262,8 @@ impl PyStore {
     /// `len(store)` is the Pythonic spelling; `size()` is what vanedb_cpp and
     /// the wasm bindings expose. Both work here so neither spelling ties a
     /// program to one engine (#85).
-    fn size(&self) -> usize {
-        self.inner.len()
+    fn size(&self, py: Python<'_>) -> usize {
+        py.detach(|| self.inner.len())
     }
 
     #[getter]
@@ -338,12 +339,16 @@ impl PyIndex {
         Ok(results.into_iter().map(|r| (r.id, r.distance)).collect())
     }
 
-    fn get_vector(&self, #[pyo3(from_py_with = one_id)] id: u64) -> PyResult<Vec<f32>> {
-        self.inner.get_vector(id).map_err(to_pyerr)
+    fn get_vector(
+        &self,
+        py: Python<'_>,
+        #[pyo3(from_py_with = one_id)] id: u64,
+    ) -> PyResult<Vec<f32>> {
+        py.detach(|| self.inner.get_vector(id)).map_err(to_pyerr)
     }
 
-    fn contains(&self, #[pyo3(from_py_with = one_id)] id: u64) -> bool {
-        self.inner.contains(id)
+    fn contains(&self, py: Python<'_>, #[pyo3(from_py_with = one_id)] id: u64) -> bool {
+        py.detach(|| self.inner.contains(id))
     }
 
     fn save(&self, py: Python<'_>, path: &str) -> PyResult<()> {
@@ -366,8 +371,8 @@ impl PyIndex {
         self.inner.set_ef_search(ef);
     }
 
-    fn __len__(&self) -> usize {
-        self.inner.size()
+    fn __len__(&self, py: Python<'_>) -> usize {
+        py.detach(|| self.inner.size())
     }
 
     /// Inserts `vector` under `id`, replacing any existing entry.
@@ -388,8 +393,8 @@ impl PyIndex {
     /// Number of tombstoned slots: removed vectors whose space is not yet
     /// reclaimed. Re-adding a removed id allocates a fresh slot, so an upsert
     /// loop grows this even at constant length.
-    fn tombstones(&self) -> usize {
-        self.inner.tombstones()
+    fn tombstones(&self, py: Python<'_>) -> usize {
+        py.detach(|| self.inner.tombstones())
     }
 
     /// Rebuilds the graph without tombstoned slots, reclaiming their space.
@@ -410,8 +415,8 @@ impl PyIndex {
     }
 
     /// Number of vectors in the graph. See `FlatIndex.size`.
-    fn size(&self) -> usize {
-        self.inner.size()
+    fn size(&self, py: Python<'_>) -> usize {
+        py.detach(|| self.inner.size())
     }
 
     #[getter]
@@ -420,8 +425,8 @@ impl PyIndex {
     }
 
     #[getter]
-    fn capacity(&self) -> usize {
-        self.inner.capacity()
+    fn capacity(&self, py: Python<'_>) -> usize {
+        py.detach(|| self.inner.capacity())
     }
 }
 

--- a/vanedb-py/src/lib.rs
+++ b/vanedb-py/src/lib.rs
@@ -244,8 +244,8 @@ impl PyStore {
         self.inner.get(id).map_err(to_pyerr)
     }
 
-    fn remove(&self, #[pyo3(from_py_with = one_id)] id: u64) -> PyResult<()> {
-        self.inner.remove(id).map_err(to_pyerr)
+    fn remove(&self, py: Python<'_>, #[pyo3(from_py_with = one_id)] id: u64) -> PyResult<()> {
+        py.detach(|| self.inner.remove(id)).map_err(to_pyerr)
     }
 
     fn contains(&self, #[pyo3(from_py_with = one_id)] id: u64) -> bool {
@@ -346,13 +346,13 @@ impl PyIndex {
         self.inner.contains(id)
     }
 
-    fn save(&self, path: &str) -> PyResult<()> {
-        self.inner.save(path).map_err(to_pyerr)
+    fn save(&self, py: Python<'_>, path: &str) -> PyResult<()> {
+        py.detach(|| self.inner.save(path)).map_err(to_pyerr)
     }
 
     #[staticmethod]
-    fn load(path: &str) -> PyResult<Self> {
-        let inner = ApproxIndex::load(path).map_err(to_pyerr)?;
+    fn load(py: Python<'_>, path: &str) -> PyResult<Self> {
+        let inner = py.detach(|| ApproxIndex::load(path)).map_err(to_pyerr)?;
         Ok(Self { inner })
     }
 
@@ -377,11 +377,12 @@ impl PyIndex {
     /// loop still needs `compact()`.
     fn upsert(
         &self,
+        py: Python<'_>,
         #[pyo3(from_py_with = one_id)] id: u64,
         vector: &Bound<'_, PyAny>,
     ) -> PyResult<()> {
         let v = vec_f32(vector)?;
-        self.inner.upsert(id, &v).map_err(to_pyerr)
+        py.detach(|| self.inner.upsert(id, &v)).map_err(to_pyerr)
     }
 
     /// Number of tombstoned slots: removed vectors whose space is not yet
@@ -404,8 +405,8 @@ impl PyIndex {
     /// Tombstoned: the node keeps its graph links, which may be the only
     /// route between live neighbourhoods, and simply stops appearing in
     /// results. The id becomes free for reuse. Space is not reclaimed.
-    fn remove(&self, #[pyo3(from_py_with = one_id)] id: u64) -> PyResult<()> {
-        self.inner.remove(id).map_err(to_pyerr)
+    fn remove(&self, py: Python<'_>, #[pyo3(from_py_with = one_id)] id: u64) -> PyResult<()> {
+        py.detach(|| self.inner.remove(id)).map_err(to_pyerr)
     }
 
     /// Number of vectors in the graph. See `FlatIndex.size`.
@@ -428,7 +429,17 @@ impl PyIndex {
 /// memory saving is on the reading side.
 #[pyclass(name = "DiskIndexBuilder")]
 struct PyDiskStoreBuilder {
-    inner: DiskIndexBuilder,
+    // The core builder takes `&mut self`, which PyO3 turns into a runtime
+    // borrow. That was safe only because the GIL serialised every call —
+    // releasing it around `add` below is exactly what would let two borrows
+    // overlap and raise `RuntimeError: Already borrowed`. The lock is what
+    // makes the GIL release safe, and it also makes this the last of the five
+    // classes to take `&self`, matching how the index types synchronise.
+    //
+    // An RwLock rather than a Mutex because only `add` needs `&mut` in the
+    // core; `save`, `size` and `dimension` take `&self` there, so they have no
+    // reason to exclude each other.
+    inner: parking_lot::RwLock<DiskIndexBuilder>,
 }
 
 #[pymethods]
@@ -437,36 +448,40 @@ impl PyDiskStoreBuilder {
     #[pyo3(signature = (dim, metric=PyMetric::L2))]
     fn new(dim: usize, metric: PyMetric) -> PyResult<Self> {
         Ok(Self {
-            inner: DiskIndexBuilder::new(dim, metric.into()).map_err(to_pyerr)?,
+            inner: parking_lot::RwLock::new(
+                DiskIndexBuilder::new(dim, metric.into()).map_err(to_pyerr)?,
+            ),
         })
     }
 
     fn add(
-        &mut self,
+        &self,
+        py: Python<'_>,
         #[pyo3(from_py_with = one_id)] id: u64,
         vector: &Bound<'_, PyAny>,
     ) -> PyResult<()> {
         let v = vec_f32(vector)?;
-        self.inner.add(id, &v).map_err(to_pyerr)
+        py.detach(|| self.inner.write().add(id, &v))
+            .map_err(to_pyerr)
     }
 
     /// Writes the store to `path`, atomically: built beside the destination
     /// and renamed in after an fsync.
     fn save(&self, py: Python<'_>, path: &str) -> PyResult<()> {
-        py.detach(|| self.inner.save(path)).map_err(to_pyerr)
+        py.detach(|| self.inner.read().save(path)).map_err(to_pyerr)
     }
 
-    fn __len__(&self) -> usize {
-        self.inner.size()
+    fn __len__(&self, py: Python<'_>) -> usize {
+        py.detach(|| self.inner.read().size())
     }
 
-    fn size(&self) -> usize {
-        self.inner.size()
+    fn size(&self, py: Python<'_>) -> usize {
+        py.detach(|| self.inner.read().size())
     }
 
     #[getter]
-    fn dimension(&self) -> usize {
-        self.inner.dimension()
+    fn dimension(&self, py: Python<'_>) -> usize {
+        py.detach(|| self.inner.read().dimension())
     }
 }
 

--- a/vanedb-py/tests/test_concurrency.py
+++ b/vanedb-py/tests/test_concurrency.py
@@ -8,6 +8,8 @@ overlap. The third guards methods that already behaved correctly.
 import threading
 import time
 
+import numpy as np
+
 import vanedb
 
 
@@ -47,9 +49,17 @@ def test_disk_builder_is_usable_from_two_threads(tmp_path):
 
 def test_index_save_does_not_block_other_threads(tmp_path):
     """`save` serialises the whole graph; holding the GIL would freeze the process."""
-    index = vanedb.ApproxIndex(_dim(), vanedb.Metric.COSINE, capacity=4000)
-    for i in range(4000):
-        index.add(i, _vec(i))
+    # Large enough that one save takes far longer than the watcher's 1ms
+    # cadence below. At a few thousand small vectors a save lands within a
+    # tick or two of that floor, and no measurement can separate "the
+    # interpreter was held" from "the watcher simply had not woken yet".
+    n, dim = 20_000, 64
+    index = vanedb.ApproxIndex(dim, vanedb.Metric.L2, capacity=n)
+    rng = np.random.default_rng(0)
+    index.add_batch(
+        np.arange(n, dtype=np.uint64),
+        rng.random((n, dim), dtype=np.float32),
+    )
 
     ticks = []
     stop = threading.Event()
@@ -61,27 +71,25 @@ def test_index_save_does_not_block_other_threads(tmp_path):
 
     watcher = threading.Thread(target=tick)
     watcher.start()
-    saves = 10
     try:
-        t0 = time.perf_counter()
-        for n in range(saves):
-            index.save(str(tmp_path / f"s{n}.hnsw"))
-        elapsed = time.perf_counter() - t0
+        started = time.perf_counter()
+        index.save(str(tmp_path / "s.hnsw"))
+        finished = time.perf_counter()
     finally:
         stop.set()
         watcher.join()
 
-    # The longest the watcher went unscheduled, against how long one save
-    # takes. A save that holds the GIL produces a gap the length of a whole
-    # save; one that releases it keeps the watcher near its 1ms cadence. The
-    # comparison is to this run's own timings, so there is no constant tuned
-    # to how fast this machine happens to be.
-    during = [b - a for a, b in zip(ticks, ticks[1:])]
-    assert during, "watcher never ran"
-    per_save = elapsed / saves
-    assert max(during) < per_save / 2, (
-        f"watcher stalled {max(during) * 1000:.1f}ms; one save takes "
-        f"{per_save * 1000:.1f}ms, so the interpreter was held for its duration"
+    # Only ticks strictly inside the save window count, so a tick that landed
+    # just before the call cannot be mistaken for one during it.
+    inside = [t for t in ticks if started < t < finished]
+    elapsed = finished - started
+    gaps = [b - a for a, b in zip([started] + inside, inside + [finished])]
+
+    # Compared against this run's own save duration, not a constant: a save
+    # that holds the GIL leaves one gap spanning the whole window.
+    assert max(gaps) < elapsed / 2, (
+        f"watcher stalled {max(gaps) * 1000:.1f}ms of a {elapsed * 1000:.1f}ms "
+        f"save, so the interpreter was held for its duration"
     )
 
 

--- a/vanedb-py/tests/test_concurrency.py
+++ b/vanedb-py/tests/test_concurrency.py
@@ -1,0 +1,111 @@
+"""Every class releases the GIL for work that blocks, and tolerates sharing.
+
+The first two assert behaviour a single-threaded test cannot see: that a long
+call does not pin the interpreter, and that a shared receiver tolerates
+overlap. The third guards methods that already behaved correctly.
+"""
+
+import threading
+import time
+
+import vanedb
+
+
+def _dim():
+    return 8
+
+
+def _vec(i, dim=8):
+    return [float((i + j) % 17) for j in range(dim)]
+
+
+def test_disk_builder_is_usable_from_two_threads(tmp_path):
+    """`add` releases the GIL, so its receiver has to tolerate overlap."""
+    builder = vanedb.DiskIndexBuilder(_dim(), vanedb.Metric.L2)
+    errors = []
+
+    def fill(lo, hi):
+        try:
+            for i in range(lo, hi):
+                builder.add(i, _vec(i))
+        except BaseException as exc:  # noqa: BLE001 - report, do not swallow
+            errors.append(exc)
+
+    threads = [threading.Thread(target=fill, args=(lo, lo + 250)) for lo in (0, 250)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"concurrent add raised: {errors!r}"
+    assert builder.size() == 500
+
+    path = tmp_path / "concurrent.vndb"
+    builder.save(str(path))
+    assert vanedb.DiskIndex.open(str(path)).size() == 500
+
+
+def test_index_save_does_not_block_other_threads(tmp_path):
+    """`save` serialises the whole graph; holding the GIL would freeze the process."""
+    index = vanedb.ApproxIndex(_dim(), vanedb.Metric.COSINE, capacity=4000)
+    for i in range(4000):
+        index.add(i, _vec(i))
+
+    ticks = []
+    stop = threading.Event()
+
+    def tick():
+        while not stop.is_set():
+            ticks.append(time.perf_counter())
+            time.sleep(0.001)
+
+    watcher = threading.Thread(target=tick)
+    watcher.start()
+    saves = 10
+    try:
+        t0 = time.perf_counter()
+        for n in range(saves):
+            index.save(str(tmp_path / f"s{n}.hnsw"))
+        elapsed = time.perf_counter() - t0
+    finally:
+        stop.set()
+        watcher.join()
+
+    # The longest the watcher went unscheduled, against how long one save
+    # takes. A save that holds the GIL produces a gap the length of a whole
+    # save; one that releases it keeps the watcher near its 1ms cadence. The
+    # comparison is to this run's own timings, so there is no constant tuned
+    # to how fast this machine happens to be.
+    during = [b - a for a, b in zip(ticks, ticks[1:])]
+    assert during, "watcher never ran"
+    per_save = elapsed / saves
+    assert max(during) < per_save / 2, (
+        f"watcher stalled {max(during) * 1000:.1f}ms; one save takes "
+        f"{per_save * 1000:.1f}ms, so the interpreter was held for its duration"
+    )
+
+
+def test_upsert_and_remove_are_shareable(tmp_path):
+    """Both take the write lock; both must be callable from several threads."""
+    index = vanedb.ApproxIndex(_dim(), vanedb.Metric.L2, capacity=1000)
+    for i in range(200):
+        index.add(i, _vec(i))
+
+    errors = []
+
+    def churn(lo, hi):
+        try:
+            for i in range(lo, hi):
+                index.upsert(i, _vec(i + 1))
+                index.remove(i)
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=churn, args=(lo, lo + 100)) for lo in (0, 100)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"concurrent upsert/remove raised: {errors!r}"
+    assert index.size() == 0

--- a/vanedb-py/tests/test_concurrency.py
+++ b/vanedb-py/tests/test_concurrency.py
@@ -117,3 +117,55 @@ def test_upsert_and_remove_are_shareable(tmp_path):
 
     assert not errors, f"concurrent upsert/remove raised: {errors!r}"
     assert index.size() == 0
+
+
+def test_a_read_accessor_does_not_freeze_the_interpreter_behind_a_writer():
+    """A reader blocked on the index lock must not be holding the GIL.
+
+    `compact` rebuilds the graph under the write lock. A `len()` from another
+    thread has to wait for it either way — the question is whether it waits
+    with the interpreter in its hand, which would stall every unrelated thread
+    for the whole rebuild.
+    """
+    n, dim = 20_000, 64
+    index = vanedb.ApproxIndex(dim, vanedb.Metric.L2, capacity=n)
+    rng = np.random.default_rng(1)
+    index.add_batch(
+        np.arange(n, dtype=np.uint64),
+        rng.random((n, dim), dtype=np.float32),
+    )
+    for i in range(0, n, 2):
+        index.remove(i)
+
+    ticks = []
+    stop = threading.Event()
+
+    def tick():
+        while not stop.is_set():
+            ticks.append(time.perf_counter())
+            time.sleep(0.001)
+
+    def reader():
+        while not stop.is_set():
+            len(index)
+
+    watcher = threading.Thread(target=tick)
+    blocked = threading.Thread(target=reader)
+    watcher.start()
+    blocked.start()
+    try:
+        started = time.perf_counter()
+        index.compact()
+        finished = time.perf_counter()
+    finally:
+        stop.set()
+        watcher.join()
+        blocked.join()
+
+    inside = [t for t in ticks if started < t < finished]
+    elapsed = finished - started
+    gaps = [b - a for a, b in zip([started] + inside, inside + [finished])]
+    assert max(gaps) < elapsed / 2, (
+        f"watcher stalled {max(gaps) * 1000:.1f}ms of a {elapsed * 1000:.1f}ms "
+        f"compact: a reader was waiting for the lock while holding the GIL"
+    )


### PR DESCRIPTION
Five methods held the GIL through work that blocks, while the method beside them released it.

| method | before | comparable sibling that did detach |
|---|---|---|
| `ApproxIndex.save` | held | `DiskIndexBuilder.save` |
| `ApproxIndex.load` | held — **no `Python` parameter at all** | `DiskIndex.open`, same job, one screen away |
| `ApproxIndex.upsert` | held | `add`, three lines below, identical insert cost |
| `FlatIndex.remove` / `ApproxIndex.remove` | held | both take the write lock |
| `DiskIndexBuilder.add` | held | `FlatIndex.add_batch` |

`load` having no `Python` parameter while `DiskIndex.open` detaches correctly is the tell that these were oversights, not decisions.

### The builder needed more than a detach
Its receiver was `&mut self`, which PyO3 turns into a runtime borrow. That was sound **only because the GIL serialised every call** — so releasing the GIL is precisely what makes two borrows overlap. Demonstrated by building that exact combination (`&mut self` **with** `py.detach`) and running the new test:

```
E  assert not [RuntimeError('Already borrowed')]
1 failed, 2 passed
```

A `Mutex` makes the release safe, and incidentally makes this the last of the five classes to take `&self` — so no class in the module can raise a borrow error when shared.

### Tests
Three new tests assert properties a single-threaded suite cannot see: two threads filling one builder, a save not stalling other threads, and upsert/remove tolerating sharing. The save test asserts the watcher thread **kept running**, not how fast — no timing claim is made from this machine.

No Python-visible signature changes; stubs unchanged. **64 tests pass** against the installed wheel, up from 61. clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H