### PR TITLE
fix: close QA's round-two findings, including a claim of mine it refuted

### DIFF
--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -113,12 +113,32 @@ jobs:
       - name: Assemble the package
         run: python3 scripts/build_npm_package.py
 
+      # Re-run the consumer check on this runner's artifact. `verify` tested a
+      # tarball built on a different machine; without this the thing published
+      # is not the thing that was checked.
+      - name: Consume it as an installed dependency
+        run: python3 scripts/check_npm_package.py
+
       # npm 11.5.1+ performs the OIDC exchange itself when the workflow has
       # `id-token: write` and a trusted publisher is configured for the
       # package. `--provenance` records the attestation.
       - name: Update npm
         run: npm install -g npm@latest
 
+      # A prerelease must not take `latest`. `vanedb-wasm-v0.2.0-rc.1` passes
+      # the version check above, and without an explicit dist-tag every
+      # `npm install vanedb-wasm` would resolve to it.
+      - name: Choose the dist-tag
+        id: disttag
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#vanedb-wasm-v}"
+          if [[ "$version" == *-* ]]; then
+            echo "tag=next" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish
-        run: npm publish --provenance --access public
+        run: npm publish --provenance --access public --tag "${{ steps.disttag.outputs.tag }}"
         working-directory: target/npm/vanedb-wasm

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -314,6 +314,20 @@ jobs:
           for browser in chrome firefox webkit; do
             python3 scripts/test_web_package.py target/wasm-artifacts/web/*.tgz "$browser"
           done
+      # The merged npm package is what gets published; without this it was
+      # built and consumed only inside the release workflow, so a break in it
+      # would surface at publish time rather than on the PR that caused it.
+      - name: Build and consume the merged npm package
+        run: |
+          python3 scripts/build_npm_package.py
+          python3 scripts/check_npm_package.py
+      - name: Test the merged package's browser half in Chrome, Firefox and WebKit
+        run: |
+          npm pack target/npm/vanedb-wasm --pack-destination target/npm --ignore-scripts
+          for browser in chrome firefox webkit; do
+            python3 scripts/test_web_package.py target/npm/vanedb-wasm-*.tgz "$browser" \
+              --entry package/web/vanedb_wasm.js
+          done
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: vanedb-wasm-packages

--- a/bench/tests/release_identity.rs
+++ b/bench/tests/release_identity.rs
@@ -96,22 +96,13 @@ fn declared_versions() -> Vec<(&'static str, String)> {
         .to_string();
     sites.push(("vanedb-capi/cbindgen.toml VANEDB_RS_VERSION", macro_version));
 
-    // The npm package's version is copied from the wasm crate's manifest by
-    // `scripts/build_npm_package.py`. That manifest is already listed above,
-    // so this pins the copy rather than the source: the publish workflow's tag
-    // check reads `vanedb-wasm/Cargo.toml`, and a package assembled from a
-    // different value would publish under a version no tag matches.
-    let assembled = repo_root().join("target/npm/vanedb-wasm/package.json");
-    if assembled.exists() {
-        let text = std::fs::read_to_string(&assembled).expect("read assembled package.json");
-        let version = text
-            .lines()
-            .find_map(|l| l.trim().strip_prefix("\"version\": \""))
-            .and_then(|v| v.split('"').next())
-            .expect("assembled package.json declares a version")
-            .to_string();
-        sites.push(("target/npm/vanedb-wasm/package.json", version));
-    }
+    // The npm package's version is not listed here. It is copied from
+    // vanedb-wasm/Cargo.toml by `scripts/build_npm_package.py`, and that
+    // manifest is already checked above — so the copy is pinned at its source.
+    // An earlier version read `target/npm/vanedb-wasm/package.json` behind an
+    // `if exists()`, which nothing in a bench test run produces: the branch was
+    // dead in every context it executed in, which is the shape of test this
+    // release has spent its time removing.
 
     // Doxygen renders this on the generated C++ docs. A free-form string, so
     // it can spell a prerelease and must match in full; it read "0.1.0"

--- a/docs/release/0.1.0-readiness.md
+++ b/docs/release/0.1.0-readiness.md
@@ -3,8 +3,10 @@
 Status: **not ready to tag**. The active target is the first **0.1.0** release.
 
 **The evidence below is historical and does not describe a tree that can be
-tagged.** It certifies artifact candidate `bf797d9`, which `main` is now 27
-non-merge commits past, with the changes concentrated in the artifacts
+tagged.** It certifies artifact candidate `bf797d9`, which `main` has moved
+well past — check with `git rev-list --no-merges --count bf797d9..HEAD` rather
+than trusting a number here; the last one written went stale within a day —
+with the changes concentrated in the artifacts
 themselves — `vanedb-capi/src/lib.rs`, the generated C header,
 `vanedb-py/src/lib.rs`, `vanedb-wasm/src/lib.rs` and the shipping engine.
 

--- a/scripts/test_web_package.py
+++ b/scripts/test_web_package.py
@@ -18,11 +18,25 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("archive", type=Path)
     parser.add_argument("browser", choices=["chrome", "firefox", "webkit"])
+    parser.add_argument(
+        "--entry",
+        default="package/vanedb_wasm.js",
+        help="module path inside the extracted archive. The two-tarball web "
+             "package puts it at the root; the merged npm package, which "
+             "serves both runtimes from one name, puts it under web/.",
+    )
     args = parser.parse_args()
     with tempfile.TemporaryDirectory(prefix="vanedb-web-") as temporary:
         with tarfile.open(args.archive) as archive:
             archive.extractall(temporary, filter="data")
-        shutil.copy2(ROOT / "vanedb-wasm/tests/packaged.html", Path(temporary) / "index.html")
+        page = (ROOT / "vanedb-wasm/tests/packaged.html").read_text()
+        default = "./package/vanedb_wasm.js"
+        wanted = f"./{args.entry}"
+        if wanted != default:
+            if default not in page:
+                raise SystemExit(f"packaged.html no longer imports {default}")
+            page = page.replace(default, wanted)
+        (Path(temporary) / "index.html").write_text(page)
         with ThreadingHTTPServer(("127.0.0.1", 0), partial(SimpleHTTPRequestHandler, directory=temporary)) as server:
             worker = Thread(target=server.serve_forever, daemon=True)
             worker.start()

--- a/vanedb-capi/tests/capi.rs
+++ b/vanedb-capi/tests/capi.rs
@@ -1083,11 +1083,17 @@ fn a_failing_abi_call_from_a_thread_local_destructor_does_not_abort() {
 /// *success* to a C caller — survived the whole suite, as did routing
 /// `InvalidK` to `VANEDB_RS_IO`.
 ///
-/// Two of those six are not reachable through this ABI at all: it derives a
-/// batch's vector count as `n * dim` rather than accepting a length, so a
-/// caller cannot present a mismatched batch or a wrong-width vector. Those
-/// codes exist because `code_for` maps every `VaneError` variant; the header
-/// records which a C caller can actually see.
+/// Three of the sixteen cannot be produced through this ABI at all.
+/// `DIMENSION_MISMATCH` and `BATCH_LENGTH_MISMATCH` are unreachable because
+/// the ABI derives a batch's vector count as `n * dim` rather than accepting a
+/// length, so a caller cannot present a mismatched batch or a wrong-width
+/// vector. `BACKEND` is unreachable because `VaneError::backend` is only
+/// constructed under `gpu-metal`, which `vanedb-capi` does not enable. They
+/// exist because `code_for` maps every `VaneError` variant.
+///
+/// An earlier version of this comment said "two", omitted `BACKEND`, and
+/// claimed the header records which codes a C caller can see. It does not —
+/// the header documents all sixteen alike.
 #[test]
 fn every_reachable_error_code_is_actually_produced() {
     unsafe {
@@ -1180,6 +1186,25 @@ fn every_reachable_error_code_is_actually_produced() {
             "writing onto a directory is an Io failure, got {code}"
         );
         let _ = std::fs::remove_dir_all(&dir);
+
+        // NOT_FOUND: reachable from four entry points and previously asserted
+        // by nothing, in the test named for producing every reachable code.
+        assert_eq!(vanedb_capi::vanedb_rs_store_remove(&*store, 4_242), 1);
+        assert_eq!(
+            vanedb_capi::vanedb_rs_last_error(),
+            vanedb_capi::VANEDB_RS_NOT_FOUND,
+            "removing an absent id must report NotFound"
+        );
+        let mut out = [0.0f32; 3];
+        assert_eq!(
+            vanedb_capi::vanedb_rs_store_get(&*store, 4_242, out.as_mut_ptr()),
+            1
+        );
+        assert_eq!(
+            vanedb_capi::vanedb_rs_last_error(),
+            vanedb_capi::VANEDB_RS_NOT_FOUND,
+            "reading an absent id must report NotFound"
+        );
 
         // NonFiniteValue through the batch path, with a correctly sized buffer:
         // this ABI computes the vector count as `n * dim`, so a short buffer is

--- a/vanedb-wasm/README.md
+++ b/vanedb-wasm/README.md
@@ -26,9 +26,10 @@ the downloadable assets; both retain the JavaScript package name `vanedb-wasm`.
 To build from source, install Rust, the `wasm32-unknown-unknown` target, and
 `wasm-pack`. Node.js is needed for the Node example. Run from the repository root:
 
-Published to npm as [`vanedb-wasm`](https://www.npmjs.com/package/vanedb-wasm).
-One package serves both runtimes through conditional `exports`, so the same
-source works either way:
+The 0.1.0 release publishes `vanedb-wasm` to npm — one package serving both
+runtimes through conditional `exports`, so the same source works either way.
+Nothing is published yet; until then, build from a checkout as shown below.
+Once released:
 
 ```js
 import init, { FlatIndex } from 'vanedb-wasm';

--- a/vanedb/tests/gpu_tests.rs
+++ b/vanedb/tests/gpu_tests.rs
@@ -61,3 +61,80 @@ fn gpu_all_metrics() {
         }
     }
 }
+
+/// GPU and scalar must agree across the tiny/normal matrix.
+///
+/// `MetalCompute::distances` gates on
+/// `buffer.scalar_fallback || needs_scalar(query)`, and a QA sweep found that
+/// changing that `||` to `&&` survives the suite. It called that the
+/// safety-critical survivor: under `&&`, a buffer classified as needing the
+/// scalar path still reaches the GPU when the query looks ordinary.
+///
+/// Measured rather than assumed, it is an equivalent mutant *on this
+/// hardware*. With the mutation applied, every combination of tiny and normal
+/// buffer against tiny and normal query, under both L2 and cosine, returns
+/// bit-identical results to the scalar reference — delta 0.000e0 in all eight.
+/// This Apple GPU does not flush the subnormal intermediates the guard exists
+/// to avoid, so no fixture on this machine can distinguish the operators.
+///
+/// The guard is still correct: `needs_scalar`'s comment describes hardware
+/// that does flush, and that hardware is what it protects against. What cannot
+/// be claimed is that any test here proves it. This asserts the agreement that
+/// *is* observable, which is what would break first on a device that flushes.
+#[test]
+fn gpu_and_scalar_agree_on_subnormal_and_ordinary_inputs() {
+    let Ok(gpu) = MetalCompute::new() else {
+        return; // no Metal device on this machine
+    };
+    let dim = 4;
+    let n = 4;
+    // Small enough that squares and differences of squares are subnormal.
+    let tiny = f32::MIN_POSITIVE.sqrt() / f32::EPSILON / 8.0;
+
+    let corpora = [
+        (
+            "tiny",
+            (0..n * dim)
+                .map(|i| tiny * ((i % 3) as f32 + 1.0))
+                .collect::<Vec<f32>>(),
+        ),
+        (
+            "ordinary",
+            (0..n * dim)
+                .map(|i| (i % 3) as f32 + 1.0)
+                .collect::<Vec<f32>>(),
+        ),
+    ];
+    let queries = [
+        ("tiny", vec![tiny; dim]),
+        (
+            "ordinary",
+            (0..dim).map(|d| d as f32 + 1.0).collect::<Vec<f32>>(),
+        ),
+    ];
+    let metrics = [
+        ("l2", GpuMetric::L2, Metric::L2),
+        ("cosine", GpuMetric::Cosine, Metric::Cosine),
+        ("dot", GpuMetric::Dot, Metric::Dot),
+    ];
+
+    for (corpus_name, vectors) in &corpora {
+        let buffer = gpu.upload(vectors, n, dim).unwrap();
+        for (query_name, query) in &queries {
+            for (metric_name, gpu_metric, cpu_metric) in metrics {
+                let got = gpu.distances(query, &buffer, gpu_metric).unwrap();
+                let reference = distance::distance_fn(cpu_metric);
+                for i in 0..n {
+                    let expected = reference(query, &vectors[i * dim..(i + 1) * dim]);
+                    let tolerance = expected.abs() * 1e-5 + 1e-30;
+                    assert!(
+                        (got[i] - expected).abs() <= tolerance,
+                        "{corpus_name} corpus / {query_name} query / {metric_name}, \
+                         slot {i}: GPU gave {}, scalar gives {expected}",
+                        got[i]
+                    );
+                }
+            }
+        }
+    }
+}

--- a/vanedb/tests/graph_structure.rs
+++ b/vanedb/tests/graph_structure.rs
@@ -284,13 +284,38 @@ fn upper_layers_are_connected_and_links_are_well_formed() {
 /// `CLAUDE.md` requires that all corruption checks be kept. A check nothing
 /// exercises alone is one that can be deleted silently.
 ///
-/// Two clauses stay unpinnable, and the reason is worth recording so the next
-/// reader does not chase them. Deleting `dim == 0` or `m < 2` does not make a
-/// malformed file load: `dim = 0` still trips `count > body.len() / row_bytes`,
-/// and `m = 1` still trips the per-layer degree cap, because a file built with
-/// a larger `M` carries degrees the smaller cap rejects. Those mutants survive
-/// with the *behaviour unchanged*, which is defence in depth rather than an
-/// unexercised guard. The cases below still cover them, just not in isolation.
+/// An earlier version of this test claimed six clauses were isolated and two
+/// were "unpinnable". A QA review deleted each clause and found only two of the
+/// eight actually pinned, and that the stated reason was wrong as well: a
+/// `dim = 0` fixture is not caught by `count > body.len() / row_bytes` — on
+/// that fixture the quotient is 20 against a count of 6 — but by the later
+/// "invalid graph degree" check. The conclusion was right by accident.
+///
+/// The cause was asserting only `Corrupt { .. }`, which cannot tell which
+/// check fired. This guard emits one distinct message, so asserting that
+/// message is what makes a case isolate its clause: a fixture that trips a
+/// *different* check now fails instead of passing for the wrong reason.
+///
+/// With that, deleting a clause individually shows five of the eight pinned:
+/// `dim == 0`, `max_elements > MAX_ELEMENTS`, `m < 2`,
+/// `ef_construction == 0`, and `count > body.len() / row_bytes`.
+///
+/// The other three are shadowed *within the same chain*, and no fixture can
+/// separate them:
+///
+/// - `count > MAX_ELEMENTS` cannot be violated without also exceeding
+///   `max_elements`, because `max_elements > MAX_ELEMENTS` is itself rejected.
+/// - `max_elements == 0` implies `count > max_elements` for any non-empty
+///   graph, and an empty one has nothing to validate.
+/// - `count > max_elements` needs a count above the capacity but within the
+///   rows the body holds, and the writer sizes the body from the capacity, so
+///   that window is empty.
+///
+/// Deleting any of the three leaves the behaviour unchanged — every file they
+/// would have rejected is still rejected by the clause that shadows them. That
+/// is redundancy, not an unexercised guard, and stating it precisely is the
+/// point: the previous version of this comment named the wrong two clauses and
+/// gave a reason that measurement disproved.
 #[test]
 fn every_header_guard_clause_rejects_on_its_own() {
     let good = {
@@ -326,13 +351,22 @@ fn every_header_guard_clause_rejects_on_its_own() {
 
     // Offsets from conformance/graph/README.md. Each case moves exactly one
     // field, to a value that violates exactly one clause.
-    let cases: [(&str, usize, u64); 6] = [
+    // The fixture is dim 4, count 6, max_elements (capacity) 16, m 4,
+    // ef_construction 16, and its body holds 12 rows at 40 bytes each. Each
+    // value below violates exactly the clause it names and nothing else.
+    // Mirrors `MAX_ELEMENTS` in vanedb/src/approx/mod.rs.
+    const MAX_ELEMENTS: u64 = 100_000_000;
+    let cases: [(&str, usize, u64); 8] = [
         ("dim_zero", 16, 0),
-        ("count_over_max_elements", 24, 9),
+        ("count_over_max_elements_const", 24, MAX_ELEMENTS + 1),
         ("max_elements_zero", 32, 0),
+        ("max_elements_over_const", 32, MAX_ELEMENTS + 1),
+        // 17 exceeds the capacity of 16 without exceeding the constant.
+        ("count_over_max_elements", 24, 17),
         ("m_below_two", 40, 1),
         ("ef_construction_zero", 48, 0),
-        ("count_beyond_body", 24, 1_000),
+        // 14 fits within the capacity of 16 but not the 12 rows the body holds.
+        ("count_beyond_body", 24, 14),
     ];
     for (name, offset, value) in cases {
         let mut bytes = good.clone();
@@ -341,9 +375,13 @@ fn every_header_guard_clause_rejects_on_its_own() {
         let err = ApproxIndex::load(&path)
             .err()
             .unwrap_or_else(|| panic!("{name}: a header violating this clause must be rejected"));
+        // The exact message, not merely `Corrupt`. This guard is the only
+        // producer of it, so matching it proves the clause under test fired
+        // rather than a later check catching the same fixture by accident.
         assert!(
-            matches!(err, vanedb::VaneError::Corrupt { .. }),
-            "{name}: expected Corrupt, got {err:?}"
+            matches!(&err, vanedb::VaneError::Corrupt { detail }
+                     if detail.contains("invalid graph dimensions or parameters")),
+            "{name}: expected the header guard to reject this, got {err:?}"
         );
     }
     let _ = fs::remove_dir_all(&dir);


### PR DESCRIPTION
QA lifted its **BLOCK** to **APPROVE WITH CONDITIONS**, and found the same failure mode had recurred *inside* the five PRs that answered it.

## It refuted a claim of mine, and was right

I wrote that two of the eight v2 header-guard clauses were "unpinnable", and that a `dim = 0` fixture is caught by `count > body.len() / row_bytes`. QA deleted each clause and measured: **only two of eight were pinned**, and on that fixture the quotient is 20 against a count of 6 — so that clause never fires. "Invalid graph degree" does. My conclusion was right by accident.

The cause was asserting only `Corrupt { .. }`, which cannot tell which check fired. Two cases were also wrong: one named `count_over_max_elements` set 9 against a capacity of 16, and `max_elements > MAX_ELEMENTS` had no case at all.

Now the guard's distinct message is asserted, so a fixture tripping a *different* check fails instead of passing. With eight honest cases, **five of eight clauses pin**. The other three are shadowed within the same chain and no fixture can separate them — `count > MAX_ELEMENTS` cannot be violated without also exceeding `max_elements`, since `max_elements > MAX_ELEMENTS` is itself rejected. Recorded precisely rather than approximated.

## `VANEDB_RS_NOT_FOUND` was asserted by nothing

In the test named `every_reachable_error_code_is_actually_produced`. It's reachable from four entry points. Now asserted through `_store_remove` and `_store_get`; mapping it to `VANEDB_RS_OK` is caught. Its comment claimed "two of sixteen" are unreachable (three are — `BACKEND` was omitted) and that "the header records which a C caller can see" (it does not).

## The npm workflow published what nobody verified

`verify` built, install-tested and uploaded a tarball; `publish` re-ran the assembler **on a different runner** and published that. It now re-runs the consumer check on its own artifact, and adds dist-tag handling so `vanedb-wasm-v0.2.0-rc.1` publishes to `next` rather than taking `latest`.

**The merged package's browser half was never executed** — deleting `web/` from `files` still printed `consumable`, because the check only runs Node and `exports` resolves `node` first. Both scripts now run in `test-wasm`, and the web half is tested in Chrome, Firefox and WebKit. Verified locally against Chrome.

## Two false statements, one dead test

- `vanedb-wasm/README.md` said the package is "Published to npm" for something never published.
- `release_identity.rs` guarded its npm check with `if assembled.exists()` — a file nothing in a bench run produces. **A dead branch, which is the shape of test this release has spent its time removing.** The version is pinned at its source manifest instead.
- The readiness doc hard-coded a commit count that went stale within a day; it now names the command.

## One QA finding measured and reclassified

It called the Metal fallback guard (`||` → `&&`) the safety-critical survivor. Measured with the mutation applied, across tiny/ordinary buffer × tiny/ordinary query × L2/cosine:

```
delta = 0.000e0   in all eight combinations
```

This GPU does not flush the subnormal intermediates the guard exists to avoid, so **no fixture on this hardware can distinguish the operators**. The guard remains correct for hardware that does flush; what cannot be claimed is that a test proves it. The new test asserts the agreement that *is* observable, across the full matrix and all three metrics, and the finding is recorded with its measurement.

Two fixtures were discarded getting there — a tiny query against an ordinary buffer cannot distinguish them, because the difference is dominated by the ordinary side.

## Evidence

287 Rust, bench, C++ and Python green; `fmt --check`, `clippy -D warnings` under both feature sets, and `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H