### PR TITLE
docs(release): stop the readiness record asserting things it does not contain

### DIFF
--- a/docs/release/0.1.0-readiness.md
+++ b/docs/release/0.1.0-readiness.md
@@ -5,10 +5,20 @@ Status: **verified, awaiting registry setup**. The active target is the first
 prerequisites below are owner actions and no publication is authorized until
 they are done.
 
-**Candidate `e3c2635` is verified at the final head.** The four independent
-assessments (CTO, AI PM, senior engineer, QA) have all approved; QA's earlier
-BLOCK on "fully test" is lifted. What remains is owner action on the three
-registries plus one edit that must land in the release commit, listed below.
+**`e3c2635` was an interim checkpoint, not the final candidate — the head has
+since moved past it, and no commit is currently designated.** The four
+independent assessments (CTO, AI PM, senior engineer, QA) approved at that
+revision and QA's earlier BLOCK on "fully test" is lifted; what those
+assessments found is not invalidated by the commits since, but the
+*designation* is. Re-designating needs a fresh CI run and a fresh set of
+publication-disabled rehearsals at the new head, because the recorded
+rehearsals predate `99e02a9`, which renamed the npm package.
+
+Designating a candidate before the registry work is done was itself the
+mistake. RELEASING.md step 5 puts the packaged-README edit *in the release
+commit*, so the final candidate cannot exist until the three registry
+prerequisites below are cleared. Until then this record verifies revisions;
+it does not nominate one.
 
 The previous record certified `bf797d9`, which is retained further down as
 historical evidence. It was superseded for a reason worth keeping visible: the
@@ -38,10 +48,16 @@ what the `event_name == 'push'` gate exists to guarantee:
 | Publish vanedb-wasm to npm | [34257297349](https://github.com/vanedb/vanedb/actions/runs/34257297349) | `Publish to npm` — skipped |
 
 Artifacts downloaded from those runs: 28 wheels, one sdist, one crate, one npm
-tarball. The crate and the npm tarball are pinned by hash below because they
-are the two single-file artifacts a consumer fetches directly; the wheels are
-verified by the rehearsal's own install-and-test step rather than pinned
-individually.
+tarball. Only the crate is pinned below. The npm tarball's hash was removed
+when `99e02a9` renamed the package to `@vanedb/wasm`: that changes the
+tarball's contents, and because `npm pack` flattens a scope the rebuilt
+tarball still carries the byte-identical filename `vanedb-wasm-0.1.0.tgz`. A
+stale hash beside an unchanged filename reads as corruption rather than as
+staleness, so deleting it was right — but the sentence that replaced it
+claimed both artifacts were pinned, which was false the moment it was
+written. The npm tarball is re-pinned at re-designation, from a rehearsal run
+under the new name. The wheels are verified by the rehearsal's own
+install-and-test step rather than pinned individually.
 
 ```
 af6b032f6cbdbaf5d45ca8dee6dc80bc7f8884326cd0766e95e402d80f044bf2  vanedb-0.1.0.crate
@@ -85,9 +101,13 @@ failed to pin.
    earlier version of this record wrongly said otherwise.
 4. **The packaged READMEs**: `vanedb/README.md` and `vanedb-py/README.md` are
    inside the `.crate` and all 28 wheels, so they must carry the published
-   install form *before* the candidate is designated — the post-publication
-   step that fixes every other guide structurally cannot reach them. See
-   RELEASING.md step 5.
+   install form — the post-publication step that fixes every other guide
+   structurally cannot reach them. The edit belongs in the release commit
+   itself and nowhere earlier (RELEASING.md step 5): until the tag exists,
+   the checkout instructions are the true ones, and a README promising
+   `pip install vanedb` before the wheel is on PyPI is wrong for every
+   reader in between. That is the same commit this record will designate,
+   which is why no designation can precede items 1-3.
 
 Registry prerequisites and final maintainer approval also remain open.
 No publication is authorized by this record.


### PR DESCRIPTION
Three corrections to `docs/release/0.1.0-readiness.md`. All the same kind: the record stated something a reader could check and find false.

### 1. The designation was stale

> **Candidate `e3c2635` is verified at the final head.**

The head moved on well over twenty commits ago — including `99e02a9`, which renamed the npm package. The four assessments at that revision are not invalidated by the commits since; the *designation* is. The record now says so, and says what re-designating needs: a fresh CI run and a fresh set of publication-disabled rehearsals at the new head, because the recorded rehearsals predate the rename.

The replacement paragraph deliberately does **not** record how many commits have landed since. This document already argues, about test counts, that "a count is a fact about a moment, not about the release" — a commit count has the same shelf life, and my first draft of this fix put one in.

### 2. It promised a checksum it did not carry

> The crate **and the npm tarball** are pinned by hash below…

Only the crate hash is present. `git show 96f7615 -- docs/release/0.1.0-readiness.md` shows the sentence being added in the *same hunk* that deletes the npm hash, so it was false the moment it was written.

Deleting the hash was correct, and the record now explains why rather than papering over it: the rename changes the tarball's contents, but `npm pack` flattens a scope, so the rebuilt tarball keeps the byte-identical filename `vanedb-wasm-0.1.0.tgz` (see `scripts/build_npm_package.py:86-87`). A stale hash beside an unchanged filename reads as *corruption* rather than as staleness — the worst of the available failure modes.

### 3. Two records appeared to contradict each other

| Record | Says |
|---|---|
| readiness item 4 | the README edit must land "*before* the candidate is designated" |
| `RELEASING.md` step 5 | "Make this edit in the release commit itself, not earlier" |

These reconcile only if the release commit **is** the designation. Item 4 now states that, plus the consequence: no candidate can be designated before the three registry prerequisites are cleared — because until the tag exists, the checkout instructions are the true ones, and a README promising `pip install vanedb` before the wheel is on PyPI is wrong for every reader in between.

That consequence is also the root cause of defect 1. Designating a candidate while registry setup was still open guaranteed the designation would go stale before it could be used.

### Scope

Docs only — no code, fixtures, or workflows touched. No added line exceeds 80 characters.

**This PR does not re-designate a candidate.** It cannot: that needs the three publication-disabled rehearsals dispatched from `main`, which are owner-gated, and it needs the packaged-README edit, which by item 4 belongs in the release commit itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H