### PR TITLE
feat(npm): claim the unscoped vanedb name with a real alias package

### DIFF
--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -72,6 +72,16 @@ jobs:
       - name: Consume it as an installed dependency
         run: python3 scripts/check_npm_package.py
 
+      # The unscoped `vanedb` alias ships on this tag too: npm's scoped and
+      # unscoped namespaces are separate, so the org reserves `@vanedb/*` and
+      # leaves the bare word open. It depends on `@vanedb/wasm` at an exact
+      # version, so the two must publish together or the dependency dangles.
+      - name: Assemble the unscoped alias
+        run: python3 scripts/build_npm_alias.py
+
+      - name: Consume the alias as an installed dependency
+        run: python3 scripts/check_npm_alias.py
+
       - name: Pack for inspection
         run: |
           npm pack target/npm/vanedb-wasm --pack-destination target/npm --ignore-scripts
@@ -124,6 +134,16 @@ jobs:
       - name: Consume it as an installed dependency
         run: python3 scripts/check_npm_package.py
 
+      # The unscoped `vanedb` alias ships on this tag too: npm's scoped and
+      # unscoped namespaces are separate, so the org reserves `@vanedb/*` and
+      # leaves the bare word open. It depends on `@vanedb/wasm` at an exact
+      # version, so the two must publish together or the dependency dangles.
+      - name: Assemble the unscoped alias
+        run: python3 scripts/build_npm_alias.py
+
+      - name: Consume the alias as an installed dependency
+        run: python3 scripts/check_npm_alias.py
+
       # npm 11.5.1+ performs the OIDC exchange itself when the workflow has
       # `id-token: write` and a trusted publisher is configured for the
       # package. `--provenance` records the attestation.
@@ -150,6 +170,12 @@ jobs:
             echo "tag=latest" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Publish
+      # Scoped first: the alias pins it by exact version, so publishing the
+      # alias first would leave a version whose dependency does not resolve.
+      - name: Publish @vanedb/wasm
         run: npm publish --provenance --access public --tag "${{ steps.disttag.outputs.tag }}"
         working-directory: target/npm/vanedb-wasm
+
+      - name: Publish vanedb
+        run: npm publish --provenance --access public --tag "${{ steps.disttag.outputs.tag }}"
+        working-directory: target/npm/vanedb

--- a/npm/vanedb/README.md
+++ b/npm/vanedb/README.md
@@ -1,0 +1,38 @@
+# VaneDB
+
+Vector search in Node.js and the browser. Bring your own embeddings.
+
+```sh
+npm install vanedb
+```
+
+This package re-exports [`@vanedb/wasm`](https://www.npmjs.com/package/@vanedb/wasm),
+the WebAssembly build of the Rust engine, at a matching version. Use whichever
+specifier you prefer — they are the same code.
+
+```js
+import init, { ApproxIndex } from 'vanedb';
+
+await init();          // no-op under Node, loads the module in a browser
+
+const index = new ApproxIndex(3, 'cosine', 100, 16, 200);
+index.add(101n, new Float32Array([1, 0, 0]));
+
+const hits = index.search(new Float32Array([1, 0, 0]), 1);
+console.log(hits.ids[0], hits.distances[0]);   // 101n, 0
+
+hits.free();
+index.free();
+```
+
+`require('vanedb')` works too.
+
+Exports `ApproxIndex`, `FlatIndex`, `SearchResults`, `version`, `init` (default)
+and `initSync`. The full API is documented in
+[`@vanedb/wasm`](https://www.npmjs.com/package/@vanedb/wasm).
+
+Persistence, disk mapping and `upsert` are not available in WebAssembly.
+
+## Source
+
+[github.com/vanedb/vanedb](https://github.com/vanedb/vanedb)

--- a/npm/vanedb/index.cjs
+++ b/npm/vanedb/index.cjs
@@ -1,0 +1,2 @@
+// See index.mjs for why `init` stays in the contract.
+module.exports = require('@vanedb/wasm');

--- a/npm/vanedb/index.d.ts
+++ b/npm/vanedb/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from '@vanedb/wasm';
+export * from '@vanedb/wasm';

--- a/npm/vanedb/index.mjs
+++ b/npm/vanedb/index.mjs
@@ -1,0 +1,6 @@
+// The unscoped name re-exports the scoped package at a matching version.
+// `init` stays in the contract even though it is a no-op on Node: keeping it
+// means this entry point can later dispatch to a native binding without a
+// breaking change for anyone who wrote `await init()`.
+export { default } from '@vanedb/wasm';
+export * from '@vanedb/wasm';

--- a/scripts/build_npm_alias.py
+++ b/scripts/build_npm_alias.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Assemble the unscoped `vanedb` npm package.
+
+npm's scoped and unscoped namespaces are separate: owning the `vanedb`
+organisation reserves `@vanedb/*` and leaves the bare word open to anyone. This
+package holds it, and makes `npm install vanedb` — the name a reader is most
+likely to type — resolve to our code rather than to whatever a stranger might
+publish there.
+
+It is a real re-export, not a placeholder: npm's policy is fine with a
+functional alias and objects to empty name-holding. It depends on
+`@vanedb/wasm` at an exact matching version, so the two can never drift.
+
+`init` stays in the public contract even though it is a no-op on Node. That is
+what lets this entry point later dispatch to a native binding without breaking
+anyone who wrote `await init()`.
+"""
+
+import argparse
+import json
+import pathlib
+import re
+import shutil
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+SOURCE = ROOT / "npm/vanedb"
+WASM_MANIFEST = ROOT / "vanedb-wasm/Cargo.toml"
+
+
+def crate_version():
+    text = WASM_MANIFEST.read_text(encoding="utf-8")
+    match = re.search(r'(?m)^version = "([^"]+)"', text)
+    if not match:
+        raise SystemExit(f"no version in {WASM_MANIFEST}")
+    return match.group(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=pathlib.Path, default=ROOT / "target/npm/vanedb")
+    parser.add_argument(
+        "--alias-version",
+        help="version for this package. Defaults to the wasm crate's, which is "
+        "the lockstep case. Override only for the bootstrap publish that "
+        "reserves the name, so the version people install is never one "
+        "published by hand.",
+    )
+    args = parser.parse_args()
+
+    wasm_version = crate_version()
+    version = args.alias_version or wasm_version
+
+    out = args.output
+    if out.exists():
+        shutil.rmtree(out)
+    out.mkdir(parents=True)
+
+    for name in ("index.mjs", "index.cjs", "index.d.ts", "README.md"):
+        shutil.copy2(SOURCE / name, out / name)
+    shutil.copy2(ROOT / "LICENSE", out / "LICENSE")
+
+    package = {
+        "name": "vanedb",
+        "version": version,
+        "description": "Vector search in Node.js and the browser. Re-exports @vanedb/wasm.",
+        "license": "MIT",
+        "repository": {"type": "git", "url": "git+https://github.com/vanedb/vanedb.git"},
+        "keywords": ["vector", "search", "embeddings", "wasm", "hnsw", "database"],
+        "homepage": "https://github.com/vanedb/vanedb#readme",
+        "type": "module",
+        "types": "./index.d.ts",
+        "exports": {
+            ".": {
+                "types": "./index.d.ts",
+                "import": "./index.mjs",
+                "require": "./index.cjs",
+            },
+            "./package.json": "./package.json",
+        },
+        # Exact, not a range: the alias exists to be indistinguishable from the
+        # package it forwards to, and a range would let them drift.
+        "dependencies": {"@vanedb/wasm": wasm_version},
+        "files": ["index.mjs", "index.cjs", "index.d.ts", "README.md", "LICENSE"],
+    }
+    (out / "package.json").write_text(json.dumps(package, indent=2) + "\n", encoding="utf-8")
+
+    print(f"vanedb {version} -> depends on @vanedb/wasm {wasm_version}")
+    print(f"npm alias assembled at {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_npm_alias.py
+++ b/scripts/check_npm_alias.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Install the alias into a throwaway project and use it through both module systems.
+
+The package is three lines of re-export, which is exactly the kind of thing that
+looks obviously correct and silently forwards nothing. This installs the packed
+tarball alongside the real `@vanedb/wasm` and runs a search through `vanedb`.
+"""
+
+import json
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+ALIAS = ROOT / "target/npm/vanedb"
+WASM = ROOT / "target/npm/vanedb-wasm"
+
+ESM = """
+import init, { FlatIndex, version } from 'vanedb';
+await init();
+const index = new FlatIndex(3, 'l2');
+index.add(7n, new Float32Array([1, 0, 0]));
+const hits = index.search(new Float32Array([1, 0, 0]), 1);
+if (hits.ids[0] !== 7n) throw new Error(`ESM: got id ${hits.ids[0]}`);
+if (typeof version() !== 'string') throw new Error('ESM: version() is not a string');
+hits.free(); index.free();
+console.log('ESM ok');
+"""
+
+CJS = """
+const vanedb = require('vanedb');
+const index = new vanedb.FlatIndex(3, 'l2');
+index.add(9n, new Float32Array([0, 1, 0]));
+const hits = index.search(new Float32Array([0, 1, 0]), 1);
+if (hits.ids[0] !== 9n) throw new Error(`CJS: got id ${hits.ids[0]}`);
+hits.free(); index.free();
+console.log('CJS ok');
+"""
+
+
+def run(command, cwd):
+    result = subprocess.run(command, cwd=cwd, capture_output=True, text=True)
+    if result.returncode:
+        print(result.stdout[-2000:])
+        print(result.stderr[-2000:], file=sys.stderr)
+        raise SystemExit(f"failed: {' '.join(command)}")
+    return result.stdout
+
+
+def main():
+    for path in (ALIAS, WASM):
+        if not path.is_dir():
+            raise SystemExit(f"{path} is missing; run the build scripts first")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        project = pathlib.Path(tmp)
+        (project / "package.json").write_text(
+            json.dumps({"name": "alias-check", "private": True, "type": "module"}) + "\n")
+        # Pack first. `npm install <dir>` links the directory, so the alias
+        # would resolve `@vanedb/wasm` from its real path in target/ and never
+        # reach this project's node_modules -- passing or failing for reasons
+        # that have nothing to do with the published package.
+        tarballs = []
+        for source in (WASM, ALIAS):
+            out = run(["npm", "pack", str(source), "--pack-destination", str(project),
+                       "--ignore-scripts"], project)
+            tarballs.append(str(project / out.strip().splitlines()[-1]))
+        # The alias depends on @vanedb/wasm by exact version, so install the
+        # local build of it too: this must test the tarballs about to be
+        # published, not whatever the registry currently holds.
+        run(["npm", "install", "--no-audit", "--no-fund", *tarballs], project)
+
+        (project / "esm.mjs").write_text(ESM)
+        (project / "cjs.cjs").write_text(CJS)
+        print(" ", run(["node", "esm.mjs"], project).strip())
+        print(" ", run(["node", "cjs.cjs"], project).strip())
+
+    print("npm alias vanedb: ESM and CommonJS consumers both OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_release_readmes.py
+++ b/scripts/check_release_readmes.py
@@ -45,7 +45,7 @@ NAME = r"(?![-\w])"
 
 TARGETS = {
     "vanedb-crate-v": {
-        "readme": "vanedb/README.md",
+        "readmes": ["vanedb/README.md"],
         "registry": "crates.io",
         # `cargo add`, a plain version requirement, or the table form a crate
         # with features needs. The table form was rejected by the first version.
@@ -57,16 +57,19 @@ TARGETS = {
         "forbidden": [r"path\s*=\s*[\"'][^\"']*vanedb"],
     },
     "vanedb-v": {
-        "readme": "vanedb-py/README.md",
+        "readmes": ["vanedb-py/README.md"],
         "registry": "PyPI",
         "published": [rf"pip install (?:--upgrade )?[\"']?vanedb{NAME}"],
         "forbidden": [r"pip install \.", r"pip install [^\s\"']*/"],
     },
     # Packaged by `scripts/build_npm_package.py` and rendered by npmjs.com.
     "vanedb-wasm-v": {
-        "readme": "vanedb-wasm/README.md",
+        "readmes": ["vanedb-wasm/README.md", "npm/vanedb/README.md"],
         "registry": "npm",
-        "published": [r"npm (?:install|i) @vanedb/wasm"],
+        # Both packages ship on this tag: the scoped one and the unscoped
+        # alias. `{NAME}` keeps `npm install vanedb` from being satisfied by
+        # `npm install vanedb-something-else`.
+        "published": [r"npm (?:install|i) @vanedb/wasm", rf"npm (?:install|i) vanedb{NAME}"],
         "forbidden": [],
     },
 }
@@ -99,19 +102,23 @@ def check(tag):
         print(f"{tag}: no packaged README is tied to this tag; nothing to check")
         return 0
 
-    problems = problems_in(target, (ROOT / target["readme"]).read_text(encoding="utf-8"))
-    if problems:
-        print(f"{target['readme']} is not ready to ship to {target['registry']}:")
-        for problem in problems:
-            print(f"  - {problem}")
+    failed = False
+    for readme in target["readmes"]:
+        problems = problems_in(target, (ROOT / readme).read_text(encoding="utf-8"))
+        if problems:
+            failed = True
+            print(f"{readme} is not ready to ship to {target['registry']}:")
+            for problem in problems:
+                print(f"  - {problem}")
+        else:
+            print(f"{readme}: carries the published-install form for {target['registry']}")
+    if failed:
         print(
-            f"\nThis file is packaged into the artifact and rendered on "
+            f"\nThese files are packaged into the artifact and rendered on "
             f"{target['registry']}, which does not permit a re-upload. See "
             f"RELEASING.md step 5."
         )
         return 1
-
-    print(f"{target['readme']}: carries the published-install form for {target['registry']}")
     return 0
 
 

--- a/scripts/test_release_scripts.py
+++ b/scripts/test_release_scripts.py
@@ -61,6 +61,12 @@ CASES = [
     (CRATE, 'Add `vanedb = "0.1.0-rc.1"` to your dependencies.',
      True, "isolates the plain version-requirement published form"),
 
+    # --- the unscoped alias ships on the same tag as the scoped package ---
+    (WASM, "npm install vanedb\n\nRe-exports @vanedb/wasm.",
+     True, "the alias README's own install line must satisfy the npm target"),
+    (WASM, "npm install vanedb-cli", False,
+     "a different unscoped package must not satisfy it"),
+
     # --- legitimate prose a broad class wrongly rejected ---
     (PY, "pip install vanedb\n\nThe C++ bindings are kept for reference and are not published.",
      True, "a true statement about another package"),


### PR DESCRIPTION
`npm view vanedb` is a **404** today. Owning the `vanedb` organisation reserves `@vanedb/*` and nothing else — npm's scoped and unscoped namespaces are entirely separate, with no precedence or first-refusal. So the name a reader is most likely to type is open to anyone, and if a stranger takes it, `npm install vanedb` starts succeeding and returns *their* code.

That differs from crates.io and PyPI, where publishing `vanedb` took the name outright.

## A real alias, not a placeholder

npm's policy is fine with a functional alias and objects to empty name-holding. This re-exports `@vanedb/wasm` and pins it at an **exact** version, not a range — the alias exists to be indistinguishable from what it forwards to, and a range would let them drift.

`init` stays in the public contract even though it's a no-op on Node. That's what lets this entry point later dispatch to a native `@vanedb/node` **without a breaking change** for anyone who wrote `await init()`. The wasm package already established that shape; keeping it leaves the migration open.

## Three lines of re-export is exactly what silently forwards nothing

`check_npm_alias.py` installs the packed tarball into a throwaway project alongside the local `@vanedb/wasm` build and runs a **real search** through `vanedb` in both ESM and CommonJS, asserting the returned id.

It packs first rather than installing the directory. `npm install <dir>` *links*, so the alias resolved its dependency from `target/` and never reached the test project's `node_modules` — I found that by watching it fail with `ERR_MODULE_NOT_FOUND`, which is the good outcome: a check that passes for the wrong reason would have been worse.

## The gate now handles two packaged READMEs per tag

This tag ships two packages, both with a README that npm renders. Checking only the first would have left the alias README exactly where `@vanedb/wasm@0.1.0`'s was — packaged, rendered, unexamined.

It caught the alias on the first run: its install line is `npm install vanedb`, which the npm patterns didn't accept. Both names now pass, **whole-token**, so `npm install vanedb-cli` still can't satisfy it. 20/20 cases.

## Publish order matters

Scoped first. The alias pins `@vanedb/wasm` by exact version, so publishing the alias first would leave a version whose dependency doesn't resolve.

## What you'll need to do once

npm has no pending publisher, so reserving the name needs one manual bootstrap. **Do it at a throwaway version** — `0.0.1-reserve.1`, not `0.1.0` — the same lesson crates.io just taught. Then configure the trusted publisher, revoke the token, and every version anyone installs goes out through CI with provenance.

## Verification

20/20 release-README cases, alias installs and runs both ways, fmt, Rust + bench suites, 98 C++ tests, actionlint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H