### PR TITLE
release: rc-accurate install lines in the two packaged READMEs

### DIFF
--- a/vanedb-py/README.md
+++ b/vanedb-py/README.md
@@ -11,18 +11,17 @@ kept in the repository for reference and local testing, and are not published.
 
 ## Installation
 
-Requires Python 3.11 or newer. To build this checkout, also install a Rust
-toolchain. From the repository root, create and activate a virtual environment:
+Requires Python 3.11 or newer.
 
 ```sh
-python -m venv .venv
-# macOS/Linux: source .venv/bin/activate
-# Windows PowerShell: .venv\Scripts\Activate.ps1
-python -m pip install ./vanedb-py
+python -m pip install vanedb==0.1.0rc1
 ```
 
-These instructions install the checkout and do not assume a published 0.1.0
-release. Python lists work without additional dependencies. NumPy is optional; its arrays
+The version is pinned because pip does not select a prerelease unless asked;
+drop the pin once 0.1.0 is out. Building from a checkout is described in the
+[repository](https://github.com/vanedb/vanedb/tree/main/vanedb-py).
+
+Python lists work without additional dependencies. NumPy is optional; its arrays
 can also be used for vector and batch inputs.
 
 ## Quick start

--- a/vanedb/README.md
+++ b/vanedb/README.md
@@ -11,9 +11,10 @@ VaneDB stores only `(u64, vector)` pairs. There is no metadata or payload
 storage and no filtered search; keep your own id-to-document mapping
 alongside it. Supply your own embeddings — VaneDB does not generate them.
 
-From a source checkout, run `cargo run -p vanedb --example quickstart --locked`
-at the repository root. For a local application, add
-`vanedb = { path = "/path/to/vanedb/vanedb" }` to its Cargo dependencies.
+Add it with `cargo add vanedb@0.1.0-rc.1`. The version is pinned because a
+plain `cargo add vanedb` excludes prereleases and currently resolves to
+nothing; drop the pin once 0.1.0 is out. From a source checkout, run
+`cargo run -p vanedb --example quickstart --locked` at the repository root.
 This complete program inserts two vectors and finds the nearest one:
 
 ```rust
@@ -69,7 +70,7 @@ Metal compute requires macOS 10.14 or newer and a usable Metal device. Enable
 `gpu-metal` explicitly in your application's dependency:
 
 ```toml
-vanedb = { path = "/path/to/vanedb/vanedb", features = ["gpu-metal"] }
+vanedb = { version = "0.1.0-rc.1", features = ["gpu-metal"] }
 ```
 
 This exposes `MetalCompute` for manually uploaded vectors and distance scans.


### PR DESCRIPTION
Prerequisite for tagging `vanedb-v0.1.0-rc.1` (reserves the PyPI name) and, later, `0.1.0` on both registries.

## Why the obvious conversion would also be wrong

`vanedb/README.md` is inside the `.crate` and is what crates.io renders. `vanedb-py/README.md` is the core-metadata description of every wheel and the sdist, and the PyPI project page. Both still told the reader to install a checkout — and `vanedb 0.1.0-rc.1` is published.

But converting them to `cargo add vanedb` / `pip install vanedb` is a **different** falsehood: Cargo's default requirement excludes prereleases, and pip does not select one unless asked, so both commands resolve to nothing for as long as the release candidate is the only published version.

| Option | Truthful today? |
|---|---|
| `vanedb = { path = "..." }` (current) | no — the crate *is* published |
| `cargo add vanedb` | no — resolves to nothing during the rc window |
| **`cargo add vanedb@0.1.0-rc.1`** | **yes** |

So the lines are pinned, and each says to drop the pin once 0.1.0 is out — an edit that belongs in the release commit, where `RELEASING.md` step 5 already puts it.

## A second path dependency step 5 doesn't name

`vanedb/README.md:72` — the `gpu-metal` feature example was also a path dependency. Step 5's prose names the *file*, not the lines, so this would have rendered `path = "/path/to/vanedb/vanedb"` on the crates.io page of a published crate. Now a version dependency.

## The Python README's build instructions are gone

Replaced with a repository link. They are process, on a page whose reader has just run `pip install` — and keeping them would have meant loosening the check's `pip install \.` pattern to admit them, weakening a tripwire to accommodate text that didn't belong there.

## Verification

Ran the check from #173 against both files: **crates.io READY, PyPI READY**. `readme.rs` still passes (3/3), so the prose still matches the real API. Rust and bench suites green.

Branches off `main`; touches only the two READMEs, so no conflict with #173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H