### PR TITLE
docs(release): npm needs a bootstrap publish too — correcting my error

### DIFF
--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -122,6 +122,12 @@ jobs:
       # npm 11.5.1+ performs the OIDC exchange itself when the workflow has
       # `id-token: write` and a trusted publisher is configured for the
       # package. `--provenance` records the attestation.
+      #
+      # That configuration lives on the package's own settings page and cannot
+      # be created before the package exists — npm has no equivalent of PyPI's
+      # pending publisher. So the first version is published by hand with a
+      # token and this job takes over from the second onwards, the same
+      # bootstrap crates.io requires.
       - name: Update npm
         run: npm install -g npm@latest
 

--- a/docs/release/0.1.0-readiness.md
+++ b/docs/release/0.1.0-readiness.md
@@ -59,9 +59,14 @@ both `disk` and `disk,gpu-metal`, and `actionlint` all clean.
    The publisher is `vanedb/vanedb`, workflow `publish-rust.yml`, environment
    `pypi`. TestPyPI is a separate registry with its own publisher list; the
    `testpypi` job only runs on an explicit dispatch, never on a tag.
-3. **npm**: claim the `vanedb` scope and configure a trusted publisher for
-   `@vanedb/wasm` — repository `vanedb/vanedb`, workflow `publish-wasm.yml`,
-   environment `npm`. Unlike crates.io, npm needs no bootstrap publish.
+3. **npm**: claim the `vanedb` scope, then bootstrap-publish `@vanedb/wasm`
+   with a granular token, then configure the trusted publisher at
+   `Packages → @vanedb/wasm → Settings → Trusted publishing` — repository
+   `vanedb/vanedb`, workflow `publish-wasm.yml`, environment `npm` — and
+   revoke the token. npm's trusted publishing is per package and the settings
+   page does not exist until the package does; there is no equivalent of
+   PyPI's pending publisher. This mirrors the crates.io bootstrap, and an
+   earlier version of this record wrongly said otherwise.
 4. **The packaged READMEs**: `vanedb/README.md` and `vanedb-py/README.md` are
    inside the `.crate` and all 28 wheels, so they must carry the published
    install form *before* the candidate is designated — the post-publication

--- a/docs/release/RELEASING.md
+++ b/docs/release/RELEASING.md
@@ -122,8 +122,22 @@ changes to a version dependency, which would make crates.io a hard prerequisite.
   and the published package carries an attestation naming this workflow and
   commit. A trusted publisher must be configured on npmjs.com for
   `@vanedb/wasm` first, which requires owning the `vanedb` npm organisation or
-  user scope. Unlike crates.io, npm needs no bootstrap publish. Scoped
-  packages default to private, which is why the publish step passes
+  user scope.
+
+  **npm needs a bootstrap publish, exactly like crates.io.** Trusted
+  publishing is configured per package, at
+  `npmjs.com → Packages → @vanedb/wasm → Settings → Trusted publishing`, and
+  that page cannot exist until the package does. npm has no equivalent of
+  PyPI's pending publisher. So the first version is published manually with a
+  granular access token, the trusted publisher is configured afterwards, and
+  the token is revoked. As with crates.io, the bootstrap version carries no
+  provenance attestation; every later version does.
+
+  Do not also push `vanedb-wasm-v<version>` for a bootstrapped version — the
+  tagged workflow would attempt the same version against a registry that
+  rejects re-uploads.
+
+  Scoped packages default to private, which is why the publish step passes
   `--access public`.
 - C library archives come from the
   approved commit's CI artifacts. Attach the C archives with their runtime


### PR DESCRIPTION
I told the maintainer that npm, unlike crates.io, needs no bootstrap publish, and wrote it into `RELEASING.md`, the readiness record and the publish workflow's comments. **It is wrong**, and it blocked them — they went looking for an organisation-level setting that does not exist.

## What is actually true

npm's trusted publishing is configured **per package**:

```
npmjs.com → Packages → @vanedb/wasm → Settings → Trusted publishing
```

That page cannot exist before the package does, and **npm has no equivalent of PyPI's pending publisher**. So the sequence mirrors crates.io exactly:

1. Claim the `vanedb` scope.
2. Publish `@vanedb/wasm@0.1.0` by hand with a granular access token.
3. Configure the trusted publisher on the package's settings page.
4. Revoke the token.

The bootstrap version carries no provenance attestation; every later version does — the same trade crates.io imposes, which the runbook already documented for that registry.

Also records the corollary the crates.io section already carries: **do not push a release tag for a bootstrapped version**, since the tagged workflow would attempt the same version against a registry that rejects re-uploads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H