### PR TITLE
ci: stop paying for runs nobody reads, and cap the ones that hang

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -3,6 +3,21 @@ name: Benchmark
 on:
   pull_request:
     branches: [main]
+    # This job benchmarks `-p vanedb` twice — once per side — for ~10 minutes.
+    # `vanedb` has no path dependencies, so a diff that touches none of these
+    # compares two identical binaries: the table is pure runner noise, and it
+    # queues ahead of the CI run that does gate the merge. `Required CI Gate`
+    # is the only required check, so skipping this leaves nothing blocked.
+    paths:
+      - 'vanedb/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/bench.yml'
+
+# A newer push supersedes the comparison in flight; nothing reads the old table.
+concurrency:
+  group: bench-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 # Least privilege: checks out and benchmarks code, writes only to the step summary.
 permissions:
@@ -15,6 +30,9 @@ jobs:
   benchmark:
     name: Performance Regression Check
     runs-on: ubuntu-latest
+    # Observed 9.5-13.7 min over the last 25 runs. Without this the default is
+    # six hours, so a bench that never converges holds a runner all afternoon.
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
     branches: [main]
 
+# A newer push to the same PR makes the in-flight run's verdict obsolete, and
+# this workflow fans out to ~53 jobs, so leaving it running costs ~80 job-
+# minutes and queues behind the run that will actually be read. Pushes to main
+# are never cancelled: each main commit keeps its own recorded verdict.
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # This workflow always runs. Component workflows are selected after checkout,
 # and the final job is the only required branch-protection check.
 permissions:
@@ -17,6 +25,7 @@ jobs:
   changes:
     name: Detect affected components
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
       cpp: ${{ steps.filter.outputs.cpp }}
@@ -61,6 +70,7 @@ jobs:
   workflow-lint:
     name: Workflow lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install actionlint
@@ -124,6 +134,7 @@ jobs:
     if: ${{ always() }}
     needs: [changes, workflow-lint, rust, cpp, integration]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Verify every affected component passed
         shell: bash

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,11 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+# A review of a superseded commit is a review of code that no longer exists.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     # Dependabot and fork PRs cannot access the OAuth secret. Skip them instead
@@ -18,6 +23,7 @@ jobs:
       github.actor != 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,6 +32,7 @@ jobs:
           contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -114,16 +114,22 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # `apt-get install doxygen` is normally 12s, but one main run (34380434702)
+    # spent 494s in it and finished 1.7 min short of the old 10-minute cap —
+    # a mirror stall away from failing `Required CI Gate` on a job whose actual
+    # work takes under a second.
+    timeout-minutes: 20
 
     steps:
     - name: Checkout code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
+    # No graphviz: cpp/Doxyfile sets HAVE_DOT = NO, so dot is never invoked.
+    # CLASS_DIAGRAMS = YES uses Doxygen's built-in renderer, not graphviz.
     - name: Install Doxygen
       run: |
         sudo apt-get update
-        sudo apt-get install -y doxygen graphviz
+        sudo apt-get install -y --no-install-recommends doxygen
 
     - name: Generate documentation
       run: doxygen Doxyfile

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -14,6 +14,7 @@ jobs:
   check:
     name: Check & Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
@@ -42,6 +43,7 @@ jobs:
   docs:
     name: Rustdoc (docs.rs configuration)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
@@ -62,6 +64,7 @@ jobs:
   check-macos:
     name: Check & Lint (macOS, gpu-metal)
     runs-on: macos-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
@@ -76,6 +79,7 @@ jobs:
   msrv:
     name: MSRV (1.85)
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -98,6 +102,7 @@ jobs:
   deny:
     name: Advisories & licenses
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
@@ -109,6 +114,7 @@ jobs:
   check-py:
     name: Check (Python bindings)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
@@ -123,6 +129,7 @@ jobs:
   wheel-py:
     name: Python wheel (maturin ${{ matrix.maturin-label }})
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -170,6 +177,7 @@ jobs:
   test-native:
     name: Test (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -342,6 +350,7 @@ jobs:
   test-wasm:
     name: Test (WASM)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,10 @@ already paid: vanedb#32, #77, #109 and #110 all exist because of it.
 ## Performance work
 
 - CI's performance workflow prints a critcmp table of the PR against main into
-  the step summary. It **reports, it does not gate**: nothing in that workflow
+  the step summary. It runs only when the diff touches `vanedb/**` or the
+  workspace manifests — `vanedb` has no path dependencies, so on any other diff
+  it would spend ten minutes comparing two identical binaries.
+  It **reports, it does not gate**: nothing in that workflow
   fails on a regression, and it is a shared runner, so it should not. Read it
   as a hint about where to look, never as evidence. (It previously ran a second
   `critcmp --threshold 5`, which reads like an assertion and is not — the flag


### PR DESCRIPTION
Audit of the last ~100 CI runs (2026-09-07 → 09-09) plus the two `main` failures on 09-08. The engine itself is healthy — every check in `AGENTS.md` passes on `main` locally. The problems are all in how CI is scheduled.

## What the logs showed

**No workflow had a `concurrency` group.** A new push never cancelled the run it superseded. Of the last 50 non-final PR CI runs, **18 kept running past their own successor** — one for 15.7 minutes — at ~53 jobs and ~80 job-minutes apiece, each with a duplicate ~10-minute Benchmark alongside it. Live example while auditing: PR #173 had two full CI runs *and* two Benchmark runs queued simultaneously, started 88 seconds apart. The cost isn't only billing — the 2–4 minute per-job queue times visible in the CI data come out of that same contended runner pool.

**Benchmark had no paths filter and is the real critical path.** Median 10.6 min (max 13.7) over the last 25 runs, versus 8.4–11.5 min wall clock for all of CI. It benchmarks `-p vanedb` twice, and `vanedb` has no path dependencies — so on a docs-only diff it compares two identical binaries. `docs/finish-the-audit-backlog` spent ~31 minutes across three pushes doing exactly that, producing a table the project's own rules say is not evidence.

**Twelve jobs had no `timeout-minutes`,** so a hang holds a runner for GitHub's six-hour default: the whole of `bench.yml`, three jobs in `ci.yml`, both Claude workflows, and nine in `rust-ci.yml`.

**The Documentation job nearly failed the required gate on a package it never uses.** `apt-get install doxygen graphviz` is normally 12s, but run [34380434702](https://github.com/vanedb/vanedb/actions/runs/34380434702) on `main` spent **494s** in it and finished 1.7 min under the old 10-minute cap — on a job whose actual doc generation takes under a second. `cpp/Doxyfile` sets `HAVE_DOT = NO`, so `dot` is never invoked; `CLASS_DIAGRAMS = YES` is Doxygen's own renderer.

## Changes

- `ci.yml`, `bench.yml`, `claude-code-review.yml`: concurrency groups. Pushes to `main` are **never** cancelled, so each `main` commit keeps its own recorded verdict; only PR runs cancel. Cancelling the CI caller cancels its reusable component workflows with it.
- `bench.yml`: restrict to diffs that can actually move it (`vanedb/**`, the workspace manifests, the workflow itself). `Required CI Gate` is the only required check, so nothing is left blocked.
- `bench.yml`, `ci.yml`, `claude.yml`, `claude-code-review.yml`, `rust-ci.yml`: `timeout-minutes` on the twelve jobs that lacked one, each roughly triple its observed maximum.
- `cpp-ci.yml`: Documentation cap 10 → 20 min, and drop the unused `graphviz`.
- `AGENTS.md`: the Performance section said the benchmark workflow runs on PRs; note that it is now path-filtered and why.

## Verification

- `actionlint` 1.7.12 — the exact version and SHA256 the `Workflow lint` job pins — clean.
- `.github/scripts/check_wheel_matrix.py` passes (28 wheels: linux 16, macos 8, windows 4), confirming the `rust-ci.yml` edits didn't disturb the wheel matrices.
- On this tree: `cargo fmt --check`, `clippy -D warnings`, `cargo test --workspace --exclude vanedb-py --features disk` (36 suites), the `bench/` workspace fmt/clippy/test, and `ctest` at **98/98** all pass.

Re-verified independently on the current head `a8034cc` (which merges `main` at `4969ce9` into the change), parsing the workflow YAML rather than reading the diff: concurrency groups present in all three files with `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`, so `main` pushes are never cancelled; every job outside the three `publish-*.yml` workflows now carries a `timeout-minutes`; `Required CI Gate` still needs only `[changes, workflow-lint, rust, cpp, integration]`, so path-filtering Benchmark blocks nothing; `graphviz` gone and `doxygen` kept, with `HAVE_DOT = NO` and `CLASS_DIAGRAMS = YES` confirmed in `cpp/Doxyfile`. On that merged tree `cargo fmt --check`, `clippy -D warnings`, `cargo test --workspace --exclude vanedb-py --features disk` (36 suites, 0 failures) and `main`'s new `scripts/test_release_scripts.py` (18/18) all pass.

## Not fixed — flagged

- **Both `main` failures on 09-08** ([34247218927](https://github.com/vanedb/vanedb/actions/runs/34247218927), [34251411729](https://github.com/vanedb/vanedb/actions/runs/34251411729)) were `actions/upload-artifact` failing `FinalizeArtifact` with a 403 from an intermediary — GitHub-side, already recovered. Worth knowing that an artifact-service blip fails `Required CI Gate` on `main`, since the uploads are in the same jobs as the tests.
- **The three `publish-*.yml` workflows still have no `timeout-minutes`** — **16 jobs**: 3 in `publish-crate.yml`, 11 in `publish-rust.yml`, 2 in `publish-wasm.yml`. Deliberately left alone: constraining a release job that is mid-publish is riskier than the hang it guards against, and they never run on PRs. A maintainer should pick those values. (Still 16 after `main`'s release-README work, which added steps to those workflows but no jobs.)
- **The Benchmark paths filter is per-push, not per-PR-diff.** GitHub evaluates `paths` on a `synchronize` event against the commits in that push, so merging `main` into a PR re-triggers Benchmark whenever `main` itself touched `vanedb/**` — as it did on head `a8034cc` via `vanedb/README.md`. The filter still removes the docs-only PR pushes it was aimed at; suppressing merge-triggered runs as well would need a paths-ignore or a job-level `if`, which is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Mk2LouuoDGumatVNihLHY