### PR TITLE
docs(release): record the three release-candidate publications

### DIFF
--- a/docs/release/0.1.0-readiness.md
+++ b/docs/release/0.1.0-readiness.md
@@ -28,6 +28,45 @@ than the branch requires. "Passes CI" is a claim about a gate, and the gate is
 versioned too — evidence should pin which checks ran, not only that they
 passed.
 
+### Release candidates published, 2026-09-09
+
+All three names are now reserved. `0.1.0` remains unspent on crates.io and
+PyPI; on npm it is not, for the reason recorded under item 3.
+
+| Registry | Version | How | Evidence |
+|---|---|---|---|
+| crates.io | `0.1.0-rc.1` | manual bootstrap (RFC 3691 leaves no alternative) | `b9a1d3f40aae342ce52d8e9d7938d00e998611eb3c9da339f29fa70895a0b5f9`, `.cargo_vcs_info.json` records `2bdd96c` |
+| PyPI | `0.1.0rc1` | tag `vanedb-v0.1.0-rc.1`, trusted publisher, [run 34402882099](https://github.com/vanedb/vanedb/actions/runs/34402882099) | 29 files — 1 sdist + 28 wheels across 7 platforms; sdist `e43614dbd1cafee197b1fd9e18078b3e2d9b3841e58c9564da35835477e756b6` |
+| npm | `0.1.0-rc.1` under `next` | tag `vanedb-wasm-v0.1.0-rc.1`, trusted publisher, [run 34402955713](https://github.com/vanedb/vanedb/actions/runs/34402955713) | **provenance attestation present**; 16 files, shasum `6b7833cfad2d30c91796cb22b80a6d12b116fcf5` |
+
+The crates.io bootstrap token was scoped `publish-new` on crate `vanedb` and
+revoked immediately. Scoping mattered: the crate now exists, so that scope is
+spent and could not have published `0.1.0` even before revocation.
+
+Why a prerelease rather than `0.1.0`: a bootstrap is a hand publish with no
+reviewer, no OIDC and no attestation, so the version it spends should not be
+the version people install. crates.io burns a version only on a *successful*
+publish, so a failed tag costs a retag rather than the number.
+
+The npm rc is the one that earns its keep twice. It proves the trusted
+publisher works end to end — `0.1.0` there was a hand publish and carries no
+attestation, and npm never frees a used version, so that page cannot be fixed.
+Publishing under `next` leaves `latest` on the `0.1.0` a user installs.
+
+### TestPyPI is exhausted for these versions
+
+The TestPyPI rehearsal ([run 34391440053](https://github.com/vanedb/vanedb/actions/runs/34391440053))
+failed with `File already exists` for
+`vanedb-0.1.0rc1-cp311-cp311-macosx_10_12_x86_64.whl`. TestPyPI already held
+**17 of 29 files** for both `0.1.0` and `0.1.0rc1`, from earlier partial
+uploads. Neither version can be completed or replaced there.
+
+This is RELEASING.md's own warning happening: `twine upload` is not one action,
+so a partial upload leaves a version permanently half-populated. It happened on
+the throwaway registry, which is what that registry is for, while the real
+upload the same evening delivered all 29 files. A future TestPyPI rehearsal
+needs a version number neither `0.1.0` nor `0.1.0rc1`.
+
 ### Verified at `e3c2635` on 2026-09-08
 
 Full CI, [run 34256444457](https://github.com/vanedb/vanedb/actions/runs/34256444457) — success, including the two jobs absent from the previous record:


### PR DESCRIPTION
All three names are reserved as of 2026-09-09. This records what was published, how, and with what evidence — plus one thing that went wrong on the throwaway registry and is worth keeping visible.

| Registry | Version | How |
|---|---|---|
| crates.io | `0.1.0-rc.1` | manual bootstrap (RFC 3691 leaves no alternative) |
| PyPI | `0.1.0rc1` | tag → trusted publisher — **29 files, 1 sdist + 28 wheels, 7 platforms** |
| npm | `0.1.0-rc.1` under `next` | tag → trusted publisher — **provenance attestation present** |

`0.1.0` remains unspent on crates.io and PyPI. On npm it is not, for the reason already recorded under item 3.

## The TestPyPI rehearsal failed, usefully

`File already exists` for `vanedb-0.1.0rc1-cp311-cp311-macosx_10_12_x86_64.whl`. TestPyPI already held **17 of 29 files** for both `0.1.0` and `0.1.0rc1`, from earlier partial uploads. Neither version can be completed or replaced there.

That is `RELEASING.md`'s own warning happening in front of us — `twine upload` is not one action, so a partial upload leaves a version permanently half-populated. It happened on the throwaway registry, which is what that registry is for, while the real upload the same evening delivered all 29 files. A future TestPyPI rehearsal needs a version that is neither `0.1.0` nor `0.1.0rc1`.

## Why a prerelease rather than 0.1.0

A bootstrap is a hand publish with no reviewer, no OIDC and no attestation, so the version it spends should not be the version people install. crates.io burns a version only on a *successful* publish, so going straight to `0.1.0` would have risked a retag, not the number — but the npm counter-example was already on the shelf, and the rc is what let the npm path be proven at all.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H