### PR TITLE
release: 0.1.0-rc.2, and make the README check verify the pinned version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1221,7 +1221,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vanedb"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "bincode",
  "criterion",
@@ -1236,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "vanedb-capi"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "cbindgen",
  "vanedb",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "vanedb-py"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "vanedb-wasm"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",

--- a/bench/Cargo.lock
+++ b/bench/Cargo.lock
@@ -883,7 +883,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vanedb"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "bincode",
  "memmap2",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "vanedb-capi"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "cbindgen",
  "vanedb",

--- a/cpp/Doxyfile
+++ b/cpp/Doxyfile
@@ -1,7 +1,7 @@
 # Doxyfile for VaneDB
 
 PROJECT_NAME           = "VaneDB"
-PROJECT_NUMBER         = "0.1.0-rc.1"
+PROJECT_NUMBER         = "0.1.0-rc.2"
 PROJECT_BRIEF          = "Embeddable vector database for edge AI"
 OUTPUT_DIRECTORY       = docs
 

--- a/cpp/pyproject.toml
+++ b/cpp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vanedb-cpp"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 description = "Supplementary C++ Python bindings for VaneDB"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/cpp/src/core/version.h
+++ b/cpp/src/core/version.h
@@ -15,7 +15,7 @@ constexpr int VERSION_MINOR = 1;
 constexpr int VERSION_PATCH = 0;
 
 /// Full version string
-constexpr const char* VERSION_STRING = "0.1.0-rc.1";
+constexpr const char* VERSION_STRING = "0.1.0-rc.2";
 
 /**
  * @brief Returns the version as a single integer for comparison.

--- a/scripts/check_release_readmes.py
+++ b/scripts/check_release_readmes.py
@@ -72,7 +72,35 @@ TARGETS = {
 }
 
 
-def problems_in(target, text):
+# Versions a README may pin, per target. A pin is only honest if it names the
+# version being published: a form check alone let `cargo add vanedb@0.1.0-rc.1`
+# ship on the crates.io page for 0.1.0-rc.2, which no registry lets you correct.
+PINS = {
+    "vanedb-crate-v": [r"cargo add vanedb@(\S+)", r'vanedb\s*=\s*"([^"]+)"',
+                       r'version\s*=\s*"([^"]+)"'],
+    "vanedb-v": [r"pip install (?:--upgrade )?vanedb==(\S+)"],
+    "vanedb-wasm-v": [r"npm (?:install|i) @vanedb/wasm@(\S+)"],
+}
+
+
+def pep440(version):
+    """`0.1.0-rc.2` as pip spells it: `0.1.0rc2`."""
+    return version.replace("-rc.", "rc").replace("-alpha.", "a").replace("-beta.", "b")
+
+
+def wrong_pins(prefix, text, version):
+    """Pins in `text` naming something other than `version`."""
+    accepted = {version, pep440(version)}
+    wrong = []
+    for pattern in PINS.get(prefix, []):
+        for match in re.finditer(pattern, text):
+            pinned = match.group(1).strip("`'\".,;:)]}")
+            if pinned not in accepted:
+                wrong.append((" ".join(match.group(0).split()), pinned))
+    return wrong
+
+
+def problems_in(target, text, prefix=None, version=None):
     """Why `text` is not ready to ship for `target`; empty means ready.
 
     Split out so the tests can drive it with fixtures instead of the real
@@ -90,6 +118,11 @@ def problems_in(target, text):
         if match:
             problems.append(f"still says the package is unpublished: {match.group(0)!r}")
 
+    if prefix and version:
+        for line, pinned in wrong_pins(prefix, text, version):
+            problems.append(
+                f"pins {pinned!r} but this tag publishes {version!r}: {line!r}")
+
     return problems
 
 
@@ -99,7 +132,9 @@ def check(tag):
         print(f"{tag}: no packaged README is tied to this tag; nothing to check")
         return 0
 
-    problems = problems_in(target, (ROOT / target["readme"]).read_text(encoding="utf-8"))
+    prefix = next(p for p in TARGETS if tag.startswith(p))
+    problems = problems_in(target, (ROOT / target["readme"]).read_text(encoding="utf-8"),
+                           prefix, tag[len(prefix):])
     if problems:
         print(f"{target['readme']} is not ready to ship to {target['registry']}:")
         for problem in problems:

--- a/scripts/test_release_scripts.py
+++ b/scripts/test_release_scripts.py
@@ -70,8 +70,37 @@ CASES = [
 ]
 
 
+PIN_CASES = [
+    # (prefix, text, version, should_be_ready, why)
+    ("vanedb-crate-v", "cargo add vanedb@0.1.0-rc.2", "0.1.0-rc.2", True,
+     "a pin naming the version being published"),
+    ("vanedb-crate-v", "cargo add vanedb@0.1.0-rc.1", "0.1.0-rc.2", False,
+     "a pin left over from the previous release candidate"),
+    ("vanedb-crate-v", 'vanedb = { version = "0.1.0-rc.1", features = ["disk"] }',
+     "0.1.0-rc.2", False, "a stale pin in the features table form"),
+    ("vanedb-v", "pip install vanedb==0.1.0rc2", "0.1.0-rc.2", True,
+     "pip spells the same version differently and must be accepted"),
+    ("vanedb-v", "pip install vanedb==0.1.0rc1", "0.1.0-rc.2", False,
+     "a stale pip pin"),
+    ("vanedb-crate-v", "cargo add vanedb", "0.1.0-rc.2", True,
+     "an unpinned line has nothing to check"),
+]
+
+
+def check_pins(failures):
+    from check_release_readmes import TARGETS, problems_in
+    for prefix, text, version, should_be_ready, why in PIN_CASES:
+        problems = problems_in(TARGETS[prefix], text, prefix, version)
+        ready = not problems
+        if ready != should_be_ready:
+            failures.append(
+                f"pin case: expected {'ready' if should_be_ready else 'NOT ready'} "
+                f"({why})\n    text: {text!r}\n    problems: {problems}")
+
+
 def main():
     failures = []
+    check_pins(failures)
     for target, text, should_be_ready, why in CASES:
         problems = problems_in(target, text)
         ready = not problems
@@ -82,7 +111,8 @@ def main():
             )
     for failure in failures:
         print(f"FAIL {failure}")
-    print(f"{len(CASES) - len(failures)}/{len(CASES)} release-README cases pass")
+    total = len(CASES) + len(PIN_CASES)
+    print(f"{total - len(failures)}/{total} release-README cases pass")
     return 1 if failures else 0
 
 

--- a/vanedb-capi/Cargo.toml
+++ b/vanedb-capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vanedb-capi"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 edition = "2021"
 # Bound by bincode 2.x, the newest runtime dependency. CI checks it.
 rust-version = "1.85"

--- a/vanedb-capi/include/vanedb_rs_capi.h
+++ b/vanedb-capi/include/vanedb_rs_capi.h
@@ -17,7 +17,7 @@ typedef struct vanedb_rs_disk vanedb_rs_disk;
 /* The version this header was generated from. Compare against
  * vanedb_rs_version() at runtime to catch a shared object that does not
  * match the header you compiled against. */
-#define VANEDB_RS_VERSION "0.1.0-rc.1"
+#define VANEDB_RS_VERSION "0.1.0-rc.2"
 
 /* Distance metric, passed as uint32_t: */
 #define VANEDB_RS_L2     0u

--- a/vanedb-py/Cargo.toml
+++ b/vanedb-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vanedb-py"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 edition = "2021"
 # Bound by bincode 2.x, the newest runtime dependency. CI checks it.
 rust-version = "1.85"

--- a/vanedb-py/README.md
+++ b/vanedb-py/README.md
@@ -14,7 +14,7 @@ kept in the repository for reference and local testing, and are not published.
 Requires Python 3.11 or newer.
 
 ```sh
-python -m pip install vanedb==0.1.0rc1
+python -m pip install vanedb==0.1.0rc2
 ```
 
 The version is pinned because pip does not select a prerelease unless asked;

--- a/vanedb-py/pyproject.toml
+++ b/vanedb-py/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 
 [project]
 name = "vanedb"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 description = "Embeddable vector database for edge AI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/vanedb-wasm/Cargo.toml
+++ b/vanedb-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vanedb-wasm"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 edition = "2021"
 rust-version = "1.85"
 description = "Embeddable vector search for JavaScript and WebAssembly"

--- a/vanedb/Cargo.toml
+++ b/vanedb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vanedb"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 edition = "2021"
 # Bound by bincode 2.x, the newest runtime dependency. CI checks it.
 rust-version = "1.85"

--- a/vanedb/README.md
+++ b/vanedb/README.md
@@ -11,7 +11,7 @@ VaneDB stores only `(u64, vector)` pairs. There is no metadata or payload
 storage and no filtered search; keep your own id-to-document mapping
 alongside it. Supply your own embeddings — VaneDB does not generate them.
 
-Add it with `cargo add vanedb@0.1.0-rc.1`. The version is pinned because a
+Add it with `cargo add vanedb@0.1.0-rc.2`. The version is pinned because a
 plain `cargo add vanedb` excludes prereleases and currently resolves to
 nothing; drop the pin once 0.1.0 is out. From a source checkout, run
 `cargo run -p vanedb --example quickstart --locked` at the repository root.
@@ -70,7 +70,7 @@ Metal compute requires macOS 10.14 or newer and a usable Metal device. Enable
 `gpu-metal` explicitly in your application's dependency:
 
 ```toml
-vanedb = { version = "0.1.0-rc.1", features = ["gpu-metal"] }
+vanedb = { version = "0.1.0-rc.2", features = ["gpu-metal"] }
 ```
 
 This exposes `MetalCompute` for manually uploaded vectors and distance scans.


### PR DESCRIPTION
The bump, plus a hole it exposed.

## First run of the repaired bump script

All ten sites moved — including the four in `cpp/src/core/version.h` that the previous version corrupted — and `release_identity` passed inside the script's own verify chain rather than as a separate claim.

## The check caught something I'd otherwise have shipped

The packaged READMEs **pin** their install lines (`cargo add vanedb@0.1.0-rc.1`, `pip install vanedb==0.1.0rc1`), because an unpinned command resolves to nothing while a prerelease is the only published version.

After the bump those pins named **rc.1** while the tag would publish **rc.2** — and the check passed. It verified the *form* of an install line and never looked at the version inside it.

| | |
|---|---|
| Would have shipped | crates.io page for `0.1.0-rc.2` saying `cargo add vanedb@0.1.0-rc.1` |
| Recoverable? | **No** — no registry here permits a re-upload |

`★` The pin was added *because* an unpinned line would be wrong during the rc window. Fixing one falsehood introduced a second one that only appears at the *next* version — invisible until exactly the moment it becomes permanent.

## What changed

The gate now compares pinned versions against the tag. `cargo add vanedb@X`, plain and table-form version requirements, `pip install vanedb==X` and `npm install @vanedb/wasm@X` must all name the version being published. pip spells it differently, so `0.1.0rc2` is accepted for `0.1.0-rc.2`. An unpinned line still passes — nothing to be wrong about.

Six new cases pin this: a correct pin, a stale pin in each crate form, the PEP 440 spelling, a stale pip pin, and an unpinned line. **24 cases total.**

READMEs updated to rc.2, confirmed READY for all three tags — and the check still refuses a hypothetical rc.3 against these pins, so it's doing work rather than agreeing with whatever it finds.

## Verification

fmt, Rust + bench suites, 98 C++ tests, actionlint, 24/24 README cases, 5/5 bump-script tests.

## After merge

Tag `vanedb-crate-v0.1.0-rc.2`, `vanedb-v0.1.0-rc.2`, `vanedb-wasm-v0.1.0-rc.2` — all three publish through CI with provenance. crates.io works this time; rc.2 is a fresh version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H