### PR TITLE
chore: untrack editor configuration, and stop sweeping it back in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,9 @@ vanedb-py/python/vanedb/*.dylib
 *.mmap
 *.bin
 
-# Stray files from shell redirects; never intentional.
+# Swept in by `git add -A` and never intentional: stray shell redirects,
+# and per-developer editor configuration.
 /0
+.zed/
+.idea/
+*.code-workspace

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,5 +1,0 @@
-// Folder-specific settings
-//
-// For a full list of overridable settings, and general information on folder-specific settings,
-// see the documentation: https://zed.dev/docs/configuring-zed#settings-files
-{}


### PR DESCRIPTION
`.zed/settings.json` is per-developer editor state — an empty object plus the default comment header — committed by a `git add -A` in an unrelated docs change (`e540d5e`).

It never reaches the packaged crate (`cargo package --list` does not include it), so this is hygiene rather than a release risk. But it is the **second** stray from the same cause this session, after a zero-byte file named `0`, so the ignore rules now cover the class — editor configs and stray redirects — rather than the instance.

Found by the CTO re-poll review reading `git ls-files`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H