### PR TITLE
fix: reject a VNDB v1 header that understates the payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ section records what it contains rather than what changed.
 - `ApproxIndex::load` multiplied file-controlled values without checking, so a
   497-byte file could wrap the product to zero and load with absurd
   parameters, or panic on a path documented to return an error.
+- `DiskIndex::open` checked only that the file was not *shorter* than its
+  header declared. The expected length is derived from that same header, so a
+  header understating the geometry moved the goalpost instead of tripping the
+  guard: one flipped bit in `dim` read the payload at the wrong stride and
+  `get` returned a vector straddling two stored records. Both engines now
+  require exact equality, and both bound `dim` independently so an empty store
+  cannot declare an unaddressable dimension. The format carries no checksum, so
+  `DiskIndex::open` documents what remains undetectable.
 - `DiskIndex::open` accepted files with duplicate ids, after which `size`
   disagreed with lookups, `get` returned a row the id did not name, and a
   single search could return one id twice. Both engines now reject them.

--- a/bench/tests/cross_engine_format.rs
+++ b/bench/tests/cross_engine_format.rs
@@ -182,9 +182,13 @@ fn both_engines_accept_and_reject_exactly_the_same_files() {
     );
     let original = std::fs::read(&good).unwrap();
 
-    // Header bits, then a few payload bits, then the two length edges.
+    // Header bits, then payload bits from BOTH payload regions, then the two
+    // length edges. The ids occupy [32, 32 + N*8) and the vectors follow, so
+    // sampling only low offsets tests ids and never a vector component.
+    let ids_end = 32 + N * 8;
+    let sampled: Vec<usize> = vec![32, 40, 80, 100, ids_end, ids_end + 4, ids_end + 64];
     let mut cases: Vec<(String, Vec<u8>)> = Vec::new();
-    for byte in (0..32usize).chain([32, 40, 80, 100]) {
+    for byte in (0..32usize).chain(sampled.iter().copied()) {
         for bit in 0..8u32 {
             let mut bytes = original.clone();
             bytes[byte] ^= 1 << bit;
@@ -223,6 +227,8 @@ fn both_engines_accept_and_reject_exactly_the_same_files() {
         verdict.insert(name.clone(), rust_ok);
         let _ = std::fs::remove_file(&path);
     }
+    // Cleanup happens before the assertions on purpose: a failing run should
+    // leave nothing behind, and the failure message carries everything needed.
     let _ = std::fs::remove_dir_all(&dir);
 
     // The claim this test exists for.
@@ -277,7 +283,7 @@ fn both_engines_accept_and_reject_exactly_the_same_files() {
     // checksum, so at least one payload flip is a valid file to both engines.
     // `DiskIndex::open`'s Integrity section says so; this keeps that honest
     // rather than letting the doc drift into promising more than it delivers.
-    let payload_accepted = [32usize, 40, 80, 100]
+    let payload_accepted = sampled
         .iter()
         .flat_map(|byte| (0..8u32).map(move |bit| format!("flip_{byte}_{bit}")))
         .filter(|name| verdict[name])
@@ -287,4 +293,127 @@ fn both_engines_accept_and_reject_exactly_the_same_files() {
         "no payload flip was accepted -- if the format gained a checksum, \
          the Integrity section in disk.rs must be updated to say so"
     );
+}
+
+/// Not every component flip survives, which is why the Integrity section says a
+/// component flip is "usually" returned rather than "returned".
+///
+/// Constructed rather than sampled: whether a flip produces an infinity depends
+/// on the component's exponent bits, so a sweep over an arbitrary workload may
+/// or may not contain one. `1.0f32` is `0x3F800000`; setting bit 30 fills the
+/// exponent and gives `+inf`, which both readers reject.
+#[test]
+fn a_component_flip_that_produces_an_infinity_is_rejected_by_both() {
+    let dir = std::env::temp_dir().join(format!("vanedb-inf-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let good = dir.join("good.vndb");
+    let c_good = CString::new(good.to_str().unwrap()).unwrap();
+    let ids = [7u64];
+    let vectors = [1.0f32; DIM];
+    // SAFETY: both buffers hold exactly the lengths declared.
+    assert_eq!(
+        unsafe {
+            ffi::vanedb_rs_disk_build(c_good.as_ptr(), DIM, 0, ids.as_ptr(), vectors.as_ptr(), 1)
+        },
+        0
+    );
+
+    let mut bytes = std::fs::read(&good).unwrap();
+    let first_component = 32 + 8; // one id, then the vectors
+    assert_eq!(
+        f32::from_le_bytes(
+            bytes[first_component..first_component + 4]
+                .try_into()
+                .unwrap()
+        ),
+        1.0
+    );
+    bytes[first_component + 3] ^= 0x40; // bit 30: 0x3F800000 -> 0x7F800000
+    assert!(f32::from_le_bytes(
+        bytes[first_component..first_component + 4]
+            .try_into()
+            .unwrap()
+    )
+    .is_infinite());
+
+    let bad = dir.join("inf.vndb");
+    std::fs::write(&bad, &bytes).unwrap();
+    let c_bad = CString::new(bad.to_str().unwrap()).unwrap();
+
+    // SAFETY: this test owns the file and never mutates it while mapped.
+    assert!(
+        unsafe { vanedb::DiskIndex::open(&bad) }.is_err(),
+        "an infinite component must be rejected"
+    );
+    // SAFETY: same file.
+    let handle = unsafe { ffi::vanedb_cpp_disk_open(c_bad.as_ptr()) };
+    if !handle.is_null() {
+        // SAFETY: non-null handle from the matching constructor.
+        unsafe { ffi::vanedb_cpp_disk_free(handle) };
+        panic!("the C++ reader accepted an infinite component");
+    }
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The same agreement, on an empty store.
+///
+/// Separate because an empty store is 32 bytes whatever its `dim`, so
+/// `expected` is 32 for every dimension and the length check cannot see the
+/// field at all. That is the shape the non-empty sweep structurally cannot
+/// reach, and it is where the two readers last disagreed: C++ bounds `dim`
+/// unconditionally, while Rust derived its only bound from a product that is
+/// zero when `num_vectors` is zero, so `dim = 2^62` was a file one engine read
+/// and the other refused.
+#[test]
+fn both_engines_agree_on_an_empty_store_too() {
+    let dir = std::env::temp_dir().join(format!("vanedb-agree-empty-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let good = dir.join("empty.vndb");
+    let c_good = CString::new(good.to_str().unwrap()).unwrap();
+    // SAFETY: n is 0, so the null id/vector pointers are never read.
+    assert_eq!(
+        unsafe {
+            ffi::vanedb_rs_disk_build(c_good.as_ptr(), 4, 0, std::ptr::null(), std::ptr::null(), 0)
+        },
+        0
+    );
+    let original = std::fs::read(&good).unwrap();
+    assert_eq!(original.len(), 32, "an empty store is header-only");
+
+    let mut disagreements = Vec::new();
+    for byte in 8..24usize {
+        for bit in 0..8u32 {
+            let mut bytes = original.clone();
+            bytes[byte] ^= 1 << bit;
+            let path = dir.join(format!("e_{byte}_{bit}.vndb"));
+            std::fs::write(&path, &bytes).unwrap();
+            let c_path = CString::new(path.to_str().unwrap()).unwrap();
+
+            // SAFETY: this test owns the file and never mutates it while mapped.
+            let rust_ok = unsafe { vanedb::DiskIndex::open(&path) }.is_ok();
+            // SAFETY: same file; the handle is freed before the next iteration.
+            let handle = unsafe { ffi::vanedb_cpp_disk_open(c_path.as_ptr()) };
+            let cpp_ok = !handle.is_null();
+            if cpp_ok {
+                // SAFETY: non-null handle from the matching constructor.
+                unsafe { ffi::vanedb_cpp_disk_free(handle) };
+            }
+            if rust_ok != cpp_ok {
+                disagreements.push(format!(
+                    "byte {byte} bit {bit}: rust={rust_ok} cpp={cpp_ok}"
+                ));
+            }
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+    assert!(
+        disagreements.is_empty(),
+        "the engines disagree on an empty store: {disagreements:?}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
 }

--- a/bench/tests/cross_engine_format.rs
+++ b/bench/tests/cross_engine_format.rs
@@ -148,3 +148,143 @@ fn rust_reads_cpp_with_metric(metric: u32, name: &str) {
     }
     let _ = std::fs::remove_file(&file);
 }
+
+/// Both engines must reject exactly the same corrupt files.
+///
+/// A shared format is only shared if its readers agree on what is valid.
+/// Cross-loading proves they agree on *good* files; nothing proved they agree
+/// on bad ones, and they did not: both carried a one-sided `file_size <
+/// expected` check that accepted a header understating the geometry, and
+/// fixing one engine without the other would have been a silent divergence —
+/// a file one engine reads and the other refuses.
+///
+/// The sweep covers every single-bit flip in the 32-byte header plus a sample
+/// of payload bits, so it also pins what the format deliberately does *not*
+/// catch: with no checksum, a flipped payload bit is valid to both engines,
+/// and a metric flip that lands on another defined metric is a valid file.
+/// `DiskIndex::open`'s Integrity section says exactly this; the counts here
+/// are what make that statement checkable.
+#[test]
+fn both_engines_accept_and_reject_exactly_the_same_files() {
+    let (ids, vectors) = workload();
+    let dir = std::env::temp_dir().join(format!("vanedb-agree-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let good = dir.join("good.vndb");
+    let c_good = CString::new(good.to_str().unwrap()).unwrap();
+    // SAFETY: buffers outlive the call and the lengths match `ids`/`vectors`.
+    assert_eq!(
+        unsafe {
+            ffi::vanedb_rs_disk_build(c_good.as_ptr(), DIM, 0, ids.as_ptr(), vectors.as_ptr(), N)
+        },
+        0
+    );
+    let original = std::fs::read(&good).unwrap();
+
+    // Header bits, then a few payload bits, then the two length edges.
+    let mut cases: Vec<(String, Vec<u8>)> = Vec::new();
+    for byte in (0..32usize).chain([32, 40, 80, 100]) {
+        for bit in 0..8u32 {
+            let mut bytes = original.clone();
+            bytes[byte] ^= 1 << bit;
+            cases.push((format!("flip_{byte}_{bit}"), bytes));
+        }
+    }
+    let mut longer = original.clone();
+    longer.push(0);
+    cases.push(("trailing_byte".into(), longer));
+    cases.push((
+        "truncated_byte".into(),
+        original[..original.len() - 1].to_vec(),
+    ));
+    cases.push(("pristine".into(), original.clone()));
+
+    let mut disagreements = Vec::new();
+    let mut verdict = std::collections::HashMap::new();
+    for (name, bytes) in &cases {
+        let path = dir.join(format!("{name}.vndb"));
+        std::fs::write(&path, bytes).unwrap();
+        let c_path = CString::new(path.to_str().unwrap()).unwrap();
+
+        // SAFETY: this test owns the file and never mutates it while mapped.
+        let rust_ok = unsafe { vanedb::DiskIndex::open(&path) }.is_ok();
+        // SAFETY: same file; the handle is freed before the next iteration.
+        let cpp_handle = unsafe { ffi::vanedb_cpp_disk_open(c_path.as_ptr()) };
+        let cpp_ok = !cpp_handle.is_null();
+        if cpp_ok {
+            // SAFETY: non-null handle from the matching constructor.
+            unsafe { ffi::vanedb_cpp_disk_free(cpp_handle) };
+        }
+
+        if rust_ok != cpp_ok {
+            disagreements.push(format!("{name}: rust={rust_ok} cpp={cpp_ok}"));
+        }
+        verdict.insert(name.clone(), rust_ok);
+        let _ = std::fs::remove_file(&path);
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+
+    // The claim this test exists for.
+    assert!(
+        disagreements.is_empty(),
+        "the engines disagree on {} of {} files: {disagreements:?}",
+        disagreements.len(),
+        cases.len()
+    );
+
+    // What the readers must reject: every bit of magic, version, dim and
+    // num_vectors, and the reserved word. `dim` and `num_vectors` are the
+    // fields the payload length is derived from, so a flip there makes the
+    // header disagree with the file in one direction or the other -- which is
+    // exactly what a one-sided length check missed.
+    let structural = (0..8usize).chain(8..24).chain(28..32);
+    for byte in structural {
+        for bit in 0..8u32 {
+            let name = format!("flip_{byte}_{bit}");
+            assert!(
+                !verdict[&name],
+                "{name} changes the file's shape and must be rejected by both engines"
+            );
+        }
+    }
+
+    // The metric field is the one header byte where a flip can produce a
+    // structurally valid file: 0 -> 1 and 0 -> 2 are other defined metrics.
+    // Nothing in the format records which one was intended, so both engines
+    // accept them and answer with a different distance function.
+    assert!(verdict["flip_24_0"], "L2 -> Cosine is a valid file");
+    assert!(verdict["flip_24_1"], "L2 -> Dot is a valid file");
+    for bit in 2..8u32 {
+        assert!(
+            !verdict[&format!("flip_24_{bit}")],
+            "an undefined metric value must be rejected"
+        );
+    }
+
+    // Both length edges, which is the equality check itself.
+    assert!(verdict["pristine"]);
+    assert!(
+        !verdict["truncated_byte"],
+        "a byte short of its declared geometry"
+    );
+    assert!(
+        !verdict["trailing_byte"],
+        "a byte past its declared geometry -- the direction `<` missed"
+    );
+
+    // And what the format deliberately does not protect: it carries no
+    // checksum, so at least one payload flip is a valid file to both engines.
+    // `DiskIndex::open`'s Integrity section says so; this keeps that honest
+    // rather than letting the doc drift into promising more than it delivers.
+    let payload_accepted = [32usize, 40, 80, 100]
+        .iter()
+        .flat_map(|byte| (0..8u32).map(move |bit| format!("flip_{byte}_{bit}")))
+        .filter(|name| verdict[name])
+        .count();
+    assert!(
+        payload_accepted > 0,
+        "no payload flip was accepted -- if the format gained a checksum, \
+         the Integrity section in disk.rs must be updated to say so"
+    );
+}

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -102,7 +102,20 @@ All fields are little-endian. The header is exactly 32 bytes:
 | 28 | 4 | reserved | `0` |
 
 The header is followed by `count` ids (`u64` each), then `count * dim` vector
-components (`f32` each), in the same order as the ids.
+components (`f32` each), in the same order as the ids. No padding or trailing
+bytes are allowed: the file length is exactly `32 + count * 8 + count * dim * 4`,
+and both loaders reject any other length in either direction.
+
+**Length equality is a loader rule, not just a writer rule.** A one-sided
+"shorter than declared" check leaves a header that *understates* the geometry
+accepted, because the expected length is derived from the header being checked:
+one flipped bit in `dim` reads the payload at the wrong stride, and `get`
+returns a vector that straddles two stored records. Equality does not make the
+geometry tamper-proof — `32 + count * (8 + 4 * dim)` is the same for every
+`(dim, count)` on that curve, and a header-only file (`count = 0`) fixes no
+dimension at all — so a loader must also reject a `dim` too large to address,
+which is what keeps the two engines agreeing on an empty store. Full integrity
+needs a checksum, which v1 does not carry.
 
 **Ids must be unique.** Both loaders reject a file where they are not, on the
 same rule the HNSW payload uses above: the id map must end up the same size as

--- a/cpp/CHANGELOG.md
+++ b/cpp/CHANGELOG.md
@@ -36,6 +36,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Combined dim*num_vectors overflow test
 
 ### Fixed
+- `DiskIndex` accepted a file whose header understated its geometry. The
+  expected length is computed from the header, so `file_size_ < expected` could
+  not catch a header claiming a smaller `dim` or `count` than the file holds;
+  the payload was then read at the wrong stride and `get` returned a vector
+  straddling two stored records. Now requires exact equality, matching the Rust
+  reader and the VNDB v1 spec. A defect fix in the engine, not a feature port:
+  both readers of a shared format must reject the same files, and
+  `bench/tests/cross_engine_format.rs` now asserts that over a bit sweep.
 - Windows file locking issue in mmap tests (scope store before file removal)
 - Type consistency in test file format (uint64_t for dimension field)
 - Coverage reporting now excludes test and benchmark files (measures only production code)

--- a/cpp/src/core/disk_index.h
+++ b/cpp/src/core/disk_index.h
@@ -110,7 +110,19 @@ public:
       cleanup(); throw std::runtime_error("File corrupted: size overflow");
     }
     size_t expected = HEADER_SIZE + ids_size + vecs_size;
-    if (file_size_ < expected) { cleanup(); throw std::runtime_error("File truncated"); }
+    // Equality, not `>=`. `expected` is derived from the header, so a one-sided
+    // check lets a header that understates the geometry move the goalpost
+    // instead of tripping the guard: one flipped bit in `dim` shrinks
+    // `expected` below the real length, the payload is read at the wrong
+    // stride, and `get` returns a vector straddling two stored records. `save`
+    // writes header + ids + vectors and nothing else, in both engines, so any
+    // conforming VNDB v1 file matches exactly.
+    if (file_size_ != expected) {
+      cleanup();
+      throw std::runtime_error(file_size_ < expected
+                                   ? "File truncated"
+                                   : "File longer than its header declares");
+    }
 
     ids_ptr_ = reinterpret_cast<const uint64_t*>(static_cast<const uint8_t*>(mapped_) + HEADER_SIZE);
     vectors_ptr_ = reinterpret_cast<const float*>(

--- a/cpp/tests/test_vndb_format_conformance.cpp
+++ b/cpp/tests/test_vndb_format_conformance.cpp
@@ -10,6 +10,7 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <filesystem>
 #include <fstream>
 #include <iterator>
 #include <string>
@@ -117,8 +118,12 @@ TEST_CASE("a header that disagrees with the file length is rejected in both dire
                                    std::istreambuf_iterator<char>());
   REQUIRE(original.size() == 32 + IDS.size() * 8 + IDS.size() * DIM * 4);
 
+  // The system temp directory, not the fixture tree. `temp_path_for` keeps a
+  // file beside its destination so a save can rename same-filesystem; there is
+  // no rename here, and writing into the committed fixture directory makes a
+  // read-only checkout fail and leaves .tmp files behind on an aborted run.
   const std::string path = vanedb::detail::temp_path_for(
-      std::string(VANEDB_CONFORMANCE_DIR) + "/../vndb_geometry_flip");
+      (std::filesystem::temp_directory_path() / "vndb_geometry_flip").string());
 
   std::vector<std::string> accepted;
   for (size_t byte = 8; byte < 24; ++byte) {
@@ -143,8 +148,14 @@ TEST_CASE("a header that disagrees with the file length is rejected in both dire
     }
   }
 
+  // Not INFO in a loop: a Catch2 scoped message is destroyed at the end of the
+  // iteration that created it, so the list would be gone before REQUIRE runs
+  // and a regression would report only "false". Build the diagnostic into the
+  // assertion itself, as the Rust twin does.
+  std::string detail;
   for (const auto& a : accepted) {
-    INFO("accepted: " << a);
+    detail += "\n  " + a;
   }
+  INFO("accepted " << accepted.size() << " flip(s):" << detail);
   REQUIRE(accepted.empty());
 }

--- a/cpp/tests/test_vndb_format_conformance.cpp
+++ b/cpp/tests/test_vndb_format_conformance.cpp
@@ -9,10 +9,13 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <cstdint>
+#include <cstdio>
 #include <fstream>
+#include <iterator>
 #include <string>
 #include <vector>
 
+#include "core/detail/file_utils.h"
 #include "core/disk_index.h"
 
 namespace {
@@ -94,4 +97,54 @@ TEST_CASE("writing the same content reproduces the VNDB fixture byte for byte",
     }
     std::remove(out.c_str());
   }
+}
+
+TEST_CASE("a header that disagrees with the file length is rejected in both directions",
+          "[vndb]") {
+  // `expected` is derived from the header, so a one-sided `file_size_ <
+  // expected` check lets a header that UNDERSTATES the geometry move the
+  // goalpost rather than trip the guard: the payload is then read at the wrong
+  // stride and `get` returns a vector straddling two stored records.
+  //
+  // `dim` (offsets 8..16) and `num_vectors` (16..24) are the only fields the
+  // length is computed from. Every flip in them makes the header disagree with
+  // the file, so none may be accepted. The Rust reader asserts the same thing
+  // over the same fixture layout (`corruption_tests.rs`), which is the point:
+  // both readers of VNDB v1 must reject exactly the same shapes.
+  std::ifstream in(fixture("v1_l2.vndb"), std::ios::binary);
+  REQUIRE(in);
+  const std::vector<char> original((std::istreambuf_iterator<char>(in)),
+                                   std::istreambuf_iterator<char>());
+  REQUIRE(original.size() == 32 + IDS.size() * 8 + IDS.size() * DIM * 4);
+
+  const std::string path = vanedb::detail::temp_path_for(
+      std::string(VANEDB_CONFORMANCE_DIR) + "/../vndb_geometry_flip");
+
+  std::vector<std::string> accepted;
+  for (size_t byte = 8; byte < 24; ++byte) {
+    for (int bit = 0; bit < 8; ++bit) {
+      std::vector<char> bytes = original;
+      bytes[byte] = static_cast<char>(bytes[byte] ^ (1 << bit));
+      {
+        std::ofstream out(path, std::ios::binary | std::ios::trunc);
+        REQUIRE(out);
+        out.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+      }
+      try {
+        vanedb::DiskIndex index(path);
+        accepted.push_back("byte " + std::to_string(byte) + " bit " +
+                           std::to_string(bit) + " -> dim " +
+                           std::to_string(index.dimension()) + " size " +
+                           std::to_string(index.size()));
+      } catch (const std::exception&) {
+        // Rejected, as required.
+      }
+      std::remove(path.c_str());
+    }
+  }
+
+  for (const auto& a : accepted) {
+    INFO("accepted: " << a);
+  }
+  REQUIRE(accepted.empty());
 }

--- a/vanedb/src/disk.rs
+++ b/vanedb/src/disk.rs
@@ -222,8 +222,21 @@ impl DiskIndex {
     ///
     /// Validates the header, checks every stored component is finite, and
     /// builds the id index, so this is linear in the corpus rather than a
-    /// constant-cost mapping. A file that is already corrupt or truncated is
-    /// rejected here rather than surfacing as a wrong answer later.
+    /// constant-cost mapping.
+    ///
+    /// # Integrity
+    ///
+    /// What this rejects: a bad magic or version, a header whose declared
+    /// geometry disagrees with the file length in either direction, a
+    /// non-finite stored component, a duplicate id, and a nonzero reserved
+    /// word. Corruption that changes the file's *shape* therefore cannot
+    /// surface as a wrong answer.
+    ///
+    /// What it cannot reject: the format carries no checksum, so a flipped bit
+    /// inside a stored id or vector component produces a structurally valid
+    /// file and is returned as data. A caller who needs integrity against
+    /// bitrot must supply it — verify a digest of the file before opening it,
+    /// or store on a filesystem that checksums blocks.
     ///
     /// # Safety
     ///
@@ -287,8 +300,21 @@ impl DiskIndex {
             .and_then(|n| n.checked_add(vecs_size))
             .ok_or_else(|| VaneError::corrupt("size overflow"))?;
 
-        if mmap.len() < expected {
-            return Err(VaneError::corrupt("file truncated"));
+        // Equality, not `>=`. `expected` is derived from the header, so a
+        // one-sided check lets a header that understates the geometry move the
+        // goalpost instead of tripping the guard: flipping one bit of `dim`
+        // from 3 to 2 shrinks `expected` below the real length, and the payload
+        // is then read at the wrong stride, with `get` returning a vector that
+        // straddles two stored records. `save` writes header + ids + vectors
+        // and nothing else, so any file this crate wrote matches exactly. The
+        // graph reader already holds this line (`graph_format.rs`, "trailing
+        // bytes in VNDB graph").
+        if mmap.len() != expected {
+            return Err(VaneError::corrupt(if mmap.len() < expected {
+                "file truncated"
+            } else {
+                "file longer than its header declares"
+            }));
         }
 
         let ids_offset = HEADER_SIZE;

--- a/vanedb/src/disk.rs
+++ b/vanedb/src/disk.rs
@@ -228,15 +228,31 @@ impl DiskIndex {
     ///
     /// What this rejects: a bad magic or version, a header whose declared
     /// geometry disagrees with the file length in either direction, a
-    /// non-finite stored component, a duplicate id, and a nonzero reserved
-    /// word. Corruption that changes the file's *shape* therefore cannot
-    /// surface as a wrong answer.
+    /// dimension too large to address, a non-finite stored component, a
+    /// duplicate id, and a nonzero reserved word.
     ///
-    /// What it cannot reject: the format carries no checksum, so a flipped bit
-    /// inside a stored id or vector component produces a structurally valid
-    /// file and is returned as data. A caller who needs integrity against
-    /// bitrot must supply it — verify a digest of the file before opening it,
-    /// or store on a filesystem that checksums blocks.
+    /// What it cannot reject — the format carries no checksum, so all of the
+    /// following are structurally valid files:
+    ///
+    /// - A flipped bit inside a stored id, returned as data. A flip inside a
+    ///   vector component is usually returned too, though one that produces an
+    ///   infinity or a NaN is caught by the finiteness check.
+    /// - A flipped `metric`, when the new value is another defined metric.
+    ///   Nothing records which was intended, so every distance changes and the
+    ///   file still loads.
+    /// - A *coordinated* rewrite of `dim` and `num_vectors` that preserves the
+    ///   total length. `expected` is `32 + n * (8 + 4 * dim)`, so any pair on
+    ///   that curve passes: a 2592-byte file written as `dim = 8, n = 64` also
+    ///   reads as `dim = 6, n = 80`, at the wrong stride. The length check
+    ///   makes a *single-bit* flip in either field almost always detectable —
+    ///   it moves the length — but it cannot pin the geometry.
+    /// - Any `dim` at all when `num_vectors` is 0, since the file is then
+    ///   header-only whatever the dimension. No vector can be wrong, but
+    ///   `dimension` will report the corrupted value.
+    ///
+    /// A caller who needs integrity against bitrot must supply it — verify a
+    /// digest of the file before opening it, or store on a filesystem that
+    /// checksums blocks.
     ///
     /// # Safety
     ///
@@ -286,6 +302,16 @@ impl DiskIndex {
 
         if dim == 0 && num_vectors > 0 {
             return Err(VaneError::corrupt("zero dimension with vectors"));
+        }
+
+        // Bound `dim` on its own, not only through the product below. When
+        // `num_vectors` is 0 the product is 0 for any `dim`, so the length
+        // check cannot see the field at all and an empty store would accept a
+        // `dim` of 2^62 — which the C++ reader rejects here, making one file
+        // the two engines disagree about. A dimension whose vector cannot be
+        // addressed is unreadable whether or not any vector is stored.
+        if dim > usize::MAX / 4 {
+            return Err(VaneError::corrupt("dimension overflows a byte count"));
         }
 
         let ids_size = num_vectors

--- a/vanedb/tests/corruption_tests.rs
+++ b/vanedb/tests/corruption_tests.rs
@@ -374,6 +374,90 @@ fn mmap_load_rejects_truncated_data() {
 
 #[cfg(feature = "disk")]
 #[test]
+fn mmap_load_rejects_a_header_that_understates_the_payload() {
+    // The mirror of `mmap_load_rejects_truncated_data`, and the case that was
+    // missing. `expected` is derived FROM the header, so a header that lies in
+    // the direction that makes the file look larger than declared moves the
+    // goalpost instead of tripping a one-sided `len() < expected` check.
+    //
+    // One bit, in the low byte of `dim`: 3 becomes 2. The payload is then read
+    // at the wrong stride and `get` returns a vector that straddles two stored
+    // records — a value that was never written by anyone.
+    let mut builder = DiskIndexBuilder::new(3, Metric::L2).unwrap();
+    builder.add(11, &[1.0, 2.0, 3.0]).unwrap();
+    builder.add(22, &[4.0, 5.0, 6.0]).unwrap();
+    let good = std::env::temp_dir().join(format!(
+        "vanedb_mmap_understated_good_{}.bin",
+        std::process::id()
+    ));
+    builder.save(&good).unwrap();
+
+    let mut bytes = fs::read(&good).unwrap();
+    bytes[8] ^= 0x01;
+    let bad = write_tmp("mmap_understated_bad", &bytes);
+
+    // SAFETY: this test owns both files and does not modify them while mapped.
+    let opened = unsafe { DiskIndex::open(&bad) };
+    assert!(
+        matches!(opened, Err(VaneError::Corrupt { .. })),
+        "a header whose declared geometry is shorter than the file must be \
+         rejected, not reinterpreted at the wrong stride: {:?}",
+        opened.map(|i| (i.dimension(), i.size()))
+    );
+
+    let _ = fs::remove_file(&good);
+    let _ = fs::remove_file(&bad);
+}
+
+#[cfg(feature = "disk")]
+#[test]
+fn mmap_load_rejects_every_single_bit_flip_in_the_geometry_fields() {
+    // `dim` (offsets 8..16) and `num_vectors` (16..24) are the two fields the
+    // payload length is computed from, so every flip in them makes the header
+    // disagree with the file. None may be accepted: an accepted flip here is
+    // silent misinterpretation, not a smaller index.
+    //
+    // The other header fields are covered elsewhere — magic and version have
+    // their own tests, the reserved word is checked for zero, and `metric`
+    // yields a structurally valid file, so no length check can reject it.
+    let mut builder = DiskIndexBuilder::new(4, Metric::L2).unwrap();
+    for id in 0..5u64 {
+        let f = id as f32;
+        builder.add(id, &[f, f + 1.0, f + 2.0, f + 3.0]).unwrap();
+    }
+    let good = std::env::temp_dir().join(format!(
+        "vanedb_mmap_geometry_good_{}.bin",
+        std::process::id()
+    ));
+    builder.save(&good).unwrap();
+    let original = fs::read(&good).unwrap();
+
+    let mut accepted = Vec::new();
+    for byte in 8..24usize {
+        for bit in 0..8u32 {
+            let mut bytes = original.clone();
+            bytes[byte] ^= 1 << bit;
+            let path = write_tmp(&format!("mmap_geometry_{byte}_{bit}"), &bytes);
+            // SAFETY: this test owns the file and does not modify it while mapped.
+            if let Ok(index) = unsafe { DiskIndex::open(&path) } {
+                accepted.push((byte, bit, index.dimension(), index.size()));
+            }
+            let _ = fs::remove_file(&path);
+        }
+    }
+    let _ = fs::remove_file(&good);
+
+    assert!(
+        accepted.is_empty(),
+        "{} of 128 geometry-field bit flips were accepted \
+         (byte, bit, dimension, size): {:?}",
+        accepted.len(),
+        accepted
+    );
+}
+
+#[cfg(feature = "disk")]
+#[test]
 fn mmap_load_rejects_size_overflow() {
     // num_vectors * dim that overflows usize when multiplied by sizeof(f32).
     let path = std::env::temp_dir().join("vanedb_mmap_overflow.bin");

--- a/vanedb/tests/corruption_tests.rs
+++ b/vanedb/tests/corruption_tests.rs
@@ -456,6 +456,108 @@ fn mmap_load_rejects_every_single_bit_flip_in_the_geometry_fields() {
     );
 }
 
+/// What the length check cannot do, pinned so the docs cannot overstate it.
+///
+/// `expected = 32 + n*8 + n*dim*4 = 32 + n*(8 + 4*dim)`, so every `(dim, n)`
+/// on that hyperbola produces the same file length. Equality narrows the space
+/// of accepted lies enormously — a single-bit flip in one field almost always
+/// moves the length — but it cannot pin the geometry, and a coordinated
+/// rewrite of both fields is still read as a valid file at the wrong stride.
+///
+/// Closing this needs a checksum, which VNDB v1 does not have. The
+/// `# Integrity` section on `DiskIndex::open` says so; this is what keeps that
+/// sentence honest, and it fails if the format ever gains one.
+#[cfg(feature = "disk")]
+#[test]
+fn a_coordinated_geometry_rewrite_is_still_accepted() {
+    let dir = std::env::temp_dir().join(format!("vanedb-hyperbola-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+
+    let (dim, n) = (8usize, 64usize);
+    let mut builder = DiskIndexBuilder::new(dim, Metric::L2).unwrap();
+    for id in 0..n as u64 {
+        let vector: Vec<f32> = (0..dim).map(|d| (id as usize * 7 + d * 3) as f32).collect();
+        builder.add(id, &vector).unwrap();
+    }
+    let good = dir.join("good.vndb");
+    builder.save(&good).unwrap();
+    let bytes = fs::read(&good).unwrap();
+
+    // dim 8, n 64 -> 2592 bytes. dim 6, n 80 lands on the same length.
+    let mut forged = bytes.clone();
+    forged[8..16].copy_from_slice(&6u64.to_le_bytes());
+    forged[16..24].copy_from_slice(&80u64.to_le_bytes());
+    let path = write_tmp("hyperbola", &forged);
+
+    // SAFETY: this test owns the file and does not modify it while mapped.
+    let index = unsafe { DiskIndex::open(&path) }
+        .expect("the length still matches, so this is accepted -- that is the point");
+    assert_eq!(index.dimension(), 6);
+    assert_eq!(index.size(), 80);
+    assert_ne!(
+        index.get(3).unwrap().as_ref(),
+        (0..dim).map(|d| (3 * 7 + d * 3) as f32).collect::<Vec<_>>(),
+        "a coordinated rewrite yields vectors that were never stored"
+    );
+
+    let _ = fs::remove_file(&path);
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// An empty store is 32 bytes whatever its `dim`, so the length check cannot
+/// see that field at all: `expected` is 32 for every dimension.
+///
+/// A flip there is not a wrong *vector* — there are none — but `dimension()`
+/// then lies, and `search` rejects a correctly sized query. What can still be
+/// rejected is a dimension too large to address, which is the guard that keeps
+/// the two engines agreeing: the C++ reader bounds `dim` unconditionally, and
+/// without the matching Rust bound an empty store with `dim = 2^62` was a file
+/// one engine read and the other refused.
+#[cfg(feature = "disk")]
+#[test]
+fn an_empty_store_cannot_validate_its_dimension_but_still_bounds_it() {
+    let dir = std::env::temp_dir().join(format!("vanedb-empty-dim-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    let good = dir.join("empty.vndb");
+    DiskIndexBuilder::new(4, Metric::L2)
+        .unwrap()
+        .save(&good)
+        .unwrap();
+    let bytes = fs::read(&good).unwrap();
+    assert_eq!(bytes.len(), 32, "an empty store is header-only");
+
+    // A small dim flip is invisible to a length check and is accepted.
+    let mut small = bytes.clone();
+    small[8] ^= 0x01;
+    let path = write_tmp("empty_small_dim", &small);
+    // SAFETY: this test owns the file and does not modify it while mapped.
+    let index = unsafe { DiskIndex::open(&path) }.expect("length is unchanged at 32");
+    assert_eq!(
+        index.dimension(),
+        5,
+        "the header is believed; nothing can check it"
+    );
+    let _ = fs::remove_file(&path);
+
+    // A dim whose vectors could never be addressed is rejected, matching C++.
+    for bit in [62u32, 63] {
+        let mut huge = bytes.clone();
+        let dim = u64::from_le_bytes(huge[8..16].try_into().unwrap()) ^ (1u64 << bit);
+        huge[8..16].copy_from_slice(&dim.to_le_bytes());
+        let path = write_tmp(&format!("empty_huge_dim_{bit}"), &huge);
+        // SAFETY: same.
+        let err = unsafe { DiskIndex::open(&path) }.unwrap_err();
+        assert!(
+            matches!(err, VaneError::Corrupt { .. }),
+            "dim = 2^{bit} must be rejected, got {err:?}"
+        );
+        let _ = fs::remove_file(&path);
+    }
+    let _ = fs::remove_dir_all(&dir);
+}
+
 #[cfg(feature = "disk")]
 #[test]
 fn mmap_load_rejects_size_overflow() {


### PR DESCRIPTION
## The defect

`DiskIndex::open` derives the expected payload length from the header, then checks `mmap.len() < expected`. Because `expected` comes *from* the header, that one-sided test only catches a file getting shorter. A header that lies in the other direction moves the goalpost instead of tripping the guard.

One bit, in the low byte of `dim`:

```
file length          = 72 bytes
header dim field     = 3
bytes[8] ^= 0x01                       # dim 3 -> 2

ACCEPTED a corrupt file:
  dimension() = 2               (the file was written with 3)
  get(11)     = [1.0, 2.0]      (stored [1.0, 2.0, 3.0])
  get(22)     = [3.0, 4.0]      (stored [4.0, 5.0, 6.0])   <- never stored
  search      = [{id:11, d:0.0}, {id:22, d:8.0}]           <- confident, wrong
```

`get(22)` returns a vector straddling two stored records. A sweep of all 128 single-bit flips in the two geometry fields found three silent cases: `dim` 3→2, and `num_vectors` 5→4 and 5→1, the latter two silently dropping vectors.

## The fix

`save` writes header + ids + vectors and nothing else — verified in both engines and against the three committed fixtures, all of which match their declared geometry exactly. So the invariant that actually holds is **equality**, which is both stricter and simpler than the inequality it replaces.

The graph reader already enforces its equivalent (`graph_format.rs`, `"trailing bytes in VNDB graph"`). This brings the v1 reader into line with it.

**The C++ reader carried the identical defect at the identical place** (`cpp/src/core/disk_index.h:113`). Fixed there too. Both readers of a shared format must reject the same shapes, or cross-engine conformance asserts less than it appears to. Per `CLAUDE.md` this is a defect fix in the engine itself, not a feature port.

## The doc comment

It claimed *"a file that is already corrupt or truncated is rejected here rather than surfacing as a wrong answer later."* Shape corruption now genuinely cannot — but the format carries no checksum, so a flipped bit inside a stored id or component is still returned as data. The blanket claim is replaced by an Integrity section stating both halves, and pointing a caller who needs bitrot protection at a digest or a checksumming filesystem.

## Evidence

Both tests fail before the fix and pass after:

```
mmap_load_rejects_a_header_that_understates_the_payload ... FAILED
  a header whose declared geometry is shorter than the file must be
  rejected, not reinterpreted at the wrong stride: Ok((2, 2))

mmap_load_rejects_every_single_bit_flip_in_the_geometry_fields ... FAILED
  2 of 128 geometry-field bit flips were accepted: [(16, 0, 4, 4), (16, 2, 4, 1)]
```

C++ equivalent over the same fixture layout: `a header that disagrees with the file length is rejected in both directions` — failed before, passes after.

After: **32 Rust test binaries, 36 bench (cross-engine format + graph included), 96 C++** all green. `cargo fmt --check` and `clippy -D warnings` clean.

Found by an independent agent building an application against the crate as a first-time user; reproduced and verified separately before fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H