### PR TITLE
feat(wasm): export the raw module; restore the bump script with tests

### DIFF
--- a/scripts/build_npm_package.py
+++ b/scripts/build_npm_package.py
@@ -158,6 +158,19 @@ def main() -> None:
     for doc in ("README.md", "LICENSE"):
         shutil.copy2(CRATE / doc, out / doc)
 
+    # The `./vanedb_wasm_bg.wasm` export names the web copy. wasm-pack emits
+    # one per target and they have always been identical, but "always been" is
+    # not a guarantee: if they ever diverge, that export would hand Node
+    # consumers the browser module.
+    node_wasm = (out / "node/vanedb_wasm_bg.wasm").read_bytes()
+    web_wasm = (out / "web/vanedb_wasm_bg.wasm").read_bytes()
+    if node_wasm != web_wasm:
+        raise SystemExit(
+            "the node and web wasm modules differ, so a single "
+            "`./vanedb_wasm_bg.wasm` export would be wrong for one of them; "
+            "make the export conditional before shipping this"
+        )
+
     generated = json.loads((node_dir / "package.json").read_text())
     package = {
         # Scoped, so a future native binding can take `@vanedb/node` without
@@ -192,6 +205,12 @@ def main() -> None:
                 "browser": "./web/index.js",
                 "default": "./web/index.js",
             },
+            # A bundler that wants to inline the module cannot reach a path the
+            # exports map does not name, so without this a consumer has to
+            # vendor a copy of the .wasm out of the package by hand. The two
+            # builds emit byte-identical modules -- asserted below, so this one
+            # path cannot silently become wrong for one of them.
+            "./vanedb_wasm_bg.wasm": "./web/vanedb_wasm_bg.wasm",
             "./package.json": "./package.json",
         },
         "main": "./node/index.cjs",

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Set the release version everywhere it is declared.
+
+Ten sites state the version across four languages. Eight can spell a
+prerelease; `cpp/CMakeLists.txt`'s `project(VERSION)` and `version.h`'s three
+numeric components cannot, because CMake accepts numeric components only --
+those track the release core. `vanedb-capi/include/vanedb_rs_capi.h` is not
+edited here: `vanedb-capi/build.rs` stamps it from `CARGO_PKG_VERSION`.
+
+Four of those sites live in one file, `cpp/src/core/version.h`. An earlier
+version of this script planned every edit against the text it read at plan
+time, then wrote each independently -- so the last write to that file discarded
+the other three, and a bump left `VERSION_MAJOR` untouched while reporting it
+changed. Edits are grouped per file and applied to one buffer, highest offset
+first, so the spans stay valid as the text shifts.
+
+`bench/tests/release_identity.rs` detects a partial bump. This performs one and
+then runs that test, rather than claiming success.
+"""
+
+import argparse
+import pathlib
+import re
+import subprocess
+import sys
+from collections import defaultdict
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# `\Z`, not `$`: `$` matches before a trailing newline, so `0.2.0\n` from a
+# `$(cat version.txt)` wrapper was accepted and written into every Cargo.toml.
+VERSION = re.compile(r"\A(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z.-]+)?\Z")
+
+# (path, regex with one capture group around the version, kind)
+SITES = [
+    ("vanedb/Cargo.toml",        r'(?m)^version = "([^"]+)"',          "full"),
+    ("vanedb-py/Cargo.toml",     r'(?m)^version = "([^"]+)"',          "full"),
+    ("vanedb-capi/Cargo.toml",   r'(?m)^version = "([^"]+)"',          "full"),
+    ("vanedb-wasm/Cargo.toml",   r'(?m)^version = "([^"]+)"',          "full"),
+    ("vanedb-py/pyproject.toml", r'(?m)^version = "([^"]+)"',          "full"),
+    ("cpp/pyproject.toml",       r'(?m)^version = "([^"]+)"',          "full"),
+    ("cpp/src/core/version.h",   r'VERSION_STRING = "([^"]+)"',        "full"),
+    ("cpp/Doxyfile",             r'PROJECT_NUMBER\s+= "([^"]+)"',      "full"),
+    ("cpp/CMakeLists.txt",       r'project\(vanedb VERSION ([0-9.]+)', "core"),
+    ("cpp/src/core/version.h",   r"VERSION_MAJOR = (\d+)",             "major"),
+    ("cpp/src/core/version.h",   r"VERSION_MINOR = (\d+)",             "minor"),
+    ("cpp/src/core/version.h",   r"VERSION_PATCH = (\d+)",             "patch"),
+]
+# Stamped by build.rs, not here, but checked by the identity test -- so it
+# belongs in the coverage comparison below.
+STAMPED = "vanedb-capi/include/vanedb_rs_capi.h"
+
+IDENTITY = "bench/tests/release_identity.rs"
+
+
+def core_of(version):
+    return version.split("-", 1)[0]
+
+
+def unchecked_sites(root, paths):
+    """Paths edited here that the release-identity test never looks at.
+
+    Comment lines are stripped first: the test mentions
+    `target/npm/vanedb-wasm/package.json` only inside a comment explaining that
+    it is deliberately *not* checked, and a plain substring search over the
+    whole source would count that as coverage.
+    """
+    source = (root / IDENTITY).read_text(encoding="utf-8")
+    code = "\n".join(l for l in source.splitlines() if not l.lstrip().startswith("//"))
+    return sorted(p for p in paths if p not in code)
+
+
+def plan(root, version):
+    """Every edit, grouped per file. Returns (edits, error)."""
+    if not VERSION.match(version):
+        return None, (f"{version!r} is not a version: expected MAJOR.MINOR.PATCH "
+                      f"with an optional -prerelease, e.g. 0.1.0 or 0.1.0-rc.1")
+
+    unchecked = unchecked_sites(root, {p for p, _, _ in SITES} | {STAMPED})
+    if unchecked:
+        return None, ("these sites are edited here but not checked by "
+                      + IDENTITY + ":\n  " + "\n  ".join(unchecked))
+
+    major, minor, patch = core_of(version).split(".")
+    replacement = {"full": version, "core": core_of(version),
+                   "major": major, "minor": minor, "patch": patch}
+
+    per_file = defaultdict(list)
+    for path, pattern, kind in SITES:
+        text = (root / path).read_text(encoding="utf-8", newline="")
+        matches = list(re.finditer(pattern, text))
+        if len(matches) != 1:
+            return None, (f"{path}: {pattern!r} matched {len(matches)} times, "
+                          f"expected 1\nnothing was written; the tree is unchanged.")
+        per_file[path].append((matches[0].span(1), matches[0].group(1), replacement[kind], kind))
+    return per_file, None
+
+
+def bump(root, version, quiet=False):
+    per_file, error = plan(root, version)
+    if error:
+        print(error)
+        return 1
+    for path, edits in per_file.items():
+        file = root / path
+        text = file.read_text(encoding="utf-8", newline="")
+        # Highest offset first, so earlier spans stay valid as the text shifts.
+        for (start, end), was, now, kind in sorted(edits, key=lambda e: -e[0][0]):
+            text = text[:start] + now + text[end:]
+            if not quiet:
+                print(f"  {was:>12} -> {now:<12} {path}  ({kind})")
+        file.write_text(text, encoding="utf-8", newline="")
+    return 0
+
+
+def run(command, root):
+    print(f"\n$ {' '.join(command)}")
+    return subprocess.run(command, cwd=root, stdout=subprocess.DEVNULL).returncode
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", help="e.g. 0.1.0 or 0.1.0-rc.1")
+    parser.add_argument("--root", type=pathlib.Path, default=ROOT)
+    parser.add_argument("--no-verify", action="store_true",
+                        help="skip the lockfile refresh, header restamp and test")
+    args = parser.parse_args()
+
+    if bump(args.root, args.version):
+        sys.exit(1)
+
+    if not args.no_verify:
+        for command in (
+            ["cargo", "update", "-w", "--offline"],
+            ["cargo", "update", "--manifest-path", "bench/Cargo.toml", "-w", "--offline"],
+            ["cargo", "build", "-p", "vanedb-capi"],
+            ["cargo", "test", "--manifest-path", "bench/Cargo.toml", "--test", "release_identity"],
+        ):
+            if run(command, args.root):
+                print(f"\nFAILED: {' '.join(command)}")
+                sys.exit(1)
+
+    print(f"""
+Version set to {args.version}. Still manual, and none of it is checked by a test:
+
+  1. vanedb/README.md, vanedb-py/README.md and vanedb-wasm/README.md must carry
+     the published-install form -- in the release commit, not earlier
+     (RELEASING.md step 5). All three are packaged and rendered on a registry
+     that forbids re-upload.
+     Check with: scripts/check_release_readmes.py <tag>
+  2. CHANGELOG.md: move `## [Unreleased]` to `## [{args.version}] - <date>`.
+  3. docs/release/0.1.0-readiness.md: re-designate, with a fresh CI run.
+""")

--- a/scripts/test_bump_version.py
+++ b/scripts/test_bump_version.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Tests for `bump_version.py`, run by CI's workflow-lint job.
+
+The script previously shipped a bug that made it unable to complete a single
+bump: four sites live in `cpp/src/core/version.h`, and edits planned against
+the text read at plan time meant the last write discarded the other three. It
+was not caught, because the only check performed was a round trip — bump away
+and back — and corrupting a value then corrupting it back leaves `git diff`
+clean. These tests assert the resulting values instead.
+"""
+
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import bump_version  # noqa: E402
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+NEEDED = sorted({p for p, _, _ in bump_version.SITES} | {bump_version.IDENTITY})
+
+
+def fixture(tmp):
+    """A copy of just the files the script reads or writes."""
+    for rel in NEEDED:
+        dst = tmp / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(REPO / rel, dst)
+    return tmp
+
+
+def value(root, path, pattern):
+    import re
+    text = (root / path).read_text(encoding="utf-8")
+    match = re.search(pattern, text)
+    return match.group(1) if match else None
+
+
+CHECKS = [
+    # Every site, by the same pattern the script uses, asserted individually.
+    ("vanedb/Cargo.toml",        r'(?m)^version = "([^"]+)"',          "full"),
+    ("vanedb-py/Cargo.toml",     r'(?m)^version = "([^"]+)"',          "full"),
+    ("vanedb-capi/Cargo.toml",   r'(?m)^version = "([^"]+)"',          "full"),
+    ("vanedb-wasm/Cargo.toml",   r'(?m)^version = "([^"]+)"',          "full"),
+    ("vanedb-py/pyproject.toml", r'(?m)^version = "([^"]+)"',          "full"),
+    ("cpp/pyproject.toml",       r'(?m)^version = "([^"]+)"',          "full"),
+    ("cpp/src/core/version.h",   r'VERSION_STRING = "([^"]+)"',        "full"),
+    ("cpp/Doxyfile",             r'PROJECT_NUMBER\s+= "([^"]+)"',      "full"),
+    ("cpp/CMakeLists.txt",       r'project\(vanedb VERSION ([0-9.]+)', "core"),
+    ("cpp/src/core/version.h",   r"VERSION_MAJOR = (\d+)",             "major"),
+    ("cpp/src/core/version.h",   r"VERSION_MINOR = (\d+)",             "minor"),
+    ("cpp/src/core/version.h",   r"VERSION_PATCH = (\d+)",             "patch"),
+]
+
+
+def test_every_site_holds_the_new_value(failures):
+    """The bug that shipped: four sites in one file, only the last surviving."""
+    for version, core, parts in [("9.8.7-rc.7", "9.8.7", ("9", "8", "7")),
+                                 ("1.2.3", "1.2.3", ("1", "2", "3"))]:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = fixture(pathlib.Path(tmp))
+            if bump_version.bump(root, version, quiet=True) != 0:
+                failures.append(f"{version}: bump returned non-zero")
+                continue
+            expect = {"full": version, "core": core,
+                      "major": parts[0], "minor": parts[1], "patch": parts[2]}
+            for path, pattern, kind in CHECKS:
+                got = value(root, path, pattern)
+                if got != expect[kind]:
+                    failures.append(
+                        f"{version}: {path} ({kind}) is {got!r}, expected {expect[kind]!r}")
+
+
+def test_malformed_versions_write_nothing(failures):
+    bad = ["1.2", "abc", "v0.1.0", " 0.1.0", "0.1.0+build5", "0.1.0.1", "0.2.0\n", ""]
+    for version in bad:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = fixture(pathlib.Path(tmp))
+            before = {p: (root / p).read_bytes() for p in NEEDED}
+            if bump_version.bump(root, version, quiet=True) == 0:
+                failures.append(f"{version!r} was accepted; it should be refused")
+            after = {p: (root / p).read_bytes() for p in NEEDED}
+            if before != after:
+                failures.append(f"{version!r} was refused but modified files")
+
+
+def test_a_failed_site_writes_nothing(failures):
+    """A pattern that stops matching must abort before any write."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = fixture(pathlib.Path(tmp))
+        doxyfile = root / "cpp/Doxyfile"
+        doxyfile.write_text(
+            doxyfile.read_text(encoding="utf-8").replace('PROJECT_NUMBER         = "',
+                                                         "PROJECT_NUMBER = "),
+            encoding="utf-8")
+        before = {p: (root / p).read_bytes() for p in NEEDED if p != "cpp/Doxyfile"}
+        if bump_version.bump(root, "4.5.6", quiet=True) == 0:
+            failures.append("a non-matching site did not abort the bump")
+        after = {p: (root / p).read_bytes() for p in NEEDED if p != "cpp/Doxyfile"}
+        if before != after:
+            failures.append("a failed site left other files modified")
+
+
+def test_line_endings_are_preserved(failures):
+    """A CRLF file must not come back LF, and vice versa."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = fixture(pathlib.Path(tmp))
+        doxyfile = root / "cpp/Doxyfile"
+        doxyfile.write_bytes(doxyfile.read_bytes().replace(b"\n", b"\r\n"))
+        crlf_before = doxyfile.read_bytes().count(b"\r\n")
+        bump_version.bump(root, "2.3.4", quiet=True)
+        crlf_after = doxyfile.read_bytes().count(b"\r\n")
+        if crlf_after != crlf_before:
+            failures.append(
+                f"CRLF endings changed: {crlf_before} before, {crlf_after} after")
+
+
+def test_unchecked_sites_ignores_comments(failures):
+    """A path named only in a comment is not coverage."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = fixture(pathlib.Path(tmp))
+        identity = root / bump_version.IDENTITY
+        identity.write_text(
+            identity.read_text(encoding="utf-8") + "\n// mentions only/in/a/comment.toml\n",
+            encoding="utf-8")
+        if not bump_version.unchecked_sites(root, {"only/in/a/comment.toml"}):
+            failures.append("a path named only in a comment counted as checked")
+
+
+def main():
+    failures = []
+    for test in (test_every_site_holds_the_new_value, test_malformed_versions_write_nothing,
+                 test_a_failed_site_writes_nothing, test_line_endings_are_preserved,
+                 test_unchecked_sites_ignores_comments):
+        test(failures)
+        print(f"  ran {test.__name__}")
+    for failure in failures:
+        print(f"FAIL {failure}")
+    print(f"{'FAILED' if failures else 'ok'} — {len(failures)} failures")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Two things, both prerequisites for rc-2.

## 1. `./vanedb_wasm_bg.wasm` is now exported

A consumer bundling for a single-file offline build — the Obsidian plugin, for one — cannot reach the WebAssembly module, because Node and esbuild only resolve paths a package's `exports` map names, and the map listed `.` and `./package.json`. The workaround was to copy the module out of the package by hand and keep the copy in sync.

The package contains **two** wasm files, `node/` and `web/`. I compared them in the published `0.1.0-rc.1` tarball: **byte-identical, 134048 bytes each**, `cmp` clean. So one export path is unambiguous — no conditional map needed.

But "always been identical" isn't a guarantee. If they ever diverge, this export would hand Node consumers the browser module. **The assembly step now compares them and refuses to build if they differ**, naming the fix. Verified: exit 1 diverged, exit 0 not, and `check_npm_package.py` still installs and imports the result both ways.

`0.1.0-rc.1` does not carry this — npm never frees a version, so the export exists from the next publish onward.

## 2. `bump_version.py` returns, with the tests it needed

It was removed from #173 because it **could not complete a single bump**: four sites live in `cpp/src/core/version.h`, and every edit was planned against the text read at plan time, so the last write discarded the other three. A bump left `VERSION_MAJOR` untouched while reporting it changed.

Edits are grouped per file now and applied to one buffer, highest offset first, so earlier spans stay valid as the text shifts. Verified on a real tree: all four `version.h` sites hold the new value.

**`scripts/test_bump_version.py` asserts resulting values, not a round trip.** That distinction is the entire point — the round trip is what hid this, because corrupting a value then corrupting it back leaves `git diff` clean. Five tests:

| Test | Catches |
|---|---|
| every site holds the new value | the four-sites-in-one-file bug |
| malformed input writes nothing | `v0.1.0`, ` 0.1.0`, `0.1.0+build5`, `0.2.0\n`, `""` |
| a failed site aborts before any write | half-bumped trees |
| CRLF endings survive | the newline asymmetry |
| a commented-out path isn't coverage | the `unchecked_sites` hole |

Also from the review: `\A…\Z` instead of `$` (which accepted a trailing newline and wrote multi-line TOML), `read_text(newline="")` matching the write, an encoding on the identity-test read.

## Verification

fmt, clippy, Rust + bench suites, 98 C++ tests, actionlint, 18/18 README-check cases, 5/5 bump tests, npm package assembles and is consumable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H