### PR TITLE
feat(wasm): add upsert and a per-query beam width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,13 @@ section records what it contains rather than what changed.
   cannot silently stop older files from loading.
 - `DiskIndex::open` documents that the mapped file must not change while open,
   on the Rust, C and Python surfaces.
+- WebAssembly gains `upsert` and a per-query beam width, closing the last two
+  gaps against the other bindings. `upsert` is one operation where `remove`
+  then `add` is two, and those two can fail between the halves and leave the id
+  deleted. The beam width applies to a single `search` and leaves
+  `ef_search` alone, so rescuing one hard query no longer charges every later
+  one. `is_empty` is deliberately not ported: `len(index)` and `index.size`
+  are what those languages already say.
 - Python `Metric` pickles, so a worker pool can be handed one. The index types
   still refuse, at `dumps` rather than at `loads`: an index belongs in a
   `.vndb` file, and bytes no unpickler will accept are worse than an error.

--- a/docs/release/0.1.0-notes.md
+++ b/docs/release/0.1.0-notes.md
@@ -24,10 +24,9 @@ with `u64` ids and finite fixed-dimension vectors.
 | WebAssembly | yes | yes | — no filesystem |
 
 Batch insert and delete work on the exact in-memory and approximate indexes.
-`ApproxIndex` adds replace and compaction. Rust, Python and the C ABI take a
-per-query beam width, so raising recall for one search leaves the index's own
-setting alone; in WebAssembly that setting is a property, and replace is not
-exposed at all. Optional macOS Metal compute exposes uploaded vectors and distance scans
+`ApproxIndex` adds replace and compaction. Every binding takes a per-query beam
+width, so raising recall for one search leaves the index's own setting alone.
+Optional macOS Metal compute exposes uploaded vectors and distance scans
 through Rust; it does not accelerate the indexes themselves.
 
 Platforms: Linux x86-64 and ARM64, macOS Intel and Apple Silicon, Windows x64.

--- a/vanedb-wasm/README.md
+++ b/vanedb-wasm/README.md
@@ -53,8 +53,16 @@ neighbourhoods. `tombstones()` counts what that has cost and `compact()`
 reclaims it — worth calling once churn accumulates, since a browser is the most
 memory-constrained runtime this package targets.
 
-Persistence (`save`/`load`), disk mapping and `upsert` are not available in
-WebAssembly.
+`upsert(id, vector)` replaces a vector in one operation, inserting it if the id
+is absent. It is not `remove` then `add`: those can fail between the halves and
+leave the id deleted.
+
+`search` takes an optional beam width — `search(query, k, 64)` — that applies to
+that query alone and leaves `index.ef_search` untouched. Use it to spend extra
+recall on one hard query without paying for it on every later one.
+
+Persistence (`save`/`load`) and disk mapping are not available in WebAssembly:
+there is no filesystem to map.
 
 ## Values
 

--- a/vanedb-wasm/src/lib.rs
+++ b/vanedb-wasm/src/lib.rs
@@ -1,7 +1,7 @@
 use js_sys::BigInt;
 use wasm_bindgen::prelude::*;
 
-use vanedb::approx::ApproxIndex;
+use vanedb::approx::{ApproxIndex, SearchParams};
 use vanedb::distance::Metric;
 use vanedb::flat::{FlatIndex, SearchResult};
 
@@ -212,6 +212,17 @@ impl WasmIndex {
         self.inner.remove(one_id(id)?).map_err(to_jserr)
     }
 
+    /// Replaces the vector stored under `id`, inserting it if absent.
+    ///
+    /// One locked operation rather than `remove` then `add`. Those two can
+    /// fail between the halves and leave the id deleted, and any reader
+    /// running against the same memory sees a window where it is missing;
+    /// this has neither. A replaced slot is tombstoned like any other
+    /// removal, so `tombstones` counts it and `compact` reclaims it.
+    pub fn upsert(&self, id: BigInt, vector: &[f32]) -> Result<(), JsError> {
+        self.inner.upsert(one_id(id)?, vector).map_err(to_jserr)
+    }
+
     /// How many removed slots the graph still carries.
     ///
     /// A browser is the most memory-constrained runtime this crate targets, and
@@ -276,8 +287,26 @@ impl WasmIndex {
     /// parallel by index. Ids are never narrowed to `f32`: values at or above
     /// 2^24 are not exactly representable, so distinct records collided and
     /// callers could act on the wrong record (#39).
-    pub fn search(&self, query: &[f32], k: f64) -> Result<WasmSearchResults, JsError> {
-        let results = self.inner.search(query, count(k, "k")?).map_err(to_jserr)?;
+    /// `ef_search` widens the beam for this query alone and leaves the index's
+    /// own setting untouched. The property is shared state, so raising it to
+    /// rescue one hard query silently pays for it on every later one; this is
+    /// the way to spend that cost once. Below `k` it is raised to `k`, since
+    /// fewer candidates than results is meaningless.
+    pub fn search(
+        &self,
+        query: &[f32],
+        k: f64,
+        ef_search: Option<f64>,
+    ) -> Result<WasmSearchResults, JsError> {
+        let k = count(k, "k")?;
+        let results = match ef_search {
+            Some(ef) => {
+                let params = SearchParams::new().ef_search(count(ef, "ef_search")?);
+                self.inner.search_with(query, k, &params)
+            }
+            None => self.inner.search(query, k),
+        }
+        .map_err(to_jserr)?;
         Ok(WasmSearchResults::from(results))
     }
 

--- a/vanedb-wasm/tests/web.rs
+++ b/vanedb-wasm/tests/web.rs
@@ -48,7 +48,7 @@ fn test_hnsw_search() {
     idx.add(1u64.into(), &[0.0, 0.0, 0.0]).unwrap();
     idx.add(2u64.into(), &[10.0, 10.0, 10.0]).unwrap();
 
-    let hits = idx.search(&[0.0, 0.0, 0.0], 1.0).unwrap();
+    let hits = idx.search(&[0.0, 0.0, 0.0], 1.0, None).unwrap();
     assert_eq!(hits.ids()[0], 1);
 }
 
@@ -90,7 +90,7 @@ fn test_hnsw_add_batch() {
     let flat = [0.0f32, 0.0, 1.0, 1.0];
     index.add_batch(&ids, &flat).unwrap();
     assert_eq!(index.size(), 2);
-    let results = index.search(&[0.1, 0.1], 1.0).unwrap();
+    let results = index.search(&[0.1, 0.1], 1.0, None).unwrap();
     assert_eq!(results.ids()[0], 10);
 }
 
@@ -117,7 +117,7 @@ fn hnsw_search_round_trips_ids_beyond_f32_precision() {
     for (i, id) in PRECISION_IDS.iter().enumerate() {
         index.add((*id).into(), &[i as f32, 0.0]).unwrap();
     }
-    let mut got = index.search(&[0.0, 0.0], 4.0).unwrap().ids();
+    let mut got = index.search(&[0.0, 0.0], 4.0, None).unwrap().ids();
     got.sort_unstable();
     let mut want = PRECISION_IDS.to_vec();
     want.sort_unstable();
@@ -265,4 +265,66 @@ fn a_non_string_metric_is_rejected_not_trapped() {
     }
     // A string that is not a metric stays a metric error, not a type error.
     assert!(WasmStore::new(2.0, &JsValue::from_str("nope")).is_err());
+}
+
+/// `upsert` is one locked operation where `remove` then `add` is two.
+///
+/// wasm shipped without it while Rust, Python and the C ABI had it, and the
+/// README stated the omission without a reason. There is none: persistence is
+/// absent because a browser has no filesystem, but this is pure in-memory
+/// state, and `add` and `remove` were already exposed.
+#[wasm_bindgen_test]
+fn upsert_replaces_in_place_and_inserts_when_absent() {
+    let index = WasmIndex::new(3.0, &JsValue::from_str("l2"), 100.0, 16.0, 200.0, None).unwrap();
+    index.add(1u64.into(), &[0.0, 0.0, 0.0]).unwrap();
+
+    index.upsert(1u64.into(), &[5.0, 5.0, 5.0]).unwrap();
+    assert_eq!(index.size(), 1, "replacing must not grow the index");
+    assert_eq!(index.get(1u64.into()).unwrap(), vec![5.0, 5.0, 5.0]);
+    assert_eq!(index.tombstones(), 1, "the replaced slot is tombstoned");
+
+    index.upsert(2u64.into(), &[1.0, 1.0, 1.0]).unwrap();
+    assert_eq!(index.size(), 2, "an absent id is inserted, not refused");
+
+    // The property that makes this worth having over remove-then-add: a
+    // rejected upsert leaves the entry alone, where the two-call form can
+    // fail after the removal and lose it.
+    assert!(index.upsert(1u64.into(), &[1.0, 1.0]).is_err());
+    assert!(
+        index.contains(1u64.into()).unwrap(),
+        "a failed upsert must not delete"
+    );
+    assert_eq!(index.get(1u64.into()).unwrap(), vec![5.0, 5.0, 5.0]);
+}
+
+/// A beam width for one query, leaving the index's own setting alone.
+///
+/// `ef_search` is a property, so the only way to widen a single hard query was
+/// to raise it, search, and lower it again -- three calls, and every search in
+/// between pays. Rust, Python and the C ABI all take it per call.
+#[wasm_bindgen_test]
+fn per_query_ef_search_leaves_the_shared_setting_alone() {
+    let index = WasmIndex::new(2.0, &JsValue::from_str("l2"), 200.0, 4.0, 8.0, Some(7.0)).unwrap();
+    for i in 0..60u64 {
+        let x = i as f32;
+        index.add(i.into(), &[x, x]).unwrap();
+    }
+    index.set_ef_search(1.0).unwrap();
+
+    let widened = index.search(&[0.0, 0.0], 5.0, Some(64.0)).unwrap();
+    assert_eq!(
+        widened.ids(),
+        vec![0, 1, 2, 3, 4],
+        "a beam wider than the corpus must return the exact answer"
+    );
+    assert_eq!(
+        index.ef_search(),
+        1,
+        "a per-query width must not write to the shared property"
+    );
+
+    // Omitting it falls back to that property, and it is validated like `k`.
+    assert_eq!(index.search(&[0.0, 0.0], 5.0, None).unwrap().length(), 5);
+    assert!(index.search(&[0.0, 0.0], 5.0, Some(-1.0)).is_err());
+    assert!(index.search(&[0.0, 0.0], 5.0, Some(f64::NAN)).is_err());
 }


### PR DESCRIPTION
Closes the last two API gaps between the wasm binding and the other three, so the capability matrix stops carrying exceptions. Both operations already existed in the core — wasm was the only surface that could not reach them.

Closes the second and third items of #182.

## `upsert`

One locked replace, where the workaround is two calls that can fail between the halves and leave the id deleted. A test pins exactly that: a rejected `upsert` leaves the entry and its vector untouched.

```js
index.upsert(42n, new Float32Array([1, 0, 0]));   // replaces, or inserts if absent
```

`vanedb-wasm/README.md` stated the omission without a reason, and there wasn't one. Persistence is absent because a browser has no filesystem; this is pure in-memory state, and `add` and `remove` were already exposed.

## Per-query beam width

```js
const hits = index.search(query, 5, 64);   // wide beam, this query only
index.ef_search;                            // unchanged
```

`ef_search` is a property, so rescuing one hard query previously meant raising it, searching, and lowering it again — with every search in between paying for it. Rust, Python and the C ABI all took it per call.

The generated declaration is `search(query: Float32Array, k: number, ef_search?: number | null)`, so **no existing JS or TS caller changes**. The Rust signature gained an argument, which is why the in-crate call sites did. `FlatIndex.search` is untouched — it is exact, so a beam width is meaningless there.

## `is_empty` is deliberately *not* ported

The first item of #182 should close as won't-do. Python already answers it with `len(index)` and, via `__len__`, with `if not index:`. JS answers it with `index.size === 0`. It exists in Rust because Clippy requires it beside `len`, not because a caller asked. Porting it to two languages that each already have an idiom is API noise, not parity.

## Verification

22/22 wasm tests, up from 20, with the exit status checked directly rather than through a pipe — that masking has bitten twice in this repo. Plus fmt, clippy for the workspace and the wasm target, workspace tests, and the npm package assembling with the new declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H

