### PR TITLE
test(persistence): assert the graph header against the table, not the reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,11 @@ against. This section records what the first release will contain.
 
 ### Added
 
+- `metric()` on every binding — Python, the C ABI and wasm. A loaded index
+  reads its metric from the file, and without this a caller who did not build
+  it could not check that their query convention matched. `Metric::Dot` now
+  has binding-level test coverage, which it had nowhere before.
+- `ApproxIndex::m`, `ef_construction` and `seed` getters, for the same reason.
 - `DiskIndex` and `DiskIndexBuilder` appear in the published documentation,
   with the feature badge that says they need `disk`.
 - Declared MSRV of 1.85, checked in CI on that exact toolchain.
@@ -63,9 +68,21 @@ against. This section records what the first release will contain.
 
 ### Changed
 
-- The persistence promise is scoped to what is true: `DiskIndex` writes `VNDB`
-  v1, a specified, versioned, cross-engine format; `ApproxIndex::save` is
-  engine-specific and not yet a public format.
+- Both persistence formats are specified. `DiskIndex` writes `VNDB` v1 and
+  `ApproxIndex::save` writes `VNDB` v2, each with a field table under
+  `conformance/` and fixtures generated from that table rather than from the
+  engine. Legacy `HNSW` graph files still load, pinned by committed bytes.
+  The disk format is cross-engine; the graph format is read by this engine
+  only, since the C++ engine has no VNDB v2 reader.
+- `ApproxIndex::save` output is byte-reproducible: the same content written
+  twice produces the same file. The previous format serialised a `HashMap` in
+  iteration order, so it did not.
+- `gpu-cuda` is removed. It was a stub whose every method returned an error,
+  shipped as a published feature. Removing a Cargo feature is breaking and
+  adding one is not, so it goes before the first release; a real CUDA backend
+  can land as a minor version once CI has hardware to validate it.
+- `vanedb-cpp` is no longer published (#100). The C++ engine stays in the
+  repository as reference code and as the benchmark's control.
 - `Metric::Dot` documents that it is not scale-invariant and not a metric, so
   a vector need not be its own nearest neighbour.
 - The published recall figure is annotated as measured on uniform-random

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,8 +32,10 @@ The loaders parse untrusted input, so that is where the interesting surface is.
 **In scope**
 
 - Memory safety, including anything reachable from safe Rust
-- Malicious or corrupt index files — `VNDB` (`DiskIndex`) and `HNSW`
-  (`ApproxIndex`) — that read out of bounds, over-allocate, or load as valid
+- Malicious or corrupt index files that read out of bounds, over-allocate, or
+  load as valid. Three formats parse untrusted input: `VNDB` v1 (`DiskIndex`),
+  `VNDB` v2 (`ApproxIndex`), and legacy `HNSW` v1/v2, which `ApproxIndex` still
+  reads
 - Integer overflow in size or offset arithmetic on file-controlled values
 - Input validation bypasses in any binding: Rust, Python, C ABI or wasm
 - Thread-safety bugs causing corruption or wrong results
@@ -64,7 +66,9 @@ The loaders parse untrusted input, so that is where the interesting surface is.
   arithmetic before allocating or indexing. Neither accepts a file whose ids
   are not unique: `DiskIndex` checks directly, and `ApproxIndex` enforces a
   bijection between its id map and its stored ids, which forces the same thing.
-  `vanedb/tests/corruption_tests.rs` pins these with crafted files.
+  `vanedb/tests/corruption_tests.rs` pins the legacy and disk paths with
+  crafted files, and `vanedb/tests/vndb_graph_format.rs` pins the `VNDB` v2
+  graph reader against fixtures generated from its field table.
 - The C ABI routes every entry point through `catch_unwind`, so a panic returns
   an error rather than unwinding into a foreign frame.
 - SIMD kernels are checked against the scalar reference at every length from 0

--- a/conformance/graph/README.md
+++ b/conformance/graph/README.md
@@ -72,10 +72,11 @@ independently building the same input does today.
 
 - 1: Rust `rand` 0.10 `StdRng` seeded from the header, advanced by one level draw
   per stored slot. The section is empty.
-Encodings 2 and 3 are **reserved, not implemented**. No engine in this
-repository writes or reads them; they hold identifiers for a C++ writer so
-that one can be added without a version bump. A reader encountering them today
-rejects the file.
+The Rust engine reads, validates and preserves all three encodings — the
+fixtures cover 1, 2 and 3, and each round-trips byte for byte. Encodings 2 and
+3 exist so a C++ writer's RNG state survives a round trip through the Rust
+engine unchanged; no such writer exists in this repository yet, so nothing
+here emits them outside the fixtures.
 
 - 2: C++ libstdc++ MT19937 stream: 624 decimal u32 state words and a position
   in 0–624, separated by ASCII whitespace.
@@ -90,7 +91,8 @@ against the fixed fixtures and save/load continuation tests. If a future version
 requires a distinct, reproducible generator contract, assign a new continuation
 encoding and retain the reader for existing files; do not silently redefine it.
 
-Words contain decimal digits only. C++ seeds its fallback MT19937 from the
+Words contain decimal digits only. A C++ writer would seed its fallback
+MT19937 from the
 low 32 bits of the header seed, while preserving the full seed in the file.
 
 A reader restores its native continuation when supported. Otherwise it seeds

--- a/vanedb-py/src/lib.rs
+++ b/vanedb-py/src/lib.rs
@@ -128,7 +128,22 @@ fn batch_f32(obj: &Bound<'_, PyAny>, dim: usize) -> PyResult<(usize, Vec<f32>)> 
             "vectors must be a 2-D float32 buffer (e.g. numpy array) or a sequence of float sequences",
         )
     })?;
-    let mut flat = Vec::with_capacity(rows.len() * dim);
+    // `rows.len() * dim` on caller values. The constructor bounds `dim * 4`,
+    // which still leaves a dim large enough to wrap this product — and
+    // `with_capacity` panics rather than returning, so the failure escapes the
+    // documented ValueError model as a PanicException.
+    // `rows.len() * dim` floats, which `Vec<f32>` allocates as four times
+    // that many bytes. Both products must be valid: 2 * (2^62 - 1) fits in a
+    // usize and still asks for more than isize::MAX bytes, which
+    // `with_capacity` answers with a panic rather than an error — escaping the
+    // documented ValueError model as a PanicException.
+    let capacity = rows
+        .len()
+        .checked_mul(dim)
+        .and_then(|n| n.checked_mul(std::mem::size_of::<f32>()).map(|_| n))
+        .filter(|n| *n <= isize::MAX as usize / std::mem::size_of::<f32>())
+        .ok_or_else(|| PyValueError::new_err("rows * dim is too large to allocate"))?;
+    let mut flat = Vec::with_capacity(capacity);
     for row in &rows {
         if row.len() != dim {
             return Err(PyValueError::new_err(format!(

--- a/vanedb-py/tests/test_errors.py
+++ b/vanedb-py/tests/test_errors.py
@@ -141,14 +141,31 @@ def test_a_negative_k_or_ef_search_is_a_valueerror():
 
 
 def test_an_absurd_dimension_is_a_valueerror_not_a_panic():
-    """`rows * dim` overflowed into a capacity panic, escaping the error model.
-
-    `FlatIndex::new` accepted a dimension `ApproxIndexBuilder::build` rejects,
-    so the failure surfaced later as a PanicException rather than a ValueError.
-    """
+    """A dimension no constructor should accept."""
     with pytest.raises(ValueError):
         vanedb.FlatIndex(2**62, vanedb.Metric.L2)
     with pytest.raises(ValueError):
         vanedb.ApproxIndex(2**62, vanedb.Metric.L2)
     with pytest.raises(ValueError):
         vanedb.DiskIndexBuilder(2**62, vanedb.Metric.L2)
+
+
+def test_a_batch_whose_rows_times_dim_overflows_is_a_valueerror():
+    """The multiply happens after construction, so it needs its own case.
+
+    2**62 - 1 is the largest dimension the constructor accepts: `dim * 4` fits.
+    `rows * dim` does not, and `Vec::with_capacity` panics rather than
+    returning, so this escaped as a PanicException — which derives from
+    BaseException and slips past `except ValueError` and `except Exception`
+    alike. The earlier version of this test used 2**62 exactly, the one value
+    the constructor rejects, so it never reached the multiply it was named for.
+    """
+    dim = 2**62 - 1
+    for index in (
+        vanedb.FlatIndex(dim, vanedb.Metric.L2),
+        vanedb.ApproxIndex(dim, vanedb.Metric.L2, capacity=1),
+    ):
+        with pytest.raises(ValueError):
+            # A list of lists: the buffer fast paths take their length from
+            # the shape and never perform this multiply.
+            index.add_batch([0, 1], [[1.0], [1.0]])

--- a/vanedb/README.md
+++ b/vanedb/README.md
@@ -25,13 +25,14 @@ let hits = index.search(&query, 10)?;
 Distance kernels dispatch to NEON or AVX2 at runtime and fall back to a
 portable scalar path.
 
-Both formats are little-endian. `DiskIndex` writes `VNDB` v1, a specified,
-versioned format anchored to shared fixtures; either engine reads the other's
-file. `ApproxIndex::save` is engine-specific and not yet a stable public
-format — treat a saved graph as a way to avoid rebuilding, not as a system of
-record, until the `VNDB` graph payload lands. Its loader accepts the current
-version and the one before it; `DiskIndex` accepts `VNDB` v1 only, since there
-is no earlier version to accept.
+Both formats are little-endian and both are specified, with field tables and
+fixtures generated from those tables rather than from the engine, under
+`conformance/`. `DiskIndex` writes `VNDB` v1 and `ApproxIndex::save` writes
+`VNDB` v2. Legacy `HNSW` graph files still load.
+
+The disk format is cross-engine — either engine reads the other's file. The
+graph format is read by this engine only; the C++ engine reads its own legacy
+graph files.
 
 A header-only C++ implementation is maintained alongside this crate, with a
 cross-engine benchmark harness, in the

--- a/vanedb/src/approx/mod.rs
+++ b/vanedb/src/approx/mod.rs
@@ -267,6 +267,29 @@ impl ApproxIndex {
         self.dim
     }
 
+    /// Links a new node receives per layer. The layer-0 cap is `2 * m`.
+    ///
+    /// Reported for the same reason as [`metric`](Self::metric): a loaded
+    /// index read this from the file, and a caller that did not build it has
+    /// no other way to know what graph they are searching.
+    pub fn m(&self) -> usize {
+        self.m
+    }
+
+    /// Beam width used while building. Higher means a better graph, built
+    /// more slowly.
+    pub fn ef_construction(&self) -> usize {
+        self.ef_construction
+    }
+
+    /// The seed the level distribution was drawn from.
+    ///
+    /// Preserved across save and load, so a reloaded index continues building
+    /// the same graph it would have built had it never been written out.
+    pub fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// The metric this index ranks by.
     pub fn metric(&self) -> Metric {
         self.metric

--- a/vanedb/tests/vndb_graph_format.rs
+++ b/vanedb/tests/vndb_graph_format.rs
@@ -45,6 +45,27 @@ const FIXTURES: [&str; 13] = [
     "deleted_id_reuse.vndb",
 ];
 
+/// Every header value in `l2_rng1.vndb`, read from
+/// `conformance/graph/README.md`'s field table rather than from the engine.
+///
+/// This is the assertion the round-trip below cannot make. `load` then `save`
+/// compares the reader against the writer, so transposing two header fields in
+/// both directions reproduces the bytes exactly and passes — the very
+/// misreading an independently generated fixture exists to catch. Only
+/// comparing to the table catches it.
+#[test]
+fn the_header_matches_the_field_table() {
+    let index = ApproxIndex::load(fixture("l2_rng1.vndb")).unwrap();
+    assert_eq!(index.dimension(), 2, "dim, offset 16");
+    assert_eq!(index.len(), 3, "count, offset 24");
+    assert_eq!(index.capacity(), 4, "capacity hint, offset 32");
+    assert_eq!(index.m(), 2, "M, offset 40");
+    assert_eq!(index.ef_construction(), 16, "ef_construction, offset 48");
+    assert_eq!(index.get_ef_search(), 16, "ef_search, offset 56");
+    assert_eq!(index.seed(), 42, "seed, offset 64");
+    assert_eq!(index.metric(), Metric::L2, "metric, offset 12");
+}
+
 #[test]
 fn every_fixture_loads() {
     for name in FIXTURES {
@@ -210,22 +231,38 @@ fn a_truncated_file_is_rejected_at_every_length() {
 }
 
 #[test]
-fn an_absurd_dimension_is_rejected_before_allocating() {
-    // Offset 16 is dim. A few hundred bytes must not request terabytes.
+fn an_absurd_dimension_is_rejected() {
+    // Offset 16 is dim. A few hundred bytes must not describe terabytes.
+    // Named for what it asserts: that the file is refused. It does not
+    // observe whether an allocation was attempted first.
     let err = corrupt("l2_rng1.vndb", |b| {
         b[16..24].copy_from_slice(&(1u64 << 62).to_le_bytes())
     });
-    assert!(!format!("{err}").is_empty());
+    assert!(format!("{err}").contains("dimension"), "got: {err}");
 }
 
 #[test]
 fn a_count_larger_than_the_file_is_rejected() {
-    // Offset 24 is the stored slot count. It must be cross-checked against
-    // the bytes actually present, not trusted.
+    // Offset 24 is the stored slot count, cross-checked against the bytes
+    // actually present. A count of u64::MAX would trip the MAX_ELEMENTS cap
+    // first and never reach that check, so this uses a value that is small
+    // enough to be plausible and still larger than the file can hold.
+    let err = corrupt("l2_rng1.vndb", |b| {
+        b[24..32].copy_from_slice(&1000u64.to_le_bytes())
+    });
+    let text = format!("{err}");
+    assert!(
+        !text.contains("exceeds") && !text.contains("limit"),
+        "should fail the file-size cross-check, not the element cap: {text}"
+    );
+}
+
+#[test]
+fn a_count_beyond_the_element_cap_is_rejected() {
     let err = corrupt("l2_rng1.vndb", |b| {
         b[24..32].copy_from_slice(&u64::MAX.to_le_bytes())
     });
-    assert!(!format!("{err}").is_empty());
+    assert!(!format!("{err}").is_empty(), "must reject");
 }
 
 #[test]
@@ -250,7 +287,7 @@ fn two_live_slots_with_the_same_id_are_rejected() {
         b[SLOT1_DELETED..SLOT1_DELETED + 4].copy_from_slice(&0u32.to_le_bytes())
     });
     assert!(
-        format!("{err}").contains("duplicate"),
+        format!("{err}").contains("duplicate live"),
         "two live slots sharing an id must be rejected, got: {err}"
     );
 }


### PR DESCRIPTION
The sign-off review showed one of its four mutations still escaped: **transpose `m` and `ef_construction` in writer and reader together, and all 235 tests pass** — while the engine reads every spec fixture with two header fields swapped.

### The cause is structural, and it was mine
The byte-reproduction test does `load → save → compare`. That is a round trip **through the reader**, so any reader/writer-symmetric misreading reproduces the bytes exactly and is invisible by construction.

`vndb_format.rs` (disk) builds its content *from the spec* and compares to the fixture. My graph test claimed in its own module doc to match it, and was weaker in exactly the dimension independently-generated fixtures exist to protect. Its read direction asserted only `dimension()` and `metric()`; the legacy fixtures pin every field.

`the_header_matches_the_field_table` now pins dim, count, capacity, m, ef_construction, ef_search, seed and metric against `conformance/graph/README.md`.

```
1. VERSION 2->7                     1 failing
2. transpose m / ef_construction    1 failing   <- was 0
3. delete duplicate-live-ID guard   1 failing
4. delete trailing-bytes guard      1 failing
```

That required `m()`, `ef_construction()` and `seed()` on `ApproxIndex` — added for the same reason as `metric()`: a loaded index read them from the file.

### I introduced a false claim while removing one
The paragraph I wrote said RNG encodings 2 and 3 are "reserved, not implemented". **Six of thirteen fixtures use them**, `check_rng` parses and validates them, and the same commit's tests assert they round-trip. The truth is narrower: this engine reads and preserves all three; no C++ writer exists here to emit 2 or 3.

The crate README also still carried the disclaimer removed from `lib.rs`, so the page crates.io renders contradicted the docs beside it.

### Four inert assertions
`!format!("{err}").is_empty()` is true of every error, so those tests proved rejection but never the reason — they name it now. `a_count_larger_than_the_file_is_rejected` tripped the element cap before reaching the file-size check its comment described; it now uses a plausible count and asserts which check fired, with the cap case split out.

**237 Rust tests pass**; fmt and clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H