### PR TITLE
test: close the survivors the full mutation sweep exposed

### DIFF
--- a/vanedb/tests/disk_tests.rs
+++ b/vanedb/tests/disk_tests.rs
@@ -129,3 +129,66 @@ fn atomic_replacement_preserves_an_open_mapping() {
     drop((old, new));
     std::fs::remove_file(path).unwrap();
 }
+
+/// `is_empty` and the vector addressing arithmetic, which a mutation sweep
+/// found unasserted.
+///
+/// Four survivors lived here: `is_empty` could return a constant `true` or
+/// `false`, its `==` could become `!=`, and `get_vec`'s offset could compute
+/// `dim + 4` instead of `dim * 4`. The last is the store's core addressing —
+/// it survives because slot 0 is at offset 0 under either arithmetic, so a
+/// test that only reads the first vector cannot see it. Reading a later slot,
+/// with a dimension where the two disagree, is what exposes it.
+#[test]
+fn is_empty_and_vector_addressing_are_pinned() {
+    let dir = std::env::temp_dir().join(format!("vanedb-addressing-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    // An empty store: is_empty must be true and len zero together.
+    let empty_path = dir.join("empty.vndb");
+    DiskIndexBuilder::new(3, Metric::L2)
+        .unwrap()
+        .save(&empty_path)
+        .unwrap();
+    // SAFETY: this test owns the file and never modifies it while mapped.
+    let empty = unsafe { DiskIndex::open(&empty_path) }.unwrap();
+    assert!(empty.is_empty());
+    assert_eq!(empty.len(), 0);
+
+    // A populated store: is_empty must be false, and every slot must read back
+    // exactly what was written. `dim = 5` is chosen so `dim * 4 = 20` and
+    // `dim + 4 = 9` disagree, and the vectors are distinct per slot so a
+    // misaddressed read cannot coincide with the right answer.
+    let dim = 5usize;
+    let path = dir.join("full.vndb");
+    let mut builder = DiskIndexBuilder::new(dim, Metric::L2).unwrap();
+    let rows: Vec<(u64, Vec<f32>)> = (0..8u64)
+        .map(|id| {
+            let base = (id as f32 + 1.0) * 100.0;
+            (id, (0..dim).map(|d| base + d as f32).collect())
+        })
+        .collect();
+    for (id, vector) in &rows {
+        builder.add(*id, vector).unwrap();
+    }
+    builder.save(&path).unwrap();
+
+    // SAFETY: same.
+    let index = unsafe { DiskIndex::open(&path) }.unwrap();
+    assert!(!index.is_empty());
+    assert_eq!(index.len(), rows.len());
+    for (id, vector) in &rows {
+        assert_eq!(
+            index.get(*id).unwrap().as_ref(),
+            vector.as_slice(),
+            "slot {id} read back the wrong bytes"
+        );
+    }
+    // And through search, which reaches the same addressing by another route.
+    let hits = index.search(&rows[6].1, 1).unwrap();
+    assert_eq!(hits[0].id, 6);
+    assert!(hits[0].distance.abs() < 1e-6);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/vanedb/tests/graph_structure.rs
+++ b/vanedb/tests/graph_structure.rs
@@ -271,3 +271,80 @@ fn upper_layers_are_connected_and_links_are_well_formed() {
         "{isolated_above_base} node-layers above the base have no links at all"
     );
 }
+
+/// Each clause of the v2 header guard, violated on its own.
+///
+/// `graph_format.rs` rejects a corrupt header with one `||` chain of eight
+/// conditions. A full mutation sweep turned nine survivors loose in that
+/// function: every `||` can become `&&`, and several comparisons can be
+/// loosened, without failing a test — because the fixtures that reach the
+/// guard violate more than one clause at a time, so the remaining conditions
+/// still catch them.
+///
+/// `CLAUDE.md` requires that all corruption checks be kept. A check nothing
+/// exercises alone is one that can be deleted silently.
+///
+/// Two clauses stay unpinnable, and the reason is worth recording so the next
+/// reader does not chase them. Deleting `dim == 0` or `m < 2` does not make a
+/// malformed file load: `dim = 0` still trips `count > body.len() / row_bytes`,
+/// and `m = 1` still trips the per-layer degree cap, because a file built with
+/// a larger `M` carries degrees the smaller cap rejects. Those mutants survive
+/// with the *behaviour unchanged*, which is defence in depth rather than an
+/// unexercised guard. The cases below still cover them, just not in isolation.
+#[test]
+fn every_header_guard_clause_rejects_on_its_own() {
+    let good = {
+        let index = ApproxIndex::builder(4, Metric::L2)
+            .capacity(16)
+            .m(4)
+            .ef_construction(16)
+            .seed(5)
+            .build()
+            .unwrap();
+        for id in 0..6u64 {
+            index.add(id, &[id as f32, 1.0, 2.0, 3.0]).unwrap();
+        }
+        let dir = std::env::temp_dir().join(format!("vanedb-guards-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("g.vndb");
+        index.save(&path).unwrap();
+        let bytes = fs::read(&path).unwrap();
+        let _ = fs::remove_dir_all(&dir);
+        bytes
+    };
+    // Sanity: the untouched bytes must load, or every case below is vacuous.
+    let dir = std::env::temp_dir().join(format!("vanedb-guards-run-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    let write = |name: &str, bytes: &[u8]| {
+        let p = dir.join(format!("{name}.vndb"));
+        fs::write(&p, bytes).unwrap();
+        p
+    };
+    ApproxIndex::load(write("pristine", &good)).expect("the unmodified graph must load");
+
+    // Offsets from conformance/graph/README.md. Each case moves exactly one
+    // field, to a value that violates exactly one clause.
+    let cases: [(&str, usize, u64); 6] = [
+        ("dim_zero", 16, 0),
+        ("count_over_max_elements", 24, 9),
+        ("max_elements_zero", 32, 0),
+        ("m_below_two", 40, 1),
+        ("ef_construction_zero", 48, 0),
+        ("count_beyond_body", 24, 1_000),
+    ];
+    for (name, offset, value) in cases {
+        let mut bytes = good.clone();
+        bytes[offset..offset + 8].copy_from_slice(&value.to_le_bytes());
+        let path = write(name, &bytes);
+        let err = ApproxIndex::load(&path)
+            .err()
+            .unwrap_or_else(|| panic!("{name}: a header violating this clause must be rejected"));
+        assert!(
+            matches!(err, vanedb::VaneError::Corrupt { .. }),
+            "{name}: expected Corrupt, got {err:?}"
+        );
+    }
+    let _ = fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
The complete `cargo mutants` run — 752 mutants, versus the 376 sampled in the QA assessment — put survivors in three files. This closes the ones representing genuinely unasserted behaviour and records why two others cannot be closed.

## `DiskIndex` vector addressing was unpinned

`get_vec` computes `vectors_offset + idx * dim * 4`. Changing that `* 4` to `+ 4` **survived every test in the repository** — because slot 0 sits at offset 0 under either arithmetic, so a test reading only the first vector cannot see it.

The new case uses `dim = 5`, where `dim * 4 = 20` and `dim + 4 = 9` disagree, with a distinct vector per slot, and reads a later slot both by id and through search. `is_empty` was equally unasserted: constant `true`, constant `false`, or an inverted comparison all passed.

## Each clause of the v2 header guard now has a fixture

The graph reader rejects a corrupt header with one `||` chain of eight conditions, and **nine mutants survived inside it** — every `||` could become `&&` without failing a test, because the fixtures reaching that guard violate more than one clause at once and the survivors still catch them. `CLAUDE.md` requires all corruption checks be kept; a check nothing exercises alone can be deleted silently.

Six clauses now have a case that violates exactly that clause.

## Two that stay unpinnable, recorded rather than chased

Deleting `dim == 0` or `m < 2` does **not** make a malformed file load. `dim = 0` still trips `count > body.len() / row_bytes`, and `m = 1` still trips the per-layer degree cap, since a file built with a larger `M` carries degrees the smaller cap rejects. Those mutants survive with the *behaviour unchanged* — defence in depth, not an unexercised guard. The reason is now in the test's doc comment.

## Mutation results

```
is_empty -> true        CAUGHT
is_empty == -> !=       CAUGHT
get_vec dim*4 -> dim+4  CAUGHT
graph m<2 guard removed survived (behaviour unchanged — see above)
graph dim==0 removed    survived (behaviour unchanged — see above)
```

## A note on measurement

My first pass reported `get_vec` as surviving. It wasn't: the mutation panics on an out-of-bounds slice rather than printing `test result: FAILED`, and my check grepped for that string. Re-run on exit codes, it's caught.

A mutation harness that can only see one shape of failure is the same defect as a test that can only see one shape of success — which is the class this whole effort has been closing.

## Evidence

`fmt --check` clean, `clippy -D warnings` clean, full Rust suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H