### PR TITLE
docs: state the underflow bound once instead of seven times

### DIFF
--- a/cpp/src/core/distance_kernels.h
+++ b/cpp/src/core/distance_kernels.h
@@ -201,10 +201,10 @@ namespace vanedb::detail::scalar {
   // denominator in range for both tiny and huge vectors. A vector with no
   // usable direction is 1.0 away from everything, including itself, and
   // there are three ways to have none: a zero vector, a squared norm that
-  // overflowed float, and a squared norm that *underflowed* it — a component
-  // below roughly 2.6e-23 squares to zero, so a vector whose components are
-  // all below it has a zero norm and lands here. The 1e-25 rows of
-  // cosine_scale_invariance.tsv pin that last case in both engines.
+  // overflowed float, and one that *underflowed* it, which needs every
+  // component small enough that its square reaches zero. ../conformance's
+  // README states the bound for both engines; the 1e-25 rows of
+  // cosine_scale_invariance.tsv pin the case here.
   float denom = sqrtf(na) * sqrtf(nb);
   if (!(denom > 0.0f && std::isfinite(denom))) return 1.0f;
   float sim = dot / denom;

--- a/cpp/src/core/distance_kernels.h
+++ b/cpp/src/core/distance_kernels.h
@@ -202,8 +202,8 @@ namespace vanedb::detail::scalar {
   // usable direction is 1.0 away from everything, including itself, and
   // there are three ways to have none: a zero vector, a squared norm that
   // overflowed float, and one that *underflowed* it, which needs every
-  // component small enough that its square reaches zero. ../conformance's
-  // README states the bound for both engines; the 1e-25 rows of
+  // component small enough that its square reaches zero. conformance/README.md
+  // states the bound for both engines; the 1e-25 rows of
   // cosine_scale_invariance.tsv pin the case here.
   float denom = sqrtf(na) * sqrtf(nb);
   if (!(denom > 0.0f && std::isfinite(denom))) return 1.0f;

--- a/vanedb/src/distance/mod.rs
+++ b/vanedb/src/distance/mod.rs
@@ -48,7 +48,8 @@ pub enum Metric {
     ///   component is enough to keep it usable — and such a vector is then 1.0
     ///   from everything, itself included: a plausible-looking input with no
     ///   warning attached. Rescale before indexing if your embeddings live
-    ///   down there. `conformance/cosine_scale_invariance.tsv` pins both ends.
+    ///   down there. `vanedb/tests/fixtures/conformance/cosine_scale_invariance.tsv`
+    ///   pins both ends.
     Cosine,
     /// Negative dot product (higher similarity = lower distance).
     ///

--- a/vanedb/src/distance/scalar.rs
+++ b/vanedb/src/distance/scalar.rs
@@ -35,11 +35,12 @@ pub fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
     //
     // Policy, shared with vanedb-cpp: a vector with no usable direction is
     // 1.0 away from everything, including itself. Three ways to have none —
-    // a zero vector, a squared norm that overflowed f32, and a squared norm
-    // that *underflowed* it (a component under ~2.6e-23 squares to zero, and
-    // a vector whose components are all under it therefore has a zero norm --
-    // one ordinary component keeps the norm usable). Finite inputs never
-    // yield NaN.
+    // a zero vector, a squared norm that overflowed f32, and one that
+    // *underflowed* it, which needs every component small enough that its
+    // square reaches zero. Finite inputs never yield NaN. `Metric::Cosine`
+    // carries the bound and the rounding behind it; it is not repeated here,
+    // because the figure was wrong once and had to be chased through six
+    // files.
     // Multiplying the roots rather than rooting the product keeps the
     // denominator in range for both tiny and huge vectors.
     let denom = norm_a.sqrt() * norm_b.sqrt();

--- a/vanedb/tests/cosine_conformance.rs
+++ b/vanedb/tests/cosine_conformance.rs
@@ -102,12 +102,12 @@ fn cosine_returns_one_when_norms_overflow_rather_than_nan() {
 /// The underflow end of the "no usable direction" rule is a property of the
 /// whole vector, not of any one component.
 ///
-/// The rustdoc quotes a per-component bound (`2^-75`, about 2.6e-23) because
-/// that is where a single square reaches zero. It would be easy to read that
-/// as "a small component poisons the vector", which is not what the kernel
-/// does: the norm is a sum, so one ordinary component keeps it usable no
-/// matter how small the rest are. Both directions are asserted here, because
-/// prose is what drifted last time.
+/// `Metric::Cosine` quotes a per-component bound, because that is where a
+/// single square reaches zero. It would be easy to read that as "a small
+/// component poisons the vector", which is not what the kernel does: the norm
+/// is a sum, so one ordinary component keeps it usable no matter how small the
+/// rest are. Both directions are asserted here, because prose is what drifted
+/// last time.
 ///
 /// The magnitudes are deep inside each region rather than at the boundary.
 /// The exact boundary depends on subnormal handling — flush-to-zero would

--- a/vanedb/tests/fixtures/conformance/cosine_scale_invariance.tsv
+++ b/vanedb/tests/fixtures/conformance/cosine_scale_invariance.tsv
@@ -4,17 +4,10 @@
 #   orthogonal   a = ( s,  0)   b = ( 0,  s)   -> 1.0
 #   zero         a = ( 0,  0)   b = ( s, 2s)   -> 1.0  (a has no direction)
 #
-# Cosine distance depends only on direction, so `expected` is the same at every
-# scale the arithmetic can represent. The scales from 1e-18 to 1e18 stay inside
-# the f32 normal range at both ends and pin that invariance.
-#
-# The 1e-25 rows pin the other end: the "no usable direction" rule is decided
-# by the *computed* squared norm, and every square underflows f32 to zero once
-# each component is below roughly 2.6e-23 (2^-75). Both components here are, so
-# the norm is zero. Such a vector is neither zero nor overflowing,
-# yet both engines report 1.0 — including against itself. That is a real answer
-# a caller can get from finite, ordinary-looking input, so it is pinned here
-# rather than left to whichever engine changes first.
+# The 1e-18 … 1e18 rows pin scale invariance; the 1e-25 rows pin the underflow
+# end, where every square reaches zero and the vector has no usable direction.
+# `conformance/README.md` states the rule and the bound — once, so a corrected
+# figure does not have to be chased through the fixtures as well.
 # scale	relation	expected
 1e-25	identical	1.0
 1e-25	opposite	1.0


### PR DESCRIPTION
Re-ran everything on `main` after #167 merged, and audited contract, API, redundancy and noise. Two of the four came back clean; this PR is the one redundancy worth removing.

## Everything re-run on `d398a92`

| Suite | Result |
|---|---|
| Rust workspace (`--features disk`) | 297 pass |
| Rust `vanedb` (default features) | 224 pass |
| Benchmark workspace | 39 pass |
| C++ engine (`ctest`) | 97 pass |
| Python (installed wheel) | 177 pass |
| `fmt`, clippy ×2, `cargo doc -D warnings`, `actionlint` | clean |

## Contract — clean

All three conformance generators reproduce their committed fixtures **byte for byte**: running `conformance/{vndb,graph,legacy_graph}/generate.py` leaves `git status` empty. All 25 recorded SHA-256 sums verify (13 graph + 12 legacy).

No dead fixtures. Nine files initially looked unreferenced; all nine are reached through names built at runtime — the `.qvrd` set via `"v" + version + rng_layout + ".qvrd"` in `test_approx_index.cpp:26`, the legacy `.hnsw` set via `format!("{name}.hnsw")` in `persistence.rs`. Worth recording so the next audit does not re-flag them.

## API — deliberate, not accidental

The duplicate spellings are by decision (#85) and each is pinned by `public_surface.rs`: `size`/`len`/`is_empty`/`dimension` on four types, `get`/`get_vector` on three. The SIMD kernels are `pub` on purpose — that is precisely why they were bounded by both slice lengths after the length-mismatch finding. Nothing is exported that a caller has no use for, and `lib.rs` re-exports exactly the eight types the guides name.

The 0.x format-policy paragraph appears in three READMEs, but those are three distribution channels — a PyPI reader cannot see the crate README. Duplication across published artifacts is the right call there.

## Redundancy — the cosine underflow bound was in seven places

Not a hypothetical cost. When the figure turned out to be wrong at the first digit, correcting it took a six-file commit — and a seventh copy, in a test's doc comment, survived that sweep and stayed wrong-adjacent until now.

Two copies have to exist, because they serve audiences that cannot see each other:

- `Metric::Cosine` rustdoc — what a Rust caller reads.
- `conformance/README.md` — the contract the C++ engine follows, and C++ readers do not get rustdoc.

The CHANGELOG entry is a frozen historical record. The other four now point at one of those two instead of restating a number that has already been wrong once:

| File | Before | After |
|---|---|---|
| `distance/scalar.rs` | restates the bound | points at `Metric::Cosine` |
| `cpp/src/core/distance_kernels.h` | restates the bound | points at `conformance/README.md` |
| `cosine_conformance.rs` | restates the bound | points at `Metric::Cosine` |
| `cosine_scale_invariance.tsv` | restates the bound | points at `conformance/README.md` |

## Noise — the fixture was carrying the contract document

`cosine_scale_invariance.tsv` had eighteen comment lines above twenty-six data rows, most of it a second copy of prose that already lives in `conformance/README.md`. It now carries the row grammar and a pointer: eleven comment lines, and the mechanism stays in the document whose job it is.

**No data row changed.** Both engines pass the fixture unmodified — Rust `cosine_conformance` 6/6, C++ 11/11 cosine tests.

## Also checked, nothing to do

- `disk_tests::mmap_matches_brute_force` looked subsumed by the new `search_correctness` disk test. Mutation-tested rather than assumed: on a wrong-stride and an off-by-one id mutant both tests fail, and on an AVX2 L2 mutant only the new one does. The new test dominates on those three, but three mutants is not a subsumption proof and the old test uses a differently-shaped deterministic dataset, so it stays.
- `approx_tests::hnsw_recall_vs_brute_force` is **not** redundant with `the_graph_reaches_the_exact_answer_with_a_wide_beam`: a recall floor at a realistic beam and exactness at a corpus-wide beam are different properties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Mk2LouuoDGumatVNihLHY

---
_Generated by [Claude Code](https://claude.ai/code/session_016Mk2LouuoDGumatVNihLHY)_