### PR TITLE
fix: correct the regressions this pass introduced, and two dead assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,9 @@ For a Rust query with its own recall setting, construct
 unchanged, so concurrent callers can choose different beam widths. The effective
 beam is at least `k`; ordinary `search` uses the index's defaults.
 
-Every type accepts a `Metric` (`L2`, cosine, or dot), defaulting to `L2` in
-the Python and wasm bindings, and returns results nearest
+Every type accepts a `Metric` (`L2`, cosine, or dot), defaulting to `L2` in the
+Python bindings; wasm takes it as a required string argument. Results come back
+nearest
 first. The native `ApproxIndex` supports `save`/`load`. `DiskIndex` is written
 by `DiskIndexBuilder` and then opened read-only; `FlatIndex` is in-memory only
 and is rebuilt on each run.
@@ -134,9 +135,11 @@ WebAssembly currently supports add, batch add, search, lookup methods, remove,
 `tombstones` and `compact`; it does not expose persistence or upsert. A single id is a
 JavaScript `bigint`; batch ids are a `BigUint64Array` and vectors a row-major
 `Float32Array`. Build a browser package from the repository root with
-`wasm-pack build vanedb-wasm --target web --release --locked` after installing
-`wasm-pack` and the `wasm32-unknown-unknown` Rust target. The generated `pkg/`
-directory includes JavaScript, TypeScript declarations, and the wasm module.
+`wasm-pack build vanedb-wasm --target web --release --locked --out-dir pkg-web`
+after installing `wasm-pack` and the `wasm32-unknown-unknown` Rust target. The
+`--out-dir` matters: the Node target also defaults to `pkg/`, and whichever
+build runs second silently overwrites the first. The generated directory
+includes JavaScript, TypeScript declarations, and the wasm module.
 The [JavaScript guide](vanedb-wasm/README.md) includes runnable Node and browser
 examples. Initialize that module before constructing an index. For example, the approximate
 constructor takes `(3, "cosine", 100, 16, 200)`.

--- a/docs/release/0.1.0-readiness.md
+++ b/docs/release/0.1.0-readiness.md
@@ -3,7 +3,7 @@
 Status: **not ready to tag**. The active target is the first **0.1.0** release.
 
 **The evidence below is historical and does not describe a tree that can be
-tagged.** It certifies artifact candidate `bf797d9`, which `main` is now 26
+tagged.** It certifies artifact candidate `bf797d9`, which `main` is now 27
 non-merge commits past, with the changes concentrated in the artifacts
 themselves — `vanedb-capi/src/lib.rs`, the generated C header,
 `vanedb-py/src/lib.rs`, `vanedb-wasm/src/lib.rs` and the shipping engine.

--- a/docs/release/RELEASING.md
+++ b/docs/release/RELEASING.md
@@ -45,7 +45,21 @@ authorize publication. [Draft notes](0.1.0-notes.md) describe the candidate.
    one action, so a partial upload leaves `0.1.0` permanently half-populated.
    This is a property of the registries, not a project policy.
 
-5. Record the candidate commit, run URLs, artifact checksums, resolved findings
+5. **Before designating the final candidate**, put the published-install form
+   into `vanedb/README.md` and `vanedb-py/README.md`. `vanedb/Cargo.toml`
+   declares `readme = "README.md"`, so that file is inside the `.crate` and is
+   what crates.io renders; `vanedb-py/pyproject.toml` does the same, making its
+   README the core-metadata description of all 28 wheels and the sdist, and the
+   PyPI project page. Neither registry permits a re-upload, so a checkout-only
+   install line in either file is permanent for that version: for the whole
+   time 0.1.0 is the newest release, both registry pages would tell a visitor
+   nothing is published while they are standing on the published package.
+
+   Every other guide is git-only and is corrected after publication (#122).
+   Make this edit in the release commit itself, not earlier — until the tag,
+   the checkout instructions are the true ones.
+
+6. Record the candidate commit, run URLs, artifact checksums, resolved findings
    and final role verdicts. Finalize release notes and compatibility language.
 
 ## Registry setup
@@ -107,7 +121,10 @@ changes to a version dependency, which would make crates.io a hard prerequisite.
 After publication, verify registry version metadata and install the published
 packages in clean environments. Run the documented quickstarts and check that
 the downloadable C and WebAssembly assets match the approved checksums. Only
-then add the verified registry commands and release links to the user guides.
+then add the verified registry commands and release links to the **git-only**
+user guides: the root `README.md`, `cpp/`, and the organisation profile. That
+step cannot reach `vanedb/README.md` or `vanedb-py/README.md` — those are
+already inside the published artifacts by this point. See step 5.
 
 If publication fails, inspect which versions and files were actually accepted
 before retrying. Preserve published versions and tags; do not delete or move

--- a/vanedb-capi/src/lib.rs
+++ b/vanedb-capi/src/lib.rs
@@ -1455,7 +1455,7 @@ mod tests {
 
             let path = std::ffi::CString::new(
                 std::env::temp_dir()
-                    .join("vanedb_capi_null.disk")
+                    .join(format!("vanedb_capi_null-{}.disk", std::process::id()))
                     .to_str()
                     .unwrap(),
             )

--- a/vanedb-capi/tests/capi.rs
+++ b/vanedb-capi/tests/capi.rs
@@ -13,8 +13,15 @@ fn scratch_path(name: &str) -> String {
         .into_owned()
 }
 
+/// A per-call `ef_search` must leave the handle's stored value alone.
+///
+/// Named for what it checks. It was `search_beam_width_is_per_call`, which
+/// this one-vector fixture cannot show — every beam returns the same single
+/// result. That the beam actually reaches the search is proved by
+/// `zero_ef_search_means_the_indexs_own_setting`, over 5000 vectors with a
+/// measured recall separation.
 #[test]
-fn search_beam_width_is_per_call() {
+fn search_does_not_mutate_the_handles_beam_width() {
     unsafe {
         let h = std::ptr::NonNull::new(vanedb_capi::vanedb_rs_index_new(1, 0, 10, 2, 10, 42))
             .expect("index construction failed");

--- a/vanedb-py/tests/test_api_parity.py
+++ b/vanedb-py/tests/test_api_parity.py
@@ -200,7 +200,10 @@ def test_validation_failures_are_still_valueerror():
         flat.add(1, [1.0, 2.0])          # duplicate id
     with pytest.raises(ValueError):
         flat.search([1.0, 2.0], 0)
-    assert not isinstance(ValueError(), KeyError)
+    # (A `not isinstance(ValueError(), KeyError)` line used to sit here. It
+    # asserted CPython's builtin hierarchy, which no vanedb change can affect.
+    # The real claim — that a miss is no longer a ValueError — is asserted on a
+    # real exception in test_a_missing_id_raises_keyerror_on_every_read_and_remove.)
 
 
 def test_keyerror_carries_the_message_not_just_the_id():

--- a/vanedb-py/tests/test_package_metadata.py
+++ b/vanedb-py/tests/test_package_metadata.py
@@ -11,7 +11,12 @@ def test_installed_package_has_markdown_description():
     assert package.get("Description", "").strip()
 
 
-def test_installed_readme_python_examples():
+def test_installed_readme_python_examples(monkeypatch, tmp_path):
+    """The README's examples use bare relative paths, which is right for a
+    README and wrong for a test that `exec`s them: the DiskIndexBuilder example
+    saves `corpus.vndb`, which landed in the source tree on every run. Run them
+    somewhere disposable instead of complicating the documented code."""
+    monkeypatch.chdir(tmp_path)
     description = metadata("vanedb").get("Description", "")
     examples = re.findall(r"```python\n(.*?)\n```", description, re.DOTALL)
     assert examples, "The installed description must contain a runnable quick start"

--- a/vanedb-wasm/README.md
+++ b/vanedb-wasm/README.md
@@ -50,7 +50,7 @@ containing:
 
 ```html
 <script type="module">
-import init, { ApproxIndex } from './pkg/vanedb_wasm.js';
+import init, { ApproxIndex } from './pkg-web/vanedb_wasm.js';
 await init();
 // dim, metric, capacity, m, ef_construction, and an optional seed
 // (defaults to 42; supply it for reproducible construction).
@@ -69,7 +69,10 @@ grows past it; `m` and `ef_construction` control graph construction; `seed`
 defaults to 42 and fixes the topology for a given insertion order. Read them
 back with `m()`, `ef_construction()`, `capacity()` and `seed()`. Set
 `index.ef_search` to trade search speed for recall.
-For exact search use `new FlatIndex(dimension, metric)`.
+For exact search use `new FlatIndex(dimension, metric)`. It has the same
+surface minus the graph parameters: `add`, `add_batch`, `search`, `get`,
+`remove`, `contains`, `size()`, `metric()` and `dimension()`. The module also
+exports `version()`.
 
 `ApproxIndex` supports the full delete lifecycle. `remove(id)` tombstones a
 vector: it stops appearing in results immediately, but keeps its graph links,

--- a/vanedb/benches/approx_bench.rs
+++ b/vanedb/benches/approx_bench.rs
@@ -60,7 +60,7 @@ fn bench_hnsw_save_load(c: &mut Criterion) {
     let dim = 128;
     let n = 10_000;
     let data = gen_data(n, dim);
-    let path = std::env::temp_dir().join("vanedb_bench_hnsw.bin");
+    let path = std::env::temp_dir().join(format!("vanedb_bench_hnsw-{}.bin", std::process::id()));
 
     let idx = ApproxIndex::builder(dim, Metric::L2)
         .capacity(n)

--- a/vanedb/src/disk.rs
+++ b/vanedb/src/disk.rs
@@ -60,7 +60,7 @@ fn u32_to_metric(v: u32) -> Result<Metric> {
 /// use vanedb::{DiskIndex, DiskIndexBuilder, Metric};
 ///
 /// # fn main() -> vanedb::Result<()> {
-/// let path = std::env::temp_dir().join("vanedb-doc-example.vndb");
+/// let path = std::env::temp_dir().join(format!("vanedb-doc-example-{}.vndb", std::process::id()));
 ///
 /// let mut builder = DiskIndexBuilder::new(3, Metric::L2)?;
 /// builder.add(1, &[1.0, 0.0, 0.0])?;
@@ -550,7 +550,10 @@ mod tests {
 
     #[test]
     fn builder_save_creates_file() {
-        let path = std::env::temp_dir().join("vanedb_test_mmap_builder.bin");
+        let path = std::env::temp_dir().join(format!(
+            "vanedb_test_mmap_builder-{}.bin",
+            std::process::id()
+        ));
         let mut b = DiskIndexBuilder::new(2, Metric::L2).unwrap();
         b.add(1, &[1.0, 2.0]).unwrap();
         b.save(&path).unwrap();
@@ -563,7 +566,10 @@ mod tests {
 
     #[test]
     fn roundtrip_build_open_search() {
-        let path = std::env::temp_dir().join("vanedb_test_mmap_roundtrip.bin");
+        let path = std::env::temp_dir().join(format!(
+            "vanedb_test_mmap_roundtrip-{}.bin",
+            std::process::id()
+        ));
 
         let mut b = DiskIndexBuilder::new(3, Metric::L2).unwrap();
         b.add(10, &[0.0, 0.0, 0.0]).unwrap();
@@ -593,7 +599,8 @@ mod tests {
 
     #[test]
     fn open_rejects_bad_file() {
-        let path = std::env::temp_dir().join("vanedb_test_mmap_bad.bin");
+        let path =
+            std::env::temp_dir().join(format!("vanedb_test_mmap_bad-{}.bin", std::process::id()));
         std::fs::write(&path, b"garbage").unwrap();
         // SAFETY: this test does not modify the file while it is mapped.
         assert!(unsafe { DiskIndex::open(&path) }.is_err());
@@ -602,7 +609,8 @@ mod tests {
 
     #[test]
     fn open_rejects_truncated_file() {
-        let path = std::env::temp_dir().join("vanedb_test_mmap_trunc.bin");
+        let path =
+            std::env::temp_dir().join(format!("vanedb_test_mmap_trunc-{}.bin", std::process::id()));
         let mut data = Vec::new();
         data.extend_from_slice(&MAGIC.to_le_bytes());
         data.extend_from_slice(&VERSION.to_le_bytes());
@@ -618,7 +626,8 @@ mod tests {
 
     #[test]
     fn search_wrong_dimension() {
-        let path = std::env::temp_dir().join("vanedb_test_mmap_dim.bin");
+        let path =
+            std::env::temp_dir().join(format!("vanedb_test_mmap_dim-{}.bin", std::process::id()));
         let mut b = DiskIndexBuilder::new(3, Metric::L2).unwrap();
         b.add(1, &[1.0, 2.0, 3.0]).unwrap();
         b.save(&path).unwrap();

--- a/vanedb/tests/graph_structure.rs
+++ b/vanedb/tests/graph_structure.rs
@@ -35,8 +35,8 @@ const HEADER: usize = 96;
 struct Node {
     level: u32,
     deleted: bool,
-    /// Neighbour count per layer, index 0 = layer 0.
-    degrees: Vec<usize>,
+    /// Neighbour slots per layer, index 0 = layer 0.
+    neighbours: Vec<Vec<u64>>,
 }
 
 struct Graph {
@@ -69,16 +69,18 @@ fn parse(bytes: &[u8]) -> Graph {
         let flags = u32_at(at);
         at += 4;
         at += dim * 4; // vector components
-        let mut degrees = Vec::with_capacity(level as usize + 1);
+        let mut neighbours = Vec::with_capacity(level as usize + 1);
         for _ in 0..=level {
             let degree = u64_at(at) as usize;
-            at += 8 + degree * 8;
-            degrees.push(degree);
+            at += 8;
+            let layer: Vec<u64> = (0..degree).map(|i| u64_at(at + i * 8)).collect();
+            at += degree * 8;
+            neighbours.push(layer);
         }
         nodes.push(Node {
             level,
             deleted: flags == 1,
-            degrees,
+            neighbours,
         });
     }
     Graph {
@@ -133,15 +135,16 @@ fn no_node_exceeds_its_layer_degree_cap() {
         let graph = build_and_parse(n, m, 42);
         assert_eq!(graph.m, m, "M must round-trip through the header");
         for (slot, node) in graph.nodes.iter().enumerate() {
-            for (layer, &degree) in node.degrees.iter().enumerate() {
+            for (layer, links) in node.neighbours.iter().enumerate() {
                 let cap = if layer == 0 { 2 * m } else { m };
+                let degree = links.len();
                 assert!(
                     degree <= cap,
                     "n={n} m={m}: slot {slot} layer {layer} has {degree} links, cap {cap}"
                 );
             }
             assert_eq!(
-                node.degrees.len(),
+                node.neighbours.len(),
                 node.level as usize + 1,
                 "a node must carry exactly one neighbour list per layer it occupies"
             );
@@ -155,7 +158,7 @@ fn no_node_exceeds_its_layer_degree_cap() {
         let widest = graph
             .nodes
             .iter()
-            .filter_map(|node| node.degrees.first().copied())
+            .filter_map(|node| node.neighbours.first().map(|l| l.len()))
             .max()
             .unwrap_or(0);
         assert!(
@@ -230,14 +233,36 @@ fn the_level_distribution_is_a_hierarchy_not_a_flat_graph() {
 /// Every neighbour list must be free of self-links and duplicates, and every
 /// node above layer 0 must actually be connected there — an isolated upper
 /// node makes the layer it occupies useless for descent.
+///
+/// The first two clauses used to be a claim only: the parser walked past the
+/// neighbour ids without recording them, so nothing could see a self-link or a
+/// repeat. It records them now. Writing a comment that outruns its assertions,
+/// in the change whose whole purpose was to find tests doing exactly that, is
+/// the reason this note exists.
 #[test]
 fn upper_layers_are_connected_and_links_are_well_formed() {
     let graph = build_and_parse(1500, 16, 11);
+    let slots = graph.nodes.len();
     let mut isolated_above_base = 0;
-    for node in &graph.nodes {
-        for (layer, &degree) in node.degrees.iter().enumerate() {
-            if layer > 0 && degree == 0 {
+    for (slot, node) in graph.nodes.iter().enumerate() {
+        for (layer, links) in node.neighbours.iter().enumerate() {
+            if layer > 0 && links.is_empty() {
                 isolated_above_base += 1;
+            }
+            let mut seen = std::collections::HashSet::with_capacity(links.len());
+            for &neighbour in links {
+                assert_ne!(
+                    neighbour as usize, slot,
+                    "slot {slot} links to itself on layer {layer}"
+                );
+                assert!(
+                    (neighbour as usize) < slots,
+                    "slot {slot} layer {layer} links to {neighbour}, past the {slots} stored slots"
+                );
+                assert!(
+                    seen.insert(neighbour),
+                    "slot {slot} lists {neighbour} twice on layer {layer}"
+                );
             }
         }
     }

--- a/vanedb/tests/non_finite_conformance.rs
+++ b/vanedb/tests/non_finite_conformance.rs
@@ -92,7 +92,10 @@ fn mmap_builder_rejects_non_finite_vectors() {
 #[cfg(feature = "disk")]
 #[test]
 fn mmap_store_rejects_non_finite_queries() {
-    let path = std::env::temp_dir().join("vanedb_non_finite_query_conformance.bin");
+    let path = std::env::temp_dir().join(format!(
+        "vanedb_non_finite_query_conformance-{}.bin",
+        std::process::id()
+    ));
     let mut builder = DiskIndexBuilder::new(2, Metric::L2).unwrap();
     builder.add(1, &[0.0, 0.0]).unwrap();
     builder.save(&path).unwrap();

--- a/vanedb/tests/public_surface.rs
+++ b/vanedb/tests/public_surface.rs
@@ -96,8 +96,9 @@ fn every_error_variant_renders_a_useful_message() {
                 "{error:?} rendered as {rendered:?}, missing {fragment:?}"
             );
         }
-        // A message that is only a label tells a caller nothing.
-        assert!(rendered.len() > 5, "{error:?} rendered as {rendered:?}");
+        // (A length floor used to sit here. The shortest fragment asserted
+        // above is "finite" at six characters, so every passing `contains`
+        // already implies it — it could not fail.)
     }
 }
 


### PR DESCRIPTION
Second round of independent assessment. **CTO: APPROVE (engineering).** AI PM and senior engineer: APPROVE WITH CONDITIONS — and most of what they found were defects *this documentation pass had introduced*.

## The one that would have shipped

The wasm README's browser example still imported `./pkg/vanedb_wasm.js` after the build command was changed to `--out-dir pkg-web`. A reader following it gets a 404 — or, having run the Node build first, silently loads the **Node** artifact and hits the exact `__wbindgen_malloc` error the paragraph three lines above warns about. **The fix made the failure it documents more likely.**

It reached that state because my edit used a string replace whose anchor named `FlatIndex` while the example imports `ApproxIndex`, and I did not assert the replacement count. `scripts/package_wasm.py` puts this README inside both release tarballs, so it could not have been corrected afterward.

## Two more of mine

- **A false claim replacing a false claim.** "Every type takes a `Metric`" became "defaults to L2 in the Python and wasm bindings". Wasm has no default — both constructors take `metric: &str` positionally and `parse_metric` has no default arm.
- **The clobber footgun fixed in one of two places.** The root README still gave the browser build without `--out-dir`.

## Two regressions in the test work

- `vanedb-py/README.md`'s `DiskIndexBuilder` example saves a bare `corpus.vndb`, and `test_installed_readme_python_examples` `exec`s it — so **every pytest run left an untracked file in the source tree**. Fixed in the test with `monkeypatch.chdir(tmp_path)`; a README should keep the simple path.
- `graph_structure.rs` claimed its connectivity test verified "every neighbour list must be free of self-links and duplicates" while the parser walked *past* the ids without recording them. Writing a comment that outruns its assertions, in the change whose entire purpose was to find tests doing exactly that. The parser now records the ids and the test asserts self-links, duplicates and slot bounds.

## Closed properly this time

The temp-path sweep covered `vanedb/tests/` but not inline `#[cfg(test)]` modules, benches, the new doctest, or `vanedb-capi/src`. A multi-line-aware scan now finds **zero** unscoped `temp_dir().join` sites in either crate. The senior engineer measured 1-in-4 concurrent failures at the site it found; that site and eight others are fixed.

## Dead assertions removed

- `public_surface.rs`'s `rendered.len() > 5` — entailed by every `contains` above it, since the shortest fragment is `"finite"` at six characters.
- `test_api_parity.py`'s `not isinstance(ValueError(), KeyError)` — asserts CPython's builtin hierarchy, which no vanedb change can affect.
- `capi.rs`'s `search_beam_width_is_per_call` renamed to `search_does_not_mutate_the_handles_beam_width`: its one-vector fixture cannot show a beam width, and the claim its old name made is proved elsewhere over 5000 vectors with measured recall separation.

## Sequencing, per the PM's ruling

`vanedb/README.md` and `vanedb-py/README.md` are inside the `.crate` and all 28 wheels (`readme = "README.md"` in both manifests). The step that adds registry install commands *after* publication structurally cannot reach them, and neither registry permits a re-upload — so a checkout-only install line there is permanent for 0.1.0. Recorded in `RELEASING.md` as a pre-tag requirement, with the closing line scoped to the git-only guides. The edit itself belongs in the release commit, not now: until the tag, the checkout instructions are the true ones.

## Evidence

`fmt --check`, `clippy -D warnings`, `actionlint` clean. Rust, bench, 97 C++ and 167 Python green. Every wasm method named in the README verified present in `lib.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H