### PR TITLE
release: stamp 0.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ vanedb-py/python/vanedb/*.dylib
 *.bin
 # Test fixtures are the exception: a committed byte file is the whole point of
 # a format-compatibility test, and `*.bin` above silently ate the first one.
-!vanedb/tests/fixtures/*.bin
+!vanedb/tests/fixtures/**/*.bin
 !conformance/**/*.bin
 
 # Swept in by `git add -A` and never intentional: stray shell redirects,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This
 project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html); until
 1.0.0, breaking changes may land in a minor release.
 
-## [Unreleased]
+## [0.1.0] - 2026-09-07
 
-Nothing has been published yet, so there is no released version to diff
-against. This section records what the first release will contain.
+The first release. There is no earlier version to diff against, so this
+section records what it contains rather than what changed.
 
 ### Security
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1221,7 +1221,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vanedb"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 dependencies = [
  "bincode",
  "criterion",
@@ -1236,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "vanedb-capi"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 dependencies = [
  "cbindgen",
  "vanedb",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "vanedb-py"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "vanedb-wasm"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",

--- a/bench/Cargo.lock
+++ b/bench/Cargo.lock
@@ -883,7 +883,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vanedb"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 dependencies = [
  "bincode",
  "memmap2",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "vanedb-capi"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 dependencies = [
  "cbindgen",
  "vanedb",

--- a/bench/tests/release_identity.rs
+++ b/bench/tests/release_identity.rs
@@ -78,6 +78,16 @@ fn declared_versions() -> Vec<(&'static str, String)> {
         .to_string();
     sites.push(("cpp/src/core/version.h VERSION_STRING", string));
 
+    // Doxygen renders this on the generated C++ docs. A free-form string, so
+    // it can spell a prerelease and must match in full; it read "0.1.0"
+    // throughout the 0.1.0-rc.1 period without anything noticing.
+    let doxygen = read("cpp/Doxyfile")
+        .lines()
+        .find_map(|l| l.split_once("PROJECT_NUMBER")?.1.split('"').nth(1))
+        .expect("cpp/Doxyfile declares PROJECT_NUMBER")
+        .to_string();
+    sites.push(("cpp/Doxyfile PROJECT_NUMBER", doxygen));
+
     sites
 }
 

--- a/bench/tests/release_identity.rs
+++ b/bench/tests/release_identity.rs
@@ -1,0 +1,164 @@
+//! Every place the release version is written must agree.
+//!
+//! The version lives in eight hand-maintained places across four languages,
+//! and nothing compared them. Stamping 0.1.0 updated seven and missed
+//! `cpp/src/core/version.h`, whose `VERSION_STRING` is what the C++ Python
+//! module reports as `__version__`. CI caught it, but only on one of the
+//! fifty-odd jobs, and only because that binding happens to compare its
+//! `__version__` against its wheel metadata.
+//!
+//! The cost of missing one is not symmetric with the cost of checking. Both
+//! publish workflows gate a tag on `vanedb/Cargo.toml`, so a stale value
+//! elsewhere does not stop the release — it ships inside it, and a published
+//! version cannot be recalled.
+//!
+//! `cpp/CMakeLists.txt` is the one site that cannot carry a prerelease
+//! suffix: CMake's `project(VERSION)` accepts only numeric components. It is
+//! checked against the release core alone.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("bench/ has a parent")
+        .to_path_buf()
+}
+
+fn read(rel: &str) -> String {
+    let path = repo_root().join(rel);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("{rel} must be readable: {e}"))
+}
+
+/// The value of the first `version = "..."` key in a TOML file. Naive on
+/// purpose: it must find the `[package]` version, which is always first in
+/// this repo's manifests, and never a dependency's.
+fn toml_version(rel: &str) -> String {
+    read(rel)
+        .lines()
+        .find_map(|line| {
+            let rest = line
+                .strip_prefix("version")?
+                .trim_start()
+                .strip_prefix('=')?;
+            Some(rest.trim().trim_matches('"').to_string())
+        })
+        .unwrap_or_else(|| panic!("{rel} declares no version"))
+}
+
+/// The numeric part, dropping any prerelease suffix. Used ONLY for the two
+/// sites that cannot express one — never to compare two sites that can, or a
+/// leftover `-rc.1` becomes invisible, which is the exact bug this file
+/// exists to catch.
+fn release_core(version: &str) -> &str {
+    version.split_once('-').map_or(version, |(core, _)| core)
+}
+
+/// Every site that states the release version, as (what it is, the value).
+fn declared_versions() -> Vec<(&'static str, String)> {
+    let mut sites: Vec<(&'static str, String)> = [
+        "vanedb/Cargo.toml",
+        "vanedb-py/Cargo.toml",
+        "vanedb-capi/Cargo.toml",
+        "vanedb-wasm/Cargo.toml",
+        "vanedb-py/pyproject.toml",
+        "cpp/pyproject.toml",
+    ]
+    .iter()
+    .map(|rel| (*rel, toml_version(rel)))
+    .collect();
+
+    // The C++ engine reports this as `vanedb_cpp.__version__`.
+    let header = read("cpp/src/core/version.h");
+    let string = header
+        .lines()
+        .find_map(|l| l.split_once("VERSION_STRING = ")?.1.split('"').nth(1))
+        .expect("version.h declares VERSION_STRING")
+        .to_string();
+    sites.push(("cpp/src/core/version.h VERSION_STRING", string));
+
+    sites
+}
+
+/// Sites that are integers or CMake components, so they can never carry a
+/// prerelease suffix. Compared against the release core.
+fn core_only_sites() -> Vec<(&'static str, String)> {
+    let header = read("cpp/src/core/version.h");
+    // The header's numeric components, which drift independently of its string.
+    let mut sites = Vec::new();
+    let component = |name: &str| -> String {
+        header
+            .lines()
+            .find_map(|l| {
+                let rest = l.split_once(&format!("{name} = "))?.1;
+                Some(rest.trim_end_matches(';').trim().to_string())
+            })
+            .unwrap_or_else(|| panic!("version.h declares no {name}"))
+    };
+    sites.push((
+        "cpp/src/core/version.h components",
+        format!(
+            "{}.{}.{}",
+            component("VERSION_MAJOR"),
+            component("VERSION_MINOR"),
+            component("VERSION_PATCH")
+        ),
+    ));
+
+    sites
+}
+
+#[test]
+fn every_declared_version_agrees() {
+    let sites = declared_versions();
+    let core_only = core_only_sites();
+    assert!(
+        sites.len() + core_only.len() >= 8,
+        "only {} version sites found; the extractor is probably broken",
+        sites.len() + core_only.len()
+    );
+
+    // `vanedb/Cargo.toml` is what both publish workflows gate the tag on, so
+    // it is the reference the others must match.
+    let (_, expected) = &sites[0];
+    let mut disagreeing: Vec<String> = sites
+        .iter()
+        // Compared in full: every one of these can spell a prerelease, so a
+        // stale suffix must show up as a difference.
+        .filter(|(_, v)| v != expected)
+        .map(|(what, v)| format!("{what} says {v}, expected {expected}"))
+        .collect();
+    disagreeing.extend(
+        core_only
+            .iter()
+            .filter(|(_, v)| v != release_core(expected))
+            .map(|(what, v)| format!("{what} says {v}, expected {}", release_core(expected))),
+    );
+    assert!(
+        disagreeing.is_empty(),
+        "the release version disagrees across sites:\n  {}",
+        disagreeing.join("\n  ")
+    );
+}
+
+#[test]
+fn the_cmake_project_version_matches_the_release_core() {
+    // `project(vanedb VERSION 0.1.0 ...)`. CMake takes numeric components
+    // only, so it can never carry `-rc.1`; the core still has to agree.
+    let cmake = read("cpp/CMakeLists.txt");
+    let declared = cmake
+        .lines()
+        // Anchored to `project(`: line 1 is `cmake_minimum_required(VERSION
+        // 3.20)`, which a bare search for "VERSION " finds first.
+        .find(|l| l.trim_start().starts_with("project("))
+        .and_then(|l| l.split_once("VERSION ")?.1.split_whitespace().next())
+        .expect("cpp/CMakeLists.txt declares a project VERSION")
+        .to_string();
+    let crate_version = toml_version("vanedb/Cargo.toml");
+    assert_eq!(
+        declared,
+        release_core(&crate_version),
+        "cpp/CMakeLists.txt project VERSION must match the release core"
+    );
+}

--- a/cpp/CHANGELOG.md
+++ b/cpp/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Coverage reporting now excludes test and benchmark files (measures only production code)
 - Division by zero in DiskIndex when loading corrupted file with dim=0
 
-## [0.1.0] - Unreleased
+## [0.1.0] - 2026-09-07
 
 ### Added
 - Core distance functions with SIMD optimization (ARM NEON, x86 AVX2)

--- a/cpp/docs/GUIDE.md
+++ b/cpp/docs/GUIDE.md
@@ -140,7 +140,7 @@ import vanedb_cpp as vanedb
 import numpy as np
 
 # Check version
-print(vanedb.__version__)  # "0.1.0-rc.1"
+print(vanedb.__version__)  # "0.1.0"
 
 # === HNSW ApproxIndex (approximate, fastest for large datasets) ===
 index = vanedb.ApproxIndex(128, vanedb.Metric.COSINE)

--- a/cpp/pyproject.toml
+++ b/cpp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vanedb-cpp"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 description = "Supplementary C++ Python bindings for VaneDB"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/cpp/src/core/version.h
+++ b/cpp/src/core/version.h
@@ -15,7 +15,7 @@ constexpr int VERSION_MINOR = 1;
 constexpr int VERSION_PATCH = 0;
 
 /// Full version string
-constexpr const char* VERSION_STRING = "0.1.0-rc.1";
+constexpr const char* VERSION_STRING = "0.1.0";
 
 /**
  * @brief Returns the version as a single integer for comparison.

--- a/vanedb-capi/Cargo.toml
+++ b/vanedb-capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vanedb-capi"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 edition = "2021"
 # Bound by bincode 2.x, the newest runtime dependency. CI checks it.
 rust-version = "1.85"

--- a/vanedb-py/Cargo.toml
+++ b/vanedb-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vanedb-py"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 edition = "2021"
 # Bound by bincode 2.x, the newest runtime dependency. CI checks it.
 rust-version = "1.85"

--- a/vanedb-py/pyproject.toml
+++ b/vanedb-py/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 
 [project]
 name = "vanedb"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 description = "Embeddable vector database for edge AI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/vanedb-py/tests/test_vanedb.py
+++ b/vanedb-py/tests/test_vanedb.py
@@ -9,7 +9,8 @@ def test_version():
     # Compared against the distribution's own metadata rather than a literal:
     # a literal has to be edited on every bump, and silently passed while
     # __version__ and the wheel metadata disagreed. Version() normalises, so
-    # the SemVer spelling (0.1.0-rc.1) and the PEP 440 one (0.1.0rc1) match.
+    # the SemVer and PEP 440 spellings of a prerelease (0.1.0-rc.1 and
+    # 0.1.0rc1) compare equal.
     from importlib.metadata import version
 
     from packaging.version import Version

--- a/vanedb-wasm/Cargo.toml
+++ b/vanedb-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vanedb-wasm"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 edition = "2021"
 # Bound by bincode 2.x, the newest runtime dependency. CI checks it.
 rust-version = "1.85"

--- a/vanedb/Cargo.toml
+++ b/vanedb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vanedb"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 edition = "2021"
 # Bound by bincode 2.x, the newest runtime dependency. CI checks it.
 rust-version = "1.85"


### PR DESCRIPTION
Moves every version from `0.1.0-rc.1` to `0.1.0`. **This publishes nothing** —
both publish workflows trigger only on tags (`vanedb-crate-v*`, `vanedb-v*`)
or manual dispatch, never on a push to a branch.

It has to land first, because `validate-version` in both workflows refuses a
tag whose suffix does not match `vanedb/Cargo.toml`:

```
if version != expected:
    raise SystemExit(f"tag expects {expected}, crate version is {version}")
```

and separately requires the tag to point at a commit on `main`.

## What moves

| | from | to |
|---|---|---|
| `vanedb`, `vanedb-py`, `vanedb-capi`, `vanedb-wasm` | 0.1.0-rc.1 | 0.1.0 |
| `vanedb-py/pyproject.toml`, `cpp/pyproject.toml` | 0.1.0-rc.1 | 0.1.0 |
| `Cargo.lock`, `bench/Cargo.lock` | 0.1.0-rc.1 | 0.1.0 |
| `CHANGELOG.md` | `## [Unreleased]` | `## [0.1.0] - 2026-09-07` |

The C++ package moves too, even though #100 stopped publishing it, because one
commit identifies both engines.

`test_version` needed no edit — it compares `__version__` against the
distribution's own metadata rather than a literal, which is exactly why it did
not silently pass through this bump.

## Two things to check before merging

**The changelog date is today's.** If you tag on a different day, change it.

**This is the last commit before an irreversible step.** Tagging publishes to
crates.io and PyPI, and a published version cannot be recalled — only yanked.
The names `vanedb` on both registries were unclaimed when I last checked, so
the first publish also claims them. That step is yours; I have not run it and
will not.

## Verification

242 Rust, 30 bench, 80 Python tests pass; fmt and clippy clean on both
workspaces; the built wheel reports `vanedb-0.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H
