### PR TITLE
fix(cpp): pickle Metric by value, not by name

### DIFF
--- a/cpp/CHANGELOG.md
+++ b/cpp/CHANGELOG.md
@@ -64,10 +64,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   through its constructor, giving every protocol one path. It reduces by
   *value* rather than by name because pybind11 lets an enum hold an integer no
   value names — `Metric(7)` reprs as `<Metric.???: 7>` — and a name-based
-  reduce has to pick a named fallback for those, turning a round trip into
-  silent corruption. The test runs out-of-process, because an in-process one
-  would have taken the whole session down with it, which is why nothing caught
-  the abort.
+  reduce has to pick a named fallback for those. That is worse than lossy:
+  `FlatIndex(3, Metric(7))` rejects the invalid value, so by-name turned an
+  inert-but-invalid metric into a *valid* `L2` the engine accepts and computes
+  wrong distances with.
+
+  A pickled `Metric` is now equal to, but not the same object as, the class
+  member, because reconstruction calls the constructor. `Metric(1) is
+  Metric.COSINE` was already false, so `is` was never sound on this type — but
+  note the `vanedb` package reduces by name and does preserve identity.
+  Compare metrics with `==`, which both honour.
+
+  The test runs out-of-process, because an in-process one would have taken the
+  whole session down with it, which is why nothing caught the abort. What gives
+  it teeth is the unnamed `Metric(7)` case: the three named values round-trip
+  correctly even under the buggy implementation.
 - A persisted negative level multiplier made the next insertion fail. The
   loader now retains the multiplier derived from `M`, matching Rust, and a
   regression covers negative, infinite and NaN stored values. Recorded here

--- a/cpp/CHANGELOG.md
+++ b/cpp/CHANGELOG.md
@@ -60,10 +60,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `__getstate__`, which serves protocol 2 and up; protocols 0 and 1
   reconstruct through `copyreg._reconstructor`, which calls `object.__new__`
   on a pybind11 type. That throws a C++ exception with no Python translation,
-  so the process died on SIGABRT instead of raising. `Metric` now reduces by
-  name, giving every protocol one path. The test runs out-of-process, because
-  an in-process one would have taken the whole session down with it — which is
-  why nothing caught this.
+  so the process died on SIGABRT instead of raising. `Metric` now reduces
+  through its constructor, giving every protocol one path. It reduces by
+  *value* rather than by name because pybind11 lets an enum hold an integer no
+  value names — `Metric(7)` reprs as `<Metric.???: 7>` — and a name-based
+  reduce has to pick a named fallback for those, turning a round trip into
+  silent corruption. The test runs out-of-process, because an in-process one
+  would have taken the whole session down with it, which is why nothing caught
+  the abort.
 - A persisted negative level multiplier made the next insertion fail. The
   loader now retains the multiplier derived from `M`, matching Rust, and a
   regression covers negative, infinite and NaN stored values. Recorded here

--- a/cpp/python/vanedb.cpp
+++ b/cpp/python/vanedb.cpp
@@ -62,7 +62,7 @@ PYBIND11_MODULE(vanedb_cpp, m) {
         .value("L2", Metric::L2)
         .value("COSINE", Metric::COSINE)
         .value("DOT", Metric::DOT)
-        // Pickle by name, so every protocol takes one path.
+        // Pickle through the constructor, so every protocol takes one path.
         //
         // pybind11 gives an enum `__getstate__`, which serves protocol 2 and
         // up. Protocols 0 and 1 instead reconstruct through
@@ -71,13 +71,16 @@ PYBIND11_MODULE(vanedb_cpp, m) {
         // translation, so the interpreter aborts on SIGABRT rather than
         // raising. Nothing caught it because an in-process test would have
         // taken the whole session down with it.
+        //
+        // Reconstruct from the value, not the name. pybind11 lets an enum
+        // hold an integer no value names -- `Metric(7)` reprs as
+        // `<Metric.???: 7>` -- and reducing by name has to pick some named
+        // fallback for those, which turns a pickle round trip into silent
+        // corruption. The discriminants are already frozen by the C ABI
+        // (0=L2, 1=Cosine, 2=Dot), so naming them here commits to nothing new.
         .def("__reduce__", [](const Metric &self) {
-            const char *name = self == Metric::COSINE ? "COSINE"
-                             : self == Metric::DOT    ? "DOT"
-                                                      : "L2";
-            return py::make_tuple(
-                py::module_::import("builtins").attr("getattr"),
-                py::make_tuple(py::cast(self).get_type(), name));
+            return py::make_tuple(py::type::of(py::cast(self)),
+                                  py::make_tuple(static_cast<int>(self)));
         })
         ;
 

--- a/cpp/python/vanedb.cpp
+++ b/cpp/python/vanedb.cpp
@@ -72,12 +72,27 @@ PYBIND11_MODULE(vanedb_cpp, m) {
         // raising. Nothing caught it because an in-process test would have
         // taken the whole session down with it.
         //
-        // Reconstruct from the value, not the name. pybind11 lets an enum
-        // hold an integer no value names -- `Metric(7)` reprs as
-        // `<Metric.???: 7>` -- and reducing by name has to pick some named
-        // fallback for those, which turns a pickle round trip into silent
-        // corruption. The discriminants are already frozen by the C ABI
-        // (0=L2, 1=Cosine, 2=Dot), so naming them here commits to nothing new.
+        // Reconstruct from the value, not the name. pybind11 lets an enum hold
+        // an integer no value names -- `Metric(7)` reprs as `<Metric.???: 7>`
+        // -- and reducing by name has to pick some named fallback for those.
+        // That is not merely lossy: `FlatIndex(3, Metric(7))` rejects the
+        // invalid value, so by-name turned an inert-but-invalid metric into a
+        // *valid* L2 the engine accepts and computes wrong distances with.
+        //
+        // Committing to the discriminant costs nothing new. It is already
+        // public API on this type (`int(Metric.L2)`, `Metric(0)`), it is the C
+        // ABI's metric parameter and the VNDB on-disk metric field, and it is
+        // what CPython's own `enum` reduces to.
+        //
+        // One consequence to know: the result is equal to, but not the same
+        // object as, the class member. `Metric(1) is Metric.COSINE` was already
+        // false before this, so `is` was never sound here -- but note the
+        // sibling `vanedb` package pickles by name and *does* preserve
+        // identity. Compare metrics with `==`, which both packages honour.
+        //
+        // `py::type::of(handle)` is the runtime overload on purpose: the
+        // template form `py::type::of<Metric>()` fails to compile for an enum,
+        // because `py::enum_` does not use the generic type caster.
         .def("__reduce__", [](const Metric &self) {
             return py::make_tuple(py::type::of(py::cast(self)),
                                   py::make_tuple(static_cast<int>(self)));

--- a/cpp/tests/test_python_bindings.py
+++ b/cpp/tests/test_python_bindings.py
@@ -775,6 +775,7 @@ def test_metric_pickles_at_every_protocol():
     """
     script = textwrap.dedent(
         """
+        import copy
         import pickle
         import vanedb_cpp
 
@@ -782,15 +783,35 @@ def test_metric_pickles_at_every_protocol():
             getattr(vanedb_cpp.Metric, n)
             for n in ("L2", "COSINE", "DOT")
         ]
-        # pybind11 lets an enum hold an integer no value names, and a round
-        # trip must not quietly turn it into one that is: reducing by name has
-        # to choose some named fallback, which reports 7 back as L2.
+        # This appended case is what gives the test teeth. The three named
+        # values round-trip correctly even under a by-name reduce, so a test
+        # without an unnamed one passes the implementation that corrupts it.
+        # (pybind11 compares enums by underlying value, so `==` alone catches
+        # it once the case exists; the int() assertion below is belt-and-braces
+        # against a future __eq__, not the thing doing the work.)
         metrics.append(vanedb_cpp.Metric(7))
         for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
             for metric in metrics:
                 restored = pickle.loads(pickle.dumps(metric, protocol=protocol))
                 assert restored == metric, (protocol, metric, restored)
                 assert int(restored) == int(metric), (protocol, metric, restored)
+
+        # copy and deepcopy route through __reduce_ex__ to the same __reduce__,
+        # so they are covered by construction -- but nothing pinned that, and a
+        # future __copy__ or protocol-specific __reduce_ex__ could diverge them
+        # from pickle silently.
+        for metric in metrics:
+            for clone in (copy.copy(metric), copy.deepcopy(metric)):
+                assert clone == metric and int(clone) == int(metric), metric
+
+        # The contract is equality and value, not identity: reconstruction
+        # calls the constructor, and `Metric(1) is Metric.COSINE` is false in
+        # pybind11 regardless of pickling. These are the operations that must
+        # keep working, and they are what callers should use.
+        restored = pickle.loads(pickle.dumps(vanedb_cpp.Metric.COSINE))
+        assert restored == vanedb_cpp.Metric.COSINE
+        assert {vanedb_cpp.Metric.COSINE: "cos"}[restored] == "cos"
+        assert restored in (vanedb_cpp.Metric.L2, vanedb_cpp.Metric.COSINE)
         """
     )
     result = subprocess.run(

--- a/cpp/tests/test_python_bindings.py
+++ b/cpp/tests/test_python_bindings.py
@@ -782,10 +782,15 @@ def test_metric_pickles_at_every_protocol():
             getattr(vanedb_cpp.Metric, n)
             for n in ("L2", "COSINE", "DOT")
         ]
+        # pybind11 lets an enum hold an integer no value names, and a round
+        # trip must not quietly turn it into one that is: reducing by name has
+        # to choose some named fallback, which reports 7 back as L2.
+        metrics.append(vanedb_cpp.Metric(7))
         for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
             for metric in metrics:
                 restored = pickle.loads(pickle.dumps(metric, protocol=protocol))
                 assert restored == metric, (protocol, metric, restored)
+                assert int(restored) == int(metric), (protocol, metric, restored)
         """
     )
     result = subprocess.run(


### PR DESCRIPTION
A follow-up to the C++ pickle fix in #181, which traded a crash for a quieter defect.

That fix stopped `pickle.dumps(Metric.COSINE, protocol=0)` aborting the interpreter by reducing through `getattr(Metric, "<NAME>")`. But pybind11 lets an enum hold an integer no value names:

```python
>>> m = vanedb_cpp.Metric(7)
>>> m
<Metric.???: 7>
>>> pickle.loads(pickle.dumps(m))     # before this PR
<Metric.L2: 0>
```

A name-based reduce has to pick some named fallback for an unnamed value. Mine picked `L2`, so a round trip silently returned `7` as `0` — no error, no warning, a different metric. Reducing through the constructor preserves the value at every protocol.

The discriminants are already frozen by the C ABI (`0=L2, 1=Cosine, 2=Dot`), so depending on them here commits to nothing new.

**Credit:** this is the approach Codex independently used in the release branch for #184. Diffing the two implementations is what surfaced the difference — its comment said "preserves unnamed integer values", which was the tell. This lands the correction on `main` so the bug does not sit there while that PR is in draft, and so #184 rebases onto matching content.

The regression test now asserts the **integer value** survives rather than only equality, and covers `Metric(7)`. Equality alone passes the buggy version for all three named values, which is why the original test missed it.

## Verification

98/98 ctest, 71 binding tests, and every value — including `Metric(7)` — confirmed preserved at protocols 0, 2 and 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H
