### PR TITLE
feat(wasm)!: publish as @vanedb/wasm rather than vanedb-wasm

### DIFF
--- a/docs/release/0.1.0-readiness.md
+++ b/docs/release/0.1.0-readiness.md
@@ -51,14 +51,17 @@ both `disk` and `disk,gpu-metal`, and `actionlint` all clean.
 
 ### Still required before tagging — owner action only
 
-1. **crates.io**: add and verify an owner-approved email on account `tsvet01`.
-   Publication is impossible without it, and the first publish must be a manual
+1. ~~**crates.io**: verify an owner-approved email.~~ Done — `anton@tsvetkov.org`
+   verified on account `tsvet01`. The first publish must still be a manual
    bootstrap (RFC 3691: a trusted publisher cannot be configured before an
-   initial publish). Revoke the bootstrap token afterwards.
-2. **PyPI**: narrow the existing pending publisher for `vanedb` from "any
-   GitHub environment" to `pypi`.
-3. **npm**: configure a trusted publisher for `vanedb-wasm`. Unlike crates.io,
-   npm needs no bootstrap publish. The name is currently unclaimed.
+   initial publish); revoke that token afterwards.
+2. ~~**PyPI**: narrow the pending publisher to the `pypi` environment.~~ Done.
+   The publisher is `vanedb/vanedb`, workflow `publish-rust.yml`, environment
+   `pypi`. TestPyPI is a separate registry with its own publisher list; the
+   `testpypi` job only runs on an explicit dispatch, never on a tag.
+3. **npm**: claim the `vanedb` scope and configure a trusted publisher for
+   `@vanedb/wasm` — repository `vanedb/vanedb`, workflow `publish-wasm.yml`,
+   environment `npm`. Unlike crates.io, npm needs no bootstrap publish.
 4. **The packaged READMEs**: `vanedb/README.md` and `vanedb-py/README.md` are
    inside the `.crate` and all 28 wheels, so they must carry the published
    install form *before* the candidate is designated — the post-publication

--- a/docs/release/RELEASING.md
+++ b/docs/release/RELEASING.md
@@ -112,15 +112,19 @@ changes to a version dependency, which would make crates.io a hard prerequisite.
   protected `crates-io` job. If 0.1.0 is the manual bootstrap publication,
   do not also trigger this tag's upload of the same version; use the crate-tag
   workflow for later versions after configuring its publisher.
-- WebAssembly uses tag `vanedb-wasm-v0.1.0`. `scripts/build_npm_package.py`
-  merges the two wasm-pack targets into one `vanedb-wasm` package with
-  conditional `exports`, and `scripts/check_npm_package.py` installs the packed
+- WebAssembly uses tag `vanedb-wasm-v0.1.0` — the tag names the crate; the
+  published package is **`@vanedb/wasm`**. `scripts/build_npm_package.py`
+  merges the two wasm-pack targets into that one package with conditional
+  `exports`, and `scripts/check_npm_package.py` installs the packed
   tarball into a throwaway project and imports it through the public specifier
   in both ESM and CommonJS before the protected `npm` publication job. npm uses
   OIDC trusted publishing with `--provenance`, so no long-lived token is stored
   and the published package carries an attestation naming this workflow and
-  commit. A trusted publisher must be configured on npmjs.com for the package
-  first; unlike crates.io, npm does not require a bootstrap publish.
+  commit. A trusted publisher must be configured on npmjs.com for
+  `@vanedb/wasm` first, which requires owning the `vanedb` npm organisation or
+  user scope. Unlike crates.io, npm needs no bootstrap publish. Scoped
+  packages default to private, which is why the publish step passes
+  `--access public`.
 - C library archives come from the
   approved commit's CI artifacts. Attach the C archives with their runtime
   compatibility metadata, and `vanedb-wasm-0.1.0-nodejs.tgz` and

--- a/scripts/build_npm_package.py
+++ b/scripts/build_npm_package.py
@@ -147,7 +147,10 @@ def main() -> None:
 
     generated = json.loads((node_dir / "package.json").read_text())
     package = {
-        "name": "vanedb-wasm",
+        # Scoped, so a future native binding can take `@vanedb/node` without
+        # competing with this one for a bare name. `--access public` in the
+        # publish workflow is required: npm defaults scoped packages private.
+        "name": "@vanedb/wasm",
         "version": generated["version"],
         "description": generated["description"],
         "license": generated["license"],

--- a/vanedb-wasm/README.md
+++ b/vanedb-wasm/README.md
@@ -26,19 +26,20 @@ the downloadable assets; both retain the JavaScript package name `vanedb-wasm`.
 To build from source, install Rust, the `wasm32-unknown-unknown` target, and
 `wasm-pack`. Node.js is needed for the Node example. Run from the repository root:
 
-The 0.1.0 release publishes `vanedb-wasm` to npm — one package serving both
-runtimes through conditional `exports`, so the same source works either way.
-Nothing is published yet; until then, build from a checkout as shown below.
-Once released:
+The 0.1.0 release publishes **`@vanedb/wasm`** to npm — one package serving
+both runtimes through conditional `exports`, so the same source works either
+way. The scope leaves room for a future native binding under `@vanedb/node`
+without competing for a bare name. Nothing is published yet; until then, build
+from a checkout as shown below. Once released:
 
 ```js
-import init, { FlatIndex } from 'vanedb-wasm';
+import init, { FlatIndex } from '@vanedb/wasm';
 
 await init();          // no-op under Node, loads the module in a browser
 const index = new FlatIndex(3, 'l2');
 ```
 
-`require('vanedb-wasm')` works too. To build from a checkout instead:
+`require('@vanedb/wasm')` works too. To build from a checkout instead:
 
 ```sh
 rustup target add wasm32-unknown-unknown

--- a/vanedb-wasm/tests/npm_package.mjs
+++ b/vanedb-wasm/tests/npm_package.mjs
@@ -19,7 +19,7 @@
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
 
-const esm = await import('vanedb-wasm');
+const esm = await import('@vanedb/wasm');
 await esm.default();                       // no-op on Node; real loader in a browser
 
 assert.equal(typeof esm.version(), 'string', 'version() must be callable');
@@ -53,7 +53,7 @@ index.free();
 // The same package through require(), which resolves a different entry point
 // under the `node` + `require` condition.
 const require = createRequire(import.meta.url);
-const cjs = require('vanedb-wasm');
+const cjs = require('@vanedb/wasm');
 for (const name of ['FlatIndex', 'ApproxIndex', 'SearchResults', 'version']) {
   assert.ok(cjs[name], `${name} must also be reachable via require()`);
 }


### PR DESCRIPTION
> **BREAKING**: the npm package name. Nothing is published, so this costs no migration — which is the reason to settle it now.

`vanedb-wasm` named a mechanism. A JavaScript developer installing a vector database cares that it runs in Node and the browser, not that it's compiled from Rust to WebAssembly — and the package already serves both through conditional `exports`, so there's no sibling it needs distinguishing from.

The scope is the forward-compatible shape once more bindings are expected: a future native addon takes `@vanedb/node` without competing for the bare `vanedb` name, and the brand stays one word across all three registries.

## Mechanically

- npm **flattens the scope when packing**, so the tarball is still `vanedb-wasm-0.1.0.tgz` and the workflow's globs are unchanged.
- The **git tag stays `vanedb-wasm-v*`**. It names the crate, matching `vanedb-crate-v*` and `vanedb-v*`.
- Scoped packages default to **private**; the publish step already passes `--access public`, and `RELEASING.md` now says why.
- Publishing needs the `vanedb` npm scope claimed — recorded with the other registry prerequisites.

## Verified with the new name

```
npm package: ESM and CommonJS consumers both OK
npm package @vanedb/wasm@0.1.0: consumable
Packaged browser acceptance passed: chrome
```

Assembled, packed, installed into a throwaway project, imported through the public specifier in both module systems, then the browser half loaded in Chrome from the packed tarball. `fmt`, `actionlint`, `conformance_docs` and `release_identity` clean.

## Pre-tag checklist: 2 of 4 done

| | |
|---|---|
| crates.io email | ✅ `anton@tsvetkov.org` verified on `tsvet01` |
| PyPI publisher | ✅ narrowed to environment `pypi` |
| npm trusted publisher | ⬜ claim the `vanedb` scope, then configure for `@vanedb/wasm` |
| Packaged READMEs | ⬜ mechanical, lands in the release commit |

🤖 Generated with [Claude Code](https://claude.com/claude-code)