### PR TITLE
feat(wasm): publish one npm package serving both Node and browsers

### DIFF
--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -1,0 +1,124 @@
+name: Publish vanedb-wasm to npm
+
+# Its own tag, like the crate and the Python package, so the three artifacts
+# can be verified and published independently.
+on:
+  push:
+    tags: ['vanedb-wasm-v*']
+  # Dispatch verifies only. The publish job tests `event_name == 'push'` rather
+  # than `ref_type == 'tag'`, so a `--ref <a tag>` dispatch cannot reach it.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: Build and consume the package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.14'
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Match tag and package version
+        if: github.event_name == 'push'
+        shell: bash
+        run: |
+          version=$(python3 -c "import tomllib,pathlib; \
+            print(tomllib.loads(pathlib.Path('vanedb-wasm/Cargo.toml').read_text())['package']['version'])")
+          expected="vanedb-wasm-v${version}"
+          if [ "${GITHUB_REF_NAME}" != "$expected" ]; then
+            echo "tag ${GITHUB_REF_NAME} expects $expected" >&2
+            exit 1
+          fi
+          echo "validated vanedb-wasm ${version}"
+
+      - name: Require release tag to be on main
+        if: github.event_name == 'push'
+        shell: bash
+        run: |
+          git fetch --no-tags origin refs/heads/main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "${GITHUB_SHA}" origin/main; then
+            echo "release tags must point at a commit on main" >&2
+            exit 1
+          fi
+
+      - name: Assemble the package
+        run: python3 scripts/build_npm_package.py
+
+      - name: Consume it as an installed dependency
+        run: python3 scripts/check_npm_package.py
+
+      - name: Pack for inspection
+        run: |
+          npm pack target/npm/vanedb-wasm --pack-destination target/npm --ignore-scripts
+          ls -l target/npm/*.tgz
+          sha256sum target/npm/*.tgz
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vanedb-wasm-npm
+          path: target/npm/*.tgz
+          if-no-files-found: error
+
+  publish:
+    name: Publish to npm
+    needs: verify
+    # Same form as the crate and Python workflows: a workflow_dispatch can
+    # never satisfy it, whatever ref it names.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/vanedb-wasm-v')
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: read
+      # Trusted publishing: npm exchanges this OIDC token for a short-lived
+      # credential and records a provenance attestation tying the package to
+      # this workflow and commit. No long-lived token is stored in the repo,
+      # matching crates.io and PyPI.
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.14'
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Assemble the package
+        run: python3 scripts/build_npm_package.py
+
+      # npm 11.5.1+ performs the OIDC exchange itself when the workflow has
+      # `id-token: write` and a trusted publisher is configured for the
+      # package. `--provenance` records the attestation.
+      - name: Update npm
+        run: npm install -g npm@latest
+
+      - name: Publish
+        run: npm publish --provenance --access public
+        working-directory: target/npm/vanedb-wasm

--- a/bench/tests/release_identity.rs
+++ b/bench/tests/release_identity.rs
@@ -96,6 +96,23 @@ fn declared_versions() -> Vec<(&'static str, String)> {
         .to_string();
     sites.push(("vanedb-capi/cbindgen.toml VANEDB_RS_VERSION", macro_version));
 
+    // The npm package's version is copied from the wasm crate's manifest by
+    // `scripts/build_npm_package.py`. That manifest is already listed above,
+    // so this pins the copy rather than the source: the publish workflow's tag
+    // check reads `vanedb-wasm/Cargo.toml`, and a package assembled from a
+    // different value would publish under a version no tag matches.
+    let assembled = repo_root().join("target/npm/vanedb-wasm/package.json");
+    if assembled.exists() {
+        let text = std::fs::read_to_string(&assembled).expect("read assembled package.json");
+        let version = text
+            .lines()
+            .find_map(|l| l.trim().strip_prefix("\"version\": \""))
+            .and_then(|v| v.split('"').next())
+            .expect("assembled package.json declares a version")
+            .to_string();
+        sites.push(("target/npm/vanedb-wasm/package.json", version));
+    }
+
     // Doxygen renders this on the generated C++ docs. A free-form string, so
     // it can spell a prerelease and must match in full; it read "0.1.0"
     // throughout the 0.1.0-rc.1 period without anything noticing.

--- a/docs/release/RELEASING.md
+++ b/docs/release/RELEASING.md
@@ -112,11 +112,20 @@ changes to a version dependency, which would make crates.io a hard prerequisite.
   protected `crates-io` job. If 0.1.0 is the manual bootstrap publication,
   do not also trigger this tag's upload of the same version; use the crate-tag
   workflow for later versions after configuring its publisher.
-- C library archives and the separate Node/browser npm tarballs come from the
+- WebAssembly uses tag `vanedb-wasm-v0.1.0`. `scripts/build_npm_package.py`
+  merges the two wasm-pack targets into one `vanedb-wasm` package with
+  conditional `exports`, and `scripts/check_npm_package.py` installs the packed
+  tarball into a throwaway project and imports it through the public specifier
+  in both ESM and CommonJS before the protected `npm` publication job. npm uses
+  OIDC trusted publishing with `--provenance`, so no long-lived token is stored
+  and the published package carries an attestation naming this workflow and
+  commit. A trusted publisher must be configured on npmjs.com for the package
+  first; unlike crates.io, npm does not require a bootstrap publish.
+- C library archives come from the
   approved commit's CI artifacts. Attach the C archives with their runtime
   compatibility metadata, and `vanedb-wasm-0.1.0-nodejs.tgz` and
   `vanedb-wasm-0.1.0-web.tgz`, each with its matching checksum. There is no
-  automatic npm-registry or C++ package publication.
+  automatic C++ package publication.
 
 After publication, verify registry version metadata and install the published
 packages in clean environments. Run the documented quickstarts and check that

--- a/scripts/build_npm_package.py
+++ b/scripts/build_npm_package.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Merge the two wasm-pack outputs into one publishable npm package.
+
+wasm-pack emits a separate package per target and names them both
+`vanedb-wasm`, so they cannot both go to npm under that name. It also emits
+two *different contracts*: the Node build is CommonJS that loads the module
+synchronously, while the web build is ESM whose default export is an async
+`init` that must resolve before any class is touched.
+
+Conditional `exports` alone would therefore route one specifier to two
+different APIs. This adds a small wrapper so `init()` exists in both — a
+no-op on Node, the real loader in a browser — and the same source works
+either way:
+
+    import init, { FlatIndex } from 'vanedb-wasm';
+    await init();                  // no-op on Node
+    const index = new FlatIndex(3, 'l2');
+"""
+
+import argparse
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CRATE = ROOT / "vanedb-wasm"
+
+NODE_CJS = """// Node, `require`: wasm-pack's nodejs target loads the module synchronously,
+// so there is nothing to await. `init` exists only so browser and Node source
+// can be identical.
+const bindings = require('./vanedb_wasm.js');
+
+module.exports = Object.assign({}, bindings, {
+  default: async function init() { return bindings; },
+  initSync: function initSync() { return bindings; },
+});
+"""
+
+# Node, `import`. An ESM file re-exporting a CommonJS module cannot rely on
+# Node's named-export detection — `import { ApproxIndex } from 'vanedb-wasm'`
+# fails with "Named export not found" when the CJS module assigns its exports
+# dynamically, which wasm-pack's output does. Each name is therefore re-bound
+# explicitly, and the list is generated from the build rather than hand-written
+# so a new class cannot be silently omitted.
+NODE_MJS_HEADER = """import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const bindings = require('./vanedb_wasm.js');
+
+export default async function init() { return bindings; }
+export function initSync() { return bindings; }
+"""
+
+WEB_SHIM = """// Browser: re-export wasm-pack's web target unchanged. Its default export is
+// the async loader, which must resolve before any class is constructed.
+export { default, initSync } from './vanedb_wasm.js';
+export * from './vanedb_wasm.js';
+"""
+
+
+def exported_names(node_js: Path) -> list[str]:
+    """The names wasm-pack's nodejs target assigns to `exports`."""
+    names = []
+    for line in node_js.read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("exports.") and "=" in stripped:
+            name = stripped[len("exports."):].split("=", 1)[0].strip()
+            if name.isidentifier() and name not in names:
+                names.append(name)
+    return names
+
+
+def build(target: str, out: str) -> Path:
+    subprocess.run(
+        ["wasm-pack", "build", "--target", target, "--out-dir", out, "--locked"],
+        cwd=CRATE, check=True,
+    )
+    return CRATE / out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, default=ROOT / "target/npm/vanedb-wasm")
+    parser.add_argument("--skip-build", action="store_true",
+                        help="reuse existing pkg/ and pkg-web/ directories")
+    args = parser.parse_args()
+
+    node_dir = CRATE / "pkg" if args.skip_build else build("nodejs", "pkg")
+    web_dir = CRATE / "pkg-web" if args.skip_build else build("web", "pkg-web")
+
+    out = args.output.resolve()
+    if out.exists():
+        shutil.rmtree(out)
+    (out / "node").mkdir(parents=True)
+    (out / "web").mkdir(parents=True)
+
+    payload = ["vanedb_wasm.js", "vanedb_wasm.d.ts", "vanedb_wasm_bg.wasm"]
+    for name in payload:
+        shutil.copy2(node_dir / name, out / "node" / name)
+        shutil.copy2(web_dir / name, out / "web" / name)
+    # The Node target also emits a .d.ts for the raw module.
+    for extra in ("vanedb_wasm_bg.wasm.d.ts",):
+        if (node_dir / extra).exists():
+            shutil.copy2(node_dir / extra, out / "node" / extra)
+        if (web_dir / extra).exists():
+            shutil.copy2(web_dir / extra, out / "web" / extra)
+
+    names = exported_names(node_dir / "vanedb_wasm.js")
+    if not names:
+        raise SystemExit("no exports found in the Node build; the shim would be empty")
+
+    # The two targets must expose the same surface, or one specifier would give
+    # a browser and Node different APIs.
+    web_names = {
+        line.split("class ")[1].split()[0].rstrip("{")
+        for line in (web_dir / "vanedb_wasm.js").read_text().splitlines()
+        if line.startswith("export class ")
+    }
+    web_names |= {
+        line.split("function ")[1].split("(")[0]
+        for line in (web_dir / "vanedb_wasm.js").read_text().splitlines()
+        if line.startswith("export function ")
+    }
+    missing = set(names) - web_names
+    if missing:
+        raise SystemExit(f"the web build is missing {sorted(missing)}, exported by Node")
+
+    # The root package.json declares "type": "module", which would make Node
+    # parse wasm-pack's CommonJS output in node/ as ESM and fail on its first
+    # `exports.` assignment. A nested package.json scopes that directory back
+    # to CommonJS; index.mjs keeps its explicit extension and stays ESM.
+    (out / "node" / "package.json").write_text('{ "type": "commonjs" }\n')
+    (out / "node" / "index.cjs").write_text(NODE_CJS)
+    (out / "node" / "index.mjs").write_text(
+        NODE_MJS_HEADER
+        + "".join(f"export const {n} = bindings.{n};\n" for n in names)
+    )
+    (out / "web" / "index.js").write_text(WEB_SHIM)
+    print(f"  re-exported from the Node build: {', '.join(names)}")
+    # One .d.ts serves both: the classes are identical, and the web build's
+    # extra init types are what the shim gives Node as well.
+    shutil.copy2(web_dir / "vanedb_wasm.d.ts", out / "index.d.ts")
+
+    for doc in ("README.md", "LICENSE"):
+        shutil.copy2(CRATE / doc, out / doc)
+
+    generated = json.loads((node_dir / "package.json").read_text())
+    package = {
+        "name": "vanedb-wasm",
+        "version": generated["version"],
+        "description": generated["description"],
+        "license": generated["license"],
+        "repository": generated["repository"],
+        "keywords": ["vector", "search", "embeddings", "wasm", "hnsw", "database"],
+        "homepage": "https://github.com/vanedb/vanedb#readme",
+        "type": "module",
+        "types": "./index.d.ts",
+        # `node` before `browser` and `default`: Node honours the first match,
+        # bundlers honour `browser`, and everything else falls through to the
+        # web build, which is the safe default for an unknown runtime.
+        "exports": {
+            ".": {
+                "types": "./index.d.ts",
+                "node": {
+                    "import": "./node/index.mjs",
+                    "require": "./node/index.cjs",
+                },
+                "browser": "./web/index.js",
+                "default": "./web/index.js",
+            },
+            "./package.json": "./package.json",
+        },
+        "main": "./node/index.cjs",
+        "module": "./web/index.js",
+        "files": ["node/", "web/", "index.d.ts", "README.md", "LICENSE"],
+        "sideEffects": ["./web/index.js", "./web/vanedb_wasm.js"],
+        "engines": {"node": ">=18"},
+    }
+    (out / "package.json").write_text(json.dumps(package, indent=2) + "\n")
+    print(f"npm package assembled at {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_npm_package.py
+++ b/scripts/check_npm_package.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Assemble, pack and consume the npm package exactly as a user would.
+
+`npm pack` on the assembled directory, `npm install` of that tarball into a
+throwaway project, then the consumer test running from inside it — so the bare
+specifier resolves through the package's own `exports` conditions rather than a
+path. Every packaging failure found while building this was invisible until the
+package was installed and imported.
+"""
+
+import argparse
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TEST = ROOT / "vanedb-wasm/tests/npm_package.mjs"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("package", type=Path, nargs="?",
+                        default=ROOT / "target/npm/vanedb-wasm",
+                        help="assembled package directory")
+    args = parser.parse_args()
+    package = args.package.resolve()
+    manifest = json.loads((package / "package.json").read_text())
+
+    with tempfile.TemporaryDirectory(prefix="vanedb-npm-check-") as tmp:
+        consumer = Path(tmp)
+        (consumer / "package.json").write_text(
+            json.dumps({"name": "consumer", "version": "1.0.0",
+                        "type": "module", "private": True}) + "\n"
+        )
+        env_cache = consumer / "cache"
+        env = {"npm_config_cache": str(env_cache), "PATH": __import__("os").environ["PATH"],
+               "HOME": str(consumer)}
+        packed = subprocess.run(
+            ["npm", "pack", str(package), "--pack-destination", str(consumer),
+             "--ignore-scripts", "--json"],
+            cwd=consumer, env=env, check=True, text=True, capture_output=True,
+        )
+        tarball = consumer / json.loads(packed.stdout)[0]["filename"]
+        subprocess.run(
+            ["npm", "install", str(tarball), "--no-audit", "--no-fund", "--ignore-scripts"],
+            cwd=consumer, env=env, check=True, capture_output=True,
+        )
+        shutil.copy2(TEST, consumer / "npm_package.mjs")
+        subprocess.run(["node", "npm_package.mjs"], cwd=consumer, env=env, check=True)
+
+    print(f"npm package {manifest['name']}@{manifest['version']}: consumable")
+
+
+if __name__ == "__main__":
+    main()

--- a/vanedb-wasm/README.md
+++ b/vanedb-wasm/README.md
@@ -26,6 +26,19 @@ the downloadable assets; both retain the JavaScript package name `vanedb-wasm`.
 To build from source, install Rust, the `wasm32-unknown-unknown` target, and
 `wasm-pack`. Node.js is needed for the Node example. Run from the repository root:
 
+Published to npm as [`vanedb-wasm`](https://www.npmjs.com/package/vanedb-wasm).
+One package serves both runtimes through conditional `exports`, so the same
+source works either way:
+
+```js
+import init, { FlatIndex } from 'vanedb-wasm';
+
+await init();          // no-op under Node, loads the module in a browser
+const index = new FlatIndex(3, 'l2');
+```
+
+`require('vanedb-wasm')` works too. To build from a checkout instead:
+
 ```sh
 rustup target add wasm32-unknown-unknown
 wasm-pack build vanedb-wasm --target nodejs --release --locked

--- a/vanedb-wasm/tests/npm_package.mjs
+++ b/vanedb-wasm/tests/npm_package.mjs
@@ -1,0 +1,65 @@
+// Consumes the assembled npm package the way a user would: from an installed
+// tarball, through the public specifier, in both module systems.
+//
+// wasm-pack emits two targets with different contracts — Node is CommonJS and
+// loads synchronously, the web build is ESM whose default export is an async
+// loader. Merging them under one name is where the failures live, and all
+// three found while building this were invisible to any Rust test:
+//
+//   * ESM `import { ApproxIndex }` from a CommonJS module fails Node's
+//     named-export detection.
+//   * The root "type": "module" makes Node parse wasm-pack's CommonJS output
+//     as ESM and die on its first `exports.` assignment.
+//   * A missing export in one target is only visible when both are compared.
+//
+// Run from inside a directory that has `npm install`ed the tarball, so the
+// bare specifier resolves the way a consumer's would — through the package's
+// `exports` conditions rather than a path. `scripts/check_npm_package.py`
+// sets that up and invokes this.
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const esm = await import('vanedb-wasm');
+await esm.default();                       // no-op on Node; real loader in a browser
+
+assert.equal(typeof esm.version(), 'string', 'version() must be callable');
+for (const name of ['FlatIndex', 'ApproxIndex', 'SearchResults']) {
+  assert.equal(typeof esm[name], 'function', `${name} must be a named ESM export`);
+}
+
+const flat = new esm.FlatIndex(3, 'l2');
+flat.add(1n, Float32Array.from([1, 0, 0]));
+flat.add(2n, Float32Array.from([0, 1, 0]));
+const hits = flat.search(Float32Array.from([1, 0, 0]), 2);
+assert.deepEqual([...hits.ids], [1n, 2n], 'nearest first');
+assert.ok(Math.abs(hits.distances[0]) < 1e-6);
+assert.ok(Math.abs(hits.distances[1] - 2.0) < 1e-5, 'L2 is squared');
+hits.free();
+flat.free();
+
+// The delete lifecycle, which only reached wasm in #154.
+const index = new esm.ApproxIndex(3, 'cosine', 16, 4, 16, 7);
+index.add(10n, Float32Array.from([1, 0, 0]));
+index.add(11n, Float32Array.from([0, 1, 0]));
+assert.equal(index.tombstones(), 0);
+index.remove(10n);
+assert.equal(index.tombstones(), 1);
+index.compact();
+assert.equal(index.tombstones(), 0);
+assert.equal(index.size(), 1);
+assert.equal(index.seed(), 7n, 'the construction seed must round-trip');
+index.free();
+
+// The same package through require(), which resolves a different entry point
+// under the `node` + `require` condition.
+const require = createRequire(import.meta.url);
+const cjs = require('vanedb-wasm');
+for (const name of ['FlatIndex', 'ApproxIndex', 'SearchResults', 'version']) {
+  assert.ok(cjs[name], `${name} must also be reachable via require()`);
+}
+const viaRequire = new cjs.FlatIndex(2, 'dot');
+viaRequire.add(5n, Float32Array.from([1, 1]));
+assert.equal(viaRequire.size(), 1);
+viaRequire.free();
+
+console.log('npm package: ESM and CommonJS consumers both OK');


### PR DESCRIPTION
The wasm bindings were packed into two GitHub release tarballs and published **nowhere**. This adds npm publication with OIDC trusted publishing, matching how crates.io and PyPI already work here — no long-lived token stored, and the published package carries a provenance attestation naming the workflow and commit.

## One package, not two

`wasm-pack` emits a separate output per target and names **both** `vanedb-wasm`, so they cannot both take that name. `scripts/build_npm_package.py` merges them under conditional `exports` — `node` resolves the Node build, `browser` and `default` the web build.

The merge is more than moving files, because **the two targets ship different contracts**: the Node build is CommonJS that loads synchronously, while the web build is ESM whose default export is an async loader that must resolve before any class is touched. Routing one specifier at both would hand consumers two different APIs under one import. A generated shim gives Node an `init()` that is a no-op, so the same source runs either way:

```js
import init, { FlatIndex } from 'vanedb-wasm';
await init();                 // no-op under Node, loads the module in a browser
const index = new FlatIndex(3, 'l2');
```

`require('vanedb-wasm')` works too, through a separate entry under the `require` condition.

## Three defects found by installing it, not by reasoning about it

None was visible to any Rust test:

1. **ESM `import { ApproxIndex }` from a CommonJS module fails** Node's named-export detection — `SyntaxError: Named export 'ApproxIndex' not found`. The shim re-exports each name explicitly, and the list is *generated from the build* so a new class cannot be silently omitted.
2. **The package's `"type": "module"` made Node parse wasm-pack's CommonJS output as ESM** and die on its first `exports.` assignment. A nested `package.json` scopes that directory back to CommonJS.
3. **The two targets could drift.** The assembler now fails if the web build is missing anything the Node build exports.

## The check runs the whole path

`scripts/check_npm_package.py`: assemble → `npm pack` → `npm install` into a throwaway project → import through the **public specifier from inside it**, so resolution goes through the package's own `exports` conditions rather than a path. It asserts search results against known distances and exercises the delete lifecycle that only reached wasm in #154.

```
npm package: ESM and CommonJS consumers both OK
npm package vanedb-wasm@0.1.0: consumable
```

## Release safety

The publish job uses the same gate as the crate and Python workflows — `event_name == 'push'` plus a tag prefix — so a dispatch cannot reach it whatever ref it names, and it sits behind a protected `npm` environment. `bench/tests/release_identity.rs` now covers the assembled `package.json`, since its version is copied from the wasm crate's manifest and a mismatch would publish under a version no tag matches. Verified: forcing it to `9.9.9` fails with `says 9.9.9, expected 0.1.0`.

**Every action SHA is verified rather than assumed.** Four were already pinned elsewhere in the repo; `setup-node`'s was read from the GitHub API. wasm-pack is installed with the same script the existing CI uses rather than a new pinned action — I had initially written three fabricated SHAs and caught them by checking.

## Owner action required before this can publish

A trusted publisher must be configured for `vanedb-wasm` on npmjs.com. Unlike crates.io, npm does **not** require a bootstrap publish first. The name is currently free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H