### PR TITLE
docs(capi): make the ctypes trap that segfaulted a reviewer unmissable

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -317,6 +317,16 @@ jobs:
       # The merged npm package is what gets published; without this it was
       # built and consumed only inside the release workflow, so a break in it
       # would surface at publish time rather than on the PR that caused it.
+      # The ctypes example is the C ABI's Python-facing documentation, and a
+      # broken example is worse than none because it is what a reader copies.
+      # The unit tests check its signatures statically; this runs it against a
+      # real library, which they deliberately do not (an earlier version tried
+      # and silently skipped when the cdylib was absent).
+      - name: Run the C ABI ctypes example
+        run: |
+          cargo build -p vanedb-capi --release --locked
+          python3 vanedb-capi/examples/ctypes_quickstart.py \
+            target/release/libvanedb_capi.so
       - name: Build and consume the merged npm package
         run: |
           python3 scripts/build_npm_package.py

--- a/vanedb-capi/README.md
+++ b/vanedb-capi/README.md
@@ -83,6 +83,25 @@ handle's own setting, which `vanedb_rs_index_ef_search()` reports. Note that
 `vanedb_cpp_index_search` rejects `0` rather than resolving it — the two ABIs
 are otherwise callable through one uniform FFI.
 
+### Calling from Python with ctypes
+
+Declare `restype` and `argtypes` for **every** function before calling it.
+ctypes defaults an undeclared return to a C `int`, which truncates a 64-bit
+pointer to 32 bits; the next dereference reads a garbage address and the
+process dies with SIGSEGV and no Python traceback, because the fault happens
+inside libffi. A crash whose stack reads `PyCFuncPtr_call` →
+`_ctypes_callproc` → `ffi_call` is almost always a missing `restype` rather
+than a fault in this library. Undeclared pointer *arguments* truncate the same
+way on the way in.
+
+Use `c_void_p` rather than `c_char_p` for `vanedb_rs_last_error_message`:
+`c_char_p` copies the bytes into a Python object at the boundary, which is
+convenient but conceals the lifetime — the pointer is valid only until the next
+`vanedb_rs_*` call on that thread, or until the thread exits.
+
+[`examples/ctypes_quickstart.py`](examples/ctypes_quickstart.py) is a complete
+working consumer; CI runs it against a built library on every change.
+
 `vanedb_rs_version()` returns the library's version so a consumer can check the
 shared object matches the header it compiled against. This is a 0.x ABI: it may
 change in a minor release. See the

--- a/vanedb-capi/examples/ctypes_quickstart.py
+++ b/vanedb-capi/examples/ctypes_quickstart.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Consume the vanedb C ABI from Python through ctypes.
+
+Run against a built library:
+
+    cargo build -p vanedb-capi --release
+    python3 vanedb-capi/examples/ctypes_quickstart.py target/release/libvanedb_capi.dylib
+
+**Declare `restype` and `argtypes` for every function you call.** ctypes
+defaults an undeclared return to a C `int`, which truncates a 64-bit pointer to
+32 bits. The next dereference reads a garbage address and the process dies with
+SIGSEGV — no Python traceback, because the fault happens inside libffi. A crash
+whose stack is `PyCFuncPtr_call -> _ctypes_callproc -> ffi_call` is almost
+always this and not a bug in the library.
+
+The same applies to arguments: an undeclared pointer argument is passed as an
+int, so a 64-bit handle arrives at the callee truncated.
+"""
+
+import ctypes
+import sys
+from pathlib import Path
+
+L2, COSINE, DOT = 0, 1, 2
+OK, NULL_ARGUMENT, NOT_FOUND, DUPLICATE_ID = 0, 1, 5, 6
+
+
+def bind(lib: ctypes.CDLL) -> None:
+    """Every signature this example uses. Nothing is called before it is bound."""
+    u64 = ctypes.c_uint64
+    usize = ctypes.c_size_t
+    f32p = ctypes.POINTER(ctypes.c_float)
+
+    lib.vanedb_rs_version.restype = ctypes.c_char_p
+    lib.vanedb_rs_version.argtypes = []
+
+    lib.vanedb_rs_last_error.restype = ctypes.c_uint32
+    lib.vanedb_rs_last_error.argtypes = []
+
+    # c_void_p, not c_char_p. With c_char_p ctypes copies the bytes into a
+    # Python object at the boundary, which is convenient but hides the
+    # lifetime: the pointer is only valid until the next vanedb_rs_* call on
+    # this thread, or until this thread exits. Reading it explicitly keeps that
+    # visible.
+    lib.vanedb_rs_last_error_message.restype = ctypes.c_void_p
+    lib.vanedb_rs_last_error_message.argtypes = []
+
+    lib.vanedb_rs_store_new.restype = ctypes.c_void_p
+    lib.vanedb_rs_store_new.argtypes = [usize, ctypes.c_uint32]
+    lib.vanedb_rs_store_free.restype = None
+    lib.vanedb_rs_store_free.argtypes = [ctypes.c_void_p]
+    lib.vanedb_rs_store_add.restype = ctypes.c_int32
+    lib.vanedb_rs_store_add.argtypes = [ctypes.c_void_p, u64, f32p]
+    lib.vanedb_rs_store_len.restype = usize
+    lib.vanedb_rs_store_len.argtypes = [ctypes.c_void_p]
+    lib.vanedb_rs_store_get.restype = ctypes.c_int32
+    lib.vanedb_rs_store_get.argtypes = [ctypes.c_void_p, u64, f32p]
+    lib.vanedb_rs_store_search.restype = usize
+    lib.vanedb_rs_store_search.argtypes = [
+        ctypes.c_void_p, f32p, usize, ctypes.POINTER(u64), f32p
+    ]
+
+
+def message(lib: ctypes.CDLL) -> str:
+    pointer = lib.vanedb_rs_last_error_message()
+    return ctypes.string_at(pointer).decode() if pointer else ""
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(__doc__)
+        return 2
+    library = Path(sys.argv[1])
+    if not library.exists():
+        print(f"no library at {library}; build it with "
+              f"`cargo build -p vanedb-capi --release`")
+        return 2
+
+    lib = ctypes.CDLL(str(library))
+    bind(lib)
+    print("vanedb", lib.vanedb_rs_version().decode())
+
+    dim = 3
+    store = lib.vanedb_rs_store_new(dim, L2)
+    if not store:
+        print(f"construction failed: code {lib.vanedb_rs_last_error()} "
+              f"{message(lib)!r}")
+        return 1
+    try:
+        floats = ctypes.c_float * dim
+        assert lib.vanedb_rs_store_add(store, 1, floats(1.0, 0.0, 0.0)) == OK
+        assert lib.vanedb_rs_store_add(store, 2, floats(0.0, 1.0, 0.0)) == OK
+        print("stored", lib.vanedb_rs_store_len(store), "vectors")
+
+        # Failures report a reason. The return value alone cannot: every status
+        # function returns 1, and a search returns 0 results for both an empty
+        # store and a rejected query.
+        if lib.vanedb_rs_store_add(store, 1, floats(9.0, 9.0, 9.0)) != OK:
+            code = lib.vanedb_rs_last_error()
+            print(f"duplicate rejected: code {code} {message(lib)!r}")
+            assert code == DUPLICATE_ID
+
+        out = floats()
+        if lib.vanedb_rs_store_get(store, 99, out) != OK:
+            assert lib.vanedb_rs_last_error() == NOT_FOUND
+            print(f"absent id: code {NOT_FOUND} {message(lib)!r}")
+
+        k = 2
+        ids = (ctypes.c_uint64 * k)()
+        distances = floats(*([0.0] * k)) if k == dim else (ctypes.c_float * k)()
+        found = lib.vanedb_rs_store_search(store, floats(1.0, 0.0, 0.0), k, ids, distances)
+        assert lib.vanedb_rs_last_error() == OK, "a real failure would set a code"
+        print("nearest:", [(ids[i], round(distances[i], 4)) for i in range(found)])
+    finally:
+        lib.vanedb_rs_store_free(store)
+    print("OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vanedb-capi/tests/ctypes_example.rs
+++ b/vanedb-capi/tests/ctypes_example.rs
@@ -1,0 +1,94 @@
+//! The shipped ctypes example must declare a signature for every call it makes.
+//!
+//! An agent reviewing this crate crashed a Python interpreter with SIGSEGV
+//! calling `vanedb_rs_last_error_message` through ctypes without declaring
+//! `restype`. ctypes then treats a returned `const char*` as a C `int`,
+//! truncating the pointer, and the dereference faults inside libffi with no
+//! Python traceback. The library was sound; the caller had no guidance.
+//!
+//! `examples/ctypes_quickstart.py` is that guidance, and this checks the one
+//! property that makes it safe: every function it calls is bound first. That
+//! is a source-level check on purpose — an earlier version of this test ran
+//! the example against the cdylib and *skipped* when it was absent, which it
+//! is under a plain `cargo test`, so it passed while testing nothing. CI runs
+//! the example for real; this runs everywhere.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+fn example() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples/ctypes_quickstart.py");
+    std::fs::read_to_string(&path).expect("the ctypes example must exist")
+}
+
+/// Collect `lib.<name>` occurrences, split by whether they are a binding
+/// (`lib.x.restype = ...`) or a call (`lib.x(...)`).
+fn bound_and_called(source: &str) -> (HashSet<String>, HashSet<String>) {
+    let (mut bound, mut called) = (HashSet::new(), HashSet::new());
+    for (index, _) in source.match_indices("lib.") {
+        let rest = &source[index + 4..];
+        let name: String = rest
+            .chars()
+            .take_while(|c| c.is_alphanumeric() || *c == '_')
+            .collect();
+        if name.is_empty() {
+            continue;
+        }
+        let after = &rest[name.len()..];
+        if after.starts_with(".restype") {
+            bound.insert(name);
+        } else if after.starts_with('(') {
+            called.insert(name);
+        }
+    }
+    (bound, called)
+}
+
+#[test]
+fn the_ctypes_example_binds_every_function_it_calls() {
+    let source = example();
+    let (bound, called) = bound_and_called(&source);
+
+    assert!(
+        !called.is_empty(),
+        "found no calls at all; the scan is broken, not the example"
+    );
+    let unbound: Vec<_> = called.difference(&bound).cloned().collect();
+    assert!(
+        unbound.is_empty(),
+        "these are called without a declared restype, which truncates a \
+         returned pointer to a C int and segfaults on dereference: {unbound:?}"
+    );
+}
+
+/// Every bound function must declare `argtypes` too. An undeclared pointer
+/// argument is passed as an int, so a 64-bit handle arrives truncated — the
+/// same defect on the way in.
+#[test]
+fn the_ctypes_example_declares_argtypes_for_everything_it_binds() {
+    let source = example();
+    let (bound, _) = bound_and_called(&source);
+    let missing: Vec<_> = bound
+        .iter()
+        .filter(|name| !source.contains(&format!("lib.{name}.argtypes")))
+        .cloned()
+        .collect();
+    assert!(missing.is_empty(), "bound without argtypes: {missing:?}");
+}
+
+/// The example must not use `c_char_p` for the error message. ctypes copies
+/// the bytes into a Python object at the boundary, which hides that the
+/// pointer is only valid until the next call on this thread — the lifetime the
+/// example exists to teach.
+#[test]
+fn the_error_message_is_read_as_a_raw_pointer() {
+    let source = example();
+    let line = source
+        .lines()
+        .find(|l| l.contains("vanedb_rs_last_error_message.restype"))
+        .expect("the example must bind the message accessor");
+    assert!(
+        line.contains("c_void_p"),
+        "expected c_void_p so the lifetime stays visible, got: {line}"
+    );
+}


### PR DESCRIPTION
An agent reviewing this crate crashed a Python interpreter with **SIGSEGV** calling `vanedb_rs_last_error_message` through ctypes without declaring `restype`. ctypes then treats a returned `const char*` as a C `int`, truncating the pointer; the dereference faults inside libffi with no Python traceback.

**The library was sound** — a correctly bound probe runs 20,000 failure/read cycles clean. But the crate shipped a C ABI with *no ctypes guidance and no Python example*, so nothing stood between a consumer and the same fault.

## What's added

`examples/ctypes_quickstart.py` — a complete consumer that binds every signature, demonstrates the error channel, and explains why a stack reading `PyCFuncPtr_call` → `_ctypes_callproc` → `ffi_call` is almost always a missing `restype` rather than a library fault:

```
vanedb 0.1.0
stored 2 vectors
duplicate rejected: code 6 'duplicate id: 1'
absent id: code 5 'vector not found: 99'
nearest: [(1, 0.0), (2, 2.0)]
OK
```

It reads the message with `c_void_p` rather than `c_char_p`, because `c_char_p` copies the bytes at the boundary and **conceals the lifetime the example exists to teach** — the pointer is valid only until the next call on that thread, or until the thread exits.

The C ABI README gains a "Calling from Python with ctypes" section covering the same ground.

## The tests check the property that makes it safe

Every function called is bound first; every binding declares `argtypes`; the message accessor is read as a raw pointer. Mutation-verified:

```
remove one restype        -> FAILED ("...truncates a returned pointer...")
c_void_p -> c_char_p      -> FAILED ("expected c_void_p so the lifetime stays visible")
```

## How those tests got here

The first version ran the example against the cdylib — and **skipped** when it was absent, which it is under a plain `cargo test`, since only the staticlib lands in `target/debug`. It reported success while executing nothing: the exact defect class this release has spent its time removing, reintroduced while documenting a crash.

The signature checks are source-level so they always run. CI runs the example for real against a built library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H