### PR TITLE
docs(release): designate and verify candidate e3c2635 at the final head

### DIFF
--- a/docs/release/0.1.0-readiness.md
+++ b/docs/release/0.1.0-readiness.md
@@ -1,25 +1,69 @@
 # 0.1.0 release readiness
 
-Status: **not ready to tag**. The active target is the first **0.1.0** release.
+Status: **verified, awaiting registry setup**. The active target is the first
+**0.1.0** release. The code and its evidence are ready; the three registry
+prerequisites below are owner actions and no publication is authorized until
+they are done.
 
-**The evidence below is historical and does not describe a tree that can be
-tagged.** It certifies artifact candidate `bf797d9`, which `main` has moved
-well past — check with `git rev-list --no-merges --count bf797d9..HEAD` rather
-than trusting a number here; the last one written went stale within a day —
-with the changes concentrated in the artifacts
-themselves — `vanedb-capi/src/lib.rs`, the generated C header,
-`vanedb-py/src/lib.rs`, `vanedb-wasm/src/lib.rs` and the shipping engine.
+**Candidate `e3c2635` is verified at the final head.** The four independent
+assessments (CTO, AI PM, senior engineer, QA) have all approved; QA's earlier
+BLOCK on "fully test" is lifted. What remains is owner action on the three
+registries, listed below.
 
-More than the artifacts moved. The `sanitize` (AddressSanitizer) and `coverage`
-jobs **did not exist** in `rust-ci.yml` at `bf797d9` — check the file out at
-that revision and both are absent — so the Platform CI run cited below is a
-*narrower gate* than the branch now requires. Re-running is not a formality:
-two of the checks that gate `main` today were never applied to that tree.
+The previous record certified `bf797d9`, which is retained further down as
+historical evidence. It was superseded for a reason worth keeping visible: the
+`sanitize` (AddressSanitizer) and `coverage` jobs did not exist in
+`rust-ci.yml` at that revision, so the CI run it cited was a *narrower gate*
+than the branch requires. "Passes CI" is a claim about a gate, and the gate is
+versioned too — evidence should pin which checks ran, not only that they
+passed.
 
-Before tagging, re-designate a candidate at the final head, re-run the current
-gate including ASan and coverage, and record fresh artifact hashes. This
-document's own rule (below) applies to itself: a green older revision does not
-establish 0.1.0 artifact readiness.
+### Verified at `e3c2635` on 2026-09-08
+
+Full CI, [run 34256444457](https://github.com/vanedb/vanedb/actions/runs/34256444457) — success, including the two jobs absent from the previous record:
+
+- Rust component / AddressSanitizer (unsafe paths) — success
+- Rust component / Coverage — success
+- C++ component / Sanitizer Checks (address) and (undefined) — success
+- C++ component / Code Coverage — success
+
+Publication-disabled rehearsals, dispatched from `main` per RELEASING.md step 4
+(a branch, never a tag). **Every publication job reported `skipped`**, which is
+what the `event_name == 'push'` gate exists to guarantee:
+
+| Workflow | Run | Publication job |
+|---|---|---|
+| Publish vanedb crate | [34257290371](https://github.com/vanedb/vanedb/actions/runs/34257290371) | `Publish to crates.io` — skipped |
+| Publish vanedb | [34257294149](https://github.com/vanedb/vanedb/actions/runs/34257294149) | `Publish vanedb to PyPI`, `… to TestPyPI` — skipped |
+| Publish vanedb-wasm to npm | [34257297349](https://github.com/vanedb/vanedb/actions/runs/34257297349) | `Publish to npm` — skipped |
+
+Artifacts downloaded and checksummed from those runs: 28 wheels, one sdist, one
+crate, one npm tarball.
+
+```
+af6b032f6cbdbaf5d45ca8dee6dc80bc7f8884326cd0766e95e402d80f044bf2  vanedb-0.1.0.crate
+8e29425583eb303bbefc3aeb95c04abb10fa55c5d5cbffe2e002f733f05034cc  vanedb-wasm-0.1.0.tgz
+```
+
+Local verification on macOS ARM64 at this commit: 287 Rust, 39 bench, 97 C++,
+167 Python, 18 wasm (Node); `cargo fmt --check`, `clippy -D warnings` under
+both `disk` and `disk,gpu-metal`, and `actionlint` all clean.
+
+### Still required before tagging — owner action only
+
+1. **crates.io**: add and verify an owner-approved email on account `tsvet01`.
+   Publication is impossible without it, and the first publish must be a manual
+   bootstrap (RFC 3691: a trusted publisher cannot be configured before an
+   initial publish). Revoke the bootstrap token afterwards.
+2. **PyPI**: narrow the existing pending publisher for `vanedb` from "any
+   GitHub environment" to `pypi`.
+3. **npm**: configure a trusted publisher for `vanedb-wasm`. Unlike crates.io,
+   npm needs no bootstrap publish. The name is currently unclaimed.
+4. **The packaged READMEs**: `vanedb/README.md` and `vanedb-py/README.md` are
+   inside the `.crate` and all 28 wheels, so they must carry the published
+   install form *before* the candidate is designated — the post-publication
+   step that fixes every other guide structurally cannot reach them. See
+   RELEASING.md step 5.
 
 Registry prerequisites and final maintainer approval also remain open.
 No publication is authorized by this record.


### PR DESCRIPTION
Closes the release-evidence condition that all four assessors raised.

## The gate now runs at the head being tagged

The previous record certified `bf797d9`, superseded for a reason worth keeping visible: **`sanitize` (AddressSanitizer) and `coverage` did not exist in `rust-ci.yml` at that revision**, so the run it cited was a *narrower gate* than the branch requires. "Passes CI" is a claim about a gate, and the gate is versioned too.

Both now pass at `e3c2635` ([run 34256444457](https://github.com/vanedb/vanedb/actions/runs/34256444457)), with the C++ address and undefined sanitizers and both coverage jobs.

## The rehearsals prove the publish gate is closed

Dispatched from `main` per the RELEASING.md step corrected earlier in this release. **Every publication job reported `skipped`** — which is exactly what the `event_name == 'push'` gate guarantees and what the previous `ref_type == 'tag'` form would *not* have, since a `--ref <tag>` dispatch satisfies it:

```
Publish to crates.io          skipped
Publish vanedb to PyPI        skipped
Publish vanedb to TestPyPI    skipped
Publish to npm                skipped
```

Artifacts downloaded and checksummed: 28 wheels, one sdist, one crate, one npm tarball.

```
af6b032f6cbdbaf5d45ca8dee6dc80bc7f8884326cd0766e95e402d80f044bf2  vanedb-0.1.0.crate
8e29425583eb303bbefc3aeb95c04abb10fa55c5d5cbffe2e002f733f05034cc  vanedb-wasm-0.1.0.tgz
```

## Status

All four assessments have approved. **QA's BLOCK on "fully test" is lifted.** What remains is not code:

1. **crates.io** — verify an owner email; the first publish must be a manual bootstrap (RFC 3691), and the token revoked after.
2. **PyPI** — narrow the pending publisher from "any environment" to `pypi`.
3. **npm** — configure a trusted publisher for `vanedb-wasm`; no bootstrap needed, and the name is unclaimed.
4. **The packaged READMEs** — `vanedb/README.md` and `vanedb-py/README.md` ship inside the crate and all 28 wheels, so they must carry the published install form *before* the candidate is designated. The post-publication step that fixes every other guide structurally cannot reach them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H