### PR TITLE
release: 0.1.0-rc.1 for the registry bootstrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1221,7 +1221,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vanedb"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "bincode",
  "criterion",
@@ -1236,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "vanedb-capi"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "cbindgen",
  "vanedb",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "vanedb-py"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "vanedb-wasm"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",

--- a/bench/Cargo.lock
+++ b/bench/Cargo.lock
@@ -883,7 +883,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vanedb"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "bincode",
  "memmap2",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "vanedb-capi"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "cbindgen",
  "vanedb",

--- a/cpp/Doxyfile
+++ b/cpp/Doxyfile
@@ -1,7 +1,7 @@
 # Doxyfile for VaneDB
 
 PROJECT_NAME           = "VaneDB"
-PROJECT_NUMBER         = "0.1.0"
+PROJECT_NUMBER         = "0.1.0-rc.1"
 PROJECT_BRIEF          = "Embeddable vector database for edge AI"
 OUTPUT_DIRECTORY       = docs
 

--- a/cpp/pyproject.toml
+++ b/cpp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vanedb-cpp"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 description = "Supplementary C++ Python bindings for VaneDB"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/cpp/src/core/version.h
+++ b/cpp/src/core/version.h
@@ -15,7 +15,7 @@ constexpr int VERSION_MINOR = 1;
 constexpr int VERSION_PATCH = 0;
 
 /// Full version string
-constexpr const char* VERSION_STRING = "0.1.0";
+constexpr const char* VERSION_STRING = "0.1.0-rc.1";
 
 /**
  * @brief Returns the version as a single integer for comparison.

--- a/scripts/build_npm_package.py
+++ b/scripts/build_npm_package.py
@@ -79,6 +79,13 @@ def build(target: str, out: str) -> Path:
     return CRATE / out
 
 
+def npm_repository_url(repository):
+    """Cargo's plain https URL in the form npm stores without rewriting it."""
+    url = repository["url"] if isinstance(repository, dict) else repository
+    url = url.removeprefix("git+").removesuffix(".git")
+    return f"git+{url}.git"
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     # `target/npm/vanedb-wasm` is a filesystem path, not the package name.
@@ -158,7 +165,14 @@ def main() -> None:
         "version": generated["version"],
         "description": generated["description"],
         "license": generated["license"],
-        "repository": generated["repository"],
+        # npm's canonical form is `git+<https url>.git`; anything else is
+        # silently rewritten at publish time, which means the metadata on the
+        # registry is npm's guess rather than what we wrote. Cargo's field is a
+        # plain https URL, so normalise it here rather than duplicating it.
+        "repository": {
+            "type": "git",
+            "url": npm_repository_url(generated["repository"]),
+        },
         "keywords": ["vector", "search", "embeddings", "wasm", "hnsw", "database"],
         "homepage": "https://github.com/vanedb/vanedb#readme",
         "type": "module",

--- a/vanedb-capi/Cargo.toml
+++ b/vanedb-capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vanedb-capi"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 edition = "2021"
 # Bound by bincode 2.x, the newest runtime dependency. CI checks it.
 rust-version = "1.85"

--- a/vanedb-capi/include/vanedb_rs_capi.h
+++ b/vanedb-capi/include/vanedb_rs_capi.h
@@ -17,7 +17,7 @@ typedef struct vanedb_rs_disk vanedb_rs_disk;
 /* The version this header was generated from. Compare against
  * vanedb_rs_version() at runtime to catch a shared object that does not
  * match the header you compiled against. */
-#define VANEDB_RS_VERSION "0.1.0"
+#define VANEDB_RS_VERSION "0.1.0-rc.1"
 
 /* Distance metric, passed as uint32_t: */
 #define VANEDB_RS_L2     0u

--- a/vanedb-py/Cargo.toml
+++ b/vanedb-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vanedb-py"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 edition = "2021"
 # Bound by bincode 2.x, the newest runtime dependency. CI checks it.
 rust-version = "1.85"

--- a/vanedb-py/pyproject.toml
+++ b/vanedb-py/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 
 [project]
 name = "vanedb"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 description = "Embeddable vector database for edge AI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/vanedb-wasm/Cargo.toml
+++ b/vanedb-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vanedb-wasm"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Embeddable vector search for JavaScript and WebAssembly"

--- a/vanedb/Cargo.toml
+++ b/vanedb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vanedb"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 edition = "2021"
 # Bound by bincode 2.x, the newest runtime dependency. CI checks it.
 rust-version = "1.85"


### PR DESCRIPTION
Bumps the repo to `0.1.0-rc.1` so the crates.io bootstrap publish doesn't spend `0.1.0`.

## Why an rc rather than publishing 0.1.0 directly

crates.io cannot accept a trusted publisher before the crate exists (RFC 3691), so the first publish must be manual. Doing that as `0.1.0` would mean the actual released artifact is built on a laptop rather than by the reviewed, OIDC-authenticated, provenance-stamped CI path — and the trusted publisher would sit unexercised until 0.2.0. Publishing `0.1.0-rc.1` reserves the name without spending the version, so `0.1.0` goes out through CI like every release after it.

Prereleases are excluded from default semver ranges, so `vanedb = "0.1"` will not resolve to the rc.

## The version split

| Sites | Value | Why |
|---|---|---|
| `vanedb`, `vanedb-py`, `vanedb-capi`, `vanedb-wasm` Cargo.toml; `vanedb-py`, `cpp` pyproject.toml; `version.h` `VERSION_STRING`; `Doxyfile` `PROJECT_NUMBER` | `0.1.0-rc.1` | can express a suffix |
| `cpp/CMakeLists.txt` `project(VERSION)`; `version.h` numeric components | `0.1.0` | CMake takes numeric components only |

`bench/tests/release_identity.rs` compares exactly those two against the release *core* and the other eight in full — which is what stops a leftover `-rc.1` going invisible at the real release. It passes 2/2.

`vanedb-capi/include/vanedb_rs_capi.h` was **not** edited by hand. `build.rs` stamps it from `CARGO_PKG_VERSION`, and this is the first version change since that landed in #170 — so the drift class it was added to kill is now tested by the mechanism itself rather than by a claim about it.

## npm is a special case, recorded here deliberately

`@vanedb/wasm@0.1.0` is **already published**, manually, **without a provenance attestation** — and npm never permits republishing a version. That one is spent.

Tagging `vanedb-wasm-v0.1.0-rc.1` earns most of it back: CI publishes through the trusted publisher with `--provenance`, proving that path end to end, and the workflow assigns prereleases the `next` dist-tag so `latest` stays on the `0.1.0` a user would install. The first provenance-stamped `latest` will therefore be `0.1.1`.

## Also included

`scripts/build_npm_package.py` copied Cargo's plain https URL into `repository.url`, and npm rewrote it to `git+https://….git` at publish time with a warning — so the registry stored npm's guess rather than what we wrote. The script now emits the canonical form; the normaliser is idempotent across all three shapes the field can arrive in. Unrelated to the bump, but the same release mechanics and it affects the very next wasm publish.

## Verification

fmt, clippy `-D warnings` (both workspaces), Rust suite, bench suite including `release_identity`, **98 C++ tests**, actionlint — all pass, exit statuses checked directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H