### PR TITLE
fix(gpu): close the length and overflow classes in the un-linted Metal path

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -30,6 +30,20 @@ jobs:
           cargo build -p vanedb-capi --locked
           git diff --exit-code -- vanedb-capi/include
 
+  check-macos:
+    name: Check & Lint (macOS, gpu-metal)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        with:
+          toolchain: stable
+          components: clippy
+      # gpu-metal only compiles on Apple platforms, so the Linux lint job
+      # cannot see this surface at all. Without a leg here, MetalCompute is
+      # public API that never passes clippy or the crate's own missing_docs.
+      - run: cargo clippy -p vanedb --all-targets --features disk,gpu-metal --locked -- -D warnings
+
   msrv:
     name: MSRV (1.85)
     runs-on: ubuntu-latest

--- a/vanedb/src/gpu/metal.rs
+++ b/vanedb/src/gpu/metal.rs
@@ -74,9 +74,11 @@ pub struct GpuBuffer {
 }
 
 impl GpuBuffer {
+    /// Number of vectors uploaded.
     pub fn n(&self) -> usize {
         self.n
     }
+    /// Components per vector.
     pub fn dim(&self) -> usize {
         self.dim
     }
@@ -135,12 +137,18 @@ impl MetalCompute {
     /// Upload vectors to GPU memory. Vectors is a flat array of n * dim floats.
     /// Dimension must be divisible by 4.
     pub fn upload(&self, vectors: &[f32], n: usize, dim: usize) -> Result<GpuBuffer> {
-        if !dim.is_multiple_of(4) {
+        if dim % 4 != 0 {
             return Err(VaneError::InvalidParameter("GPU requires dim % 4 == 0"));
         }
-        if vectors.len() != n * dim {
+        // Both operands come from the caller, so the product can wrap: at
+        // n = 2^62, dim = 4 it reaches zero, matches an empty slice, and
+        // yields a buffer claiming 2^62 vectors over a zero-byte allocation.
+        let expected = n
+            .checked_mul(dim)
+            .ok_or(VaneError::InvalidParameter("n * dim overflows"))?;
+        if vectors.len() != expected {
             return Err(VaneError::DimensionMismatch {
-                expected: n * dim,
+                expected,
                 got: vectors.len(),
             });
         }
@@ -174,6 +182,11 @@ impl MetalCompute {
 
         let n = buffer.n;
         let dim = buffer.dim;
+        // Sized from `n`, which came from the caller via `upload`. Checked here
+        // rather than in the pool below, where `?` has no Result to return to.
+        let result_bytes = n
+            .checked_mul(std::mem::size_of::<f32>())
+            .ok_or(VaneError::InvalidParameter("result buffer size overflows"))?;
 
         let result = autoreleasepool(|| {
             let query_buf = self.device.new_buffer_with_data(
@@ -181,10 +194,9 @@ impl MetalCompute {
                 (dim * std::mem::size_of::<f32>()) as NSUInteger,
                 MTLResourceOptions::StorageModeShared,
             );
-            let result_buf = self.device.new_buffer(
-                (n * std::mem::size_of::<f32>()) as u64,
-                MTLResourceOptions::StorageModeShared,
-            );
+            let result_buf = self
+                .device
+                .new_buffer(result_bytes as u64, MTLResourceOptions::StorageModeShared);
             let d4: u32 = (dim / 4) as u32;
             let dim_buf = self.device.new_buffer_with_data(
                 &d4 as *const u32 as *const _,
@@ -226,6 +238,17 @@ impl MetalCompute {
     ) -> Result<Vec<SearchResult>> {
         if k == 0 {
             return Err(VaneError::InvalidK);
+        }
+        // `zip` below stops at the shorter, so a short `ids` would rank only a
+        // prefix of the corpus and return wrong neighbours with no error. The
+        // query length is already validated in `distances`; this is the same
+        // check for the other caller-supplied slice.
+        if ids.len() != buffer.n {
+            return Err(VaneError::BatchLengthMismatch {
+                ids: ids.len(),
+                vectors: buffer.n,
+                dim: buffer.dim,
+            });
         }
         let dists = self.distances(query, buffer, metric)?;
         let mut results: Vec<SearchResult> = ids

--- a/vanedb/src/gpu/metal.rs
+++ b/vanedb/src/gpu/metal.rs
@@ -180,6 +180,12 @@ impl MetalCompute {
             GpuMetric::Cosine => &self.cos_pipeline,
         };
 
+        if buffer.n == 0 {
+            // `upload(&[], 0, dim)` is valid, and dispatching a zero-sized
+            // grid is not: Metal's validation layer rejects it.
+            return Ok(Vec::new());
+        }
+
         let n = buffer.n;
         let dim = buffer.dim;
         // Sized from `n`, which came from the caller via `upload`. Checked here
@@ -244,11 +250,9 @@ impl MetalCompute {
         // query length is already validated in `distances`; this is the same
         // check for the other caller-supplied slice.
         if ids.len() != buffer.n {
-            return Err(VaneError::BatchLengthMismatch {
-                ids: ids.len(),
-                vectors: buffer.n,
-                dim: buffer.dim,
-            });
+            return Err(VaneError::InvalidParameter(
+                "ids length must match the uploaded vector count",
+            ));
         }
         let dists = self.distances(query, buffer, metric)?;
         let mut results: Vec<SearchResult> = ids

--- a/vanedb/src/gpu/mod.rs
+++ b/vanedb/src/gpu/mod.rs
@@ -1,5 +1,12 @@
+//! GPU backends. Metal is the supported path; CUDA is an unimplemented stub.
+//!
+//! These are a standalone parallel-scan API: no index uses them internally.
+//! The caller supplies a flat corpus, uploads it, and searches the handle.
+
+/// CUDA kernels. Unimplemented — every method returns an error.
 #[cfg(feature = "gpu-cuda")]
 pub mod cuda;
+/// Metal kernels, on Apple platforms.
 #[cfg(feature = "gpu-metal")]
 pub mod metal;
 
@@ -8,11 +15,18 @@ pub use self::metal::MetalCompute;
 
 use crate::distance::Metric;
 
-/// GPU distance metric (maps from Metric).
+/// GPU distance metric (maps from [`Metric`]).
+///
+/// `#[non_exhaustive]`, like [`Metric`]: matching needs a `_` arm, so adding a
+/// metric is not a breaking change.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum GpuMetric {
+    /// Squared Euclidean distance.
     L2,
+    /// Cosine distance, `1 - cos(a, b)`.
     Cosine,
+    /// Negative dot product.
     Dot,
 }
 

--- a/vanedb/src/lib.rs
+++ b/vanedb/src/lib.rs
@@ -46,7 +46,9 @@ pub mod disk;
 pub mod distance;
 pub mod error;
 pub mod flat;
+/// GPU backends, behind `gpu-metal` or `gpu-cuda`.
 #[cfg(any(feature = "gpu-metal", feature = "gpu-cuda"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "gpu-metal", feature = "gpu-cuda"))))]
 pub mod gpu;
 mod validation;
 


### PR DESCRIPTION
CI lints with `--features disk` only, so `gpu-metal` — a public module exposing `MetalCompute`, `GpuBuffer` and `GpuMetric` — had **never** passed clippy or the crate's own `missing_docs`. Two of the three defect classes fixed elsewhere this cycle had surviving instances there.

### The siblings
- **`MetalCompute::search`** zipped caller-supplied `ids` against computed distances. `zip` stops at the shorter, so a short `ids` ranked only a prefix of the corpus and returned wrong neighbours **with no error** — the same length-derivation bug as the SIMD kernels. `distances` already validated the *query* length; the discipline was applied to one slice and skipped for the other.
- **`upload`** computed `n * dim` unchecked on two caller values. At `n = 2^62, dim = 4` the product wraps to zero, matches an empty slice, and yields a buffer claiming 2^62 vectors over a zero-byte allocation — which `distances` then uses to size a result buffer and build a slice. Both are `checked_mul` now.

### Adding the lint leg paid immediately
```
error: current MSRV (Minimum Supported Rust Version) is `1.85.0`
       but this item is stable since `1.87.0`
  --> vanedb/src/gpu/metal.rs:140:17
      if !dim.is_multiple_of(4) {
```
An **MSRV violation on main**. The MSRV job could not see it because it also checks `--features disk` only. Replaced with `dim % 4 != 0`.

The new macOS leg runs clippy with `disk,gpu-metal`, the only configuration where this surface compiles. Seven `missing_docs` warnings on public items are also fixed, and `GpuMetric` becomes `#[non_exhaustive]` to match `Metric` — free now, breaking later.

Found by the senior-engineer 1.0.0 sign-off review, which asked specifically whether the classes fixed this cycle had surviving siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H