### PR TITLE
fix(wasm): give the beam-width test teeth, and correct four doc claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,8 +134,10 @@ section records what it contains rather than what changed.
   then `add` is two, and those two can fail between the halves and leave the id
   deleted. The beam width applies to a single `search` and leaves
   `ef_search` alone, so rescuing one hard query no longer charges every later
-  one. `is_empty` is deliberately not ported: `len(index)` and `index.size`
-  are what those languages already say.
+  one. `is_empty` is deliberately not ported (#182): Python already says
+  `len(index)` and JavaScript `index.size() === 0`, and it is absent from the C
+  ABI and the C++ engine too, so adding it to two of five surfaces would buy
+  no uniformity.
 - Python `Metric` pickles, so a worker pool can be handed one. The index types
   still refuse, at `dumps` rather than at `loads`: an index belongs in a
   `.vndb` file, and bytes no unpickler will accept are worse than an error.

--- a/README.md
+++ b/README.md
@@ -77,11 +77,12 @@ searchable. Building one still buffers its vectors in memory until `save`.
 `ApproxIndex` walks an HNSW graph and can miss a true neighbour. `ef_search` trades recall against speed
 per query; `m` and `ef_construction` set the graph's quality at build time.
 
-For a Rust query with its own recall setting, construct
+Every binding can set that beam per query, leaving the index's own default
+alone so concurrent callers can choose different widths. In Rust, construct
 `let params = vanedb::SearchParams::new().ef_search(100);` and call
-`index.search_with(&query, 10, &params)`. These options leave the index's default
-unchanged, so concurrent callers can choose different beam widths. The effective
-beam is at least `k`; ordinary `search` uses the index's defaults.
+`index.search_with(&query, 10, &params)`; Python takes `ef_search=` on `search`,
+WebAssembly a third argument, and the C ABI a parameter. The effective beam is
+at least `k`; ordinary `search` uses the index's defaults.
 
 Every type accepts a `Metric` (`L2`, cosine, or dot), defaulting to `L2` in the
 Python bindings; wasm takes it as a required string argument. Results come back
@@ -122,7 +123,8 @@ if file size matters.
 | C ABI | Flat, Approx, Disk | `VANEDB_RS_COSINE`; caller-provided id and distance arrays |
 
 WebAssembly currently supports add, batch add, search, lookup methods, remove,
-`tombstones` and `compact`; it does not expose persistence or upsert. A single id is a
+`upsert`, `tombstones` and `compact`; it does not expose persistence, which
+would need a filesystem. A single id is a
 JavaScript `bigint`; batch ids are a `BigUint64Array` and vectors a row-major
 `Float32Array`. Build a browser package from the repository root with
 `wasm-pack build vanedb-wasm --target web --release --locked --out-dir pkg-web`

--- a/vanedb-wasm/README.md
+++ b/vanedb-wasm/README.md
@@ -53,13 +53,19 @@ neighbourhoods. `tombstones()` counts what that has cost and `compact()`
 reclaims it — worth calling once churn accumulates, since a browser is the most
 memory-constrained runtime this package targets.
 
-`upsert(id, vector)` replaces a vector in one operation, inserting it if the id
-is absent. It is not `remove` then `add`: those can fail between the halves and
-leave the id deleted.
+`ApproxIndex.upsert(id, vector)` replaces a vector in one operation, inserting
+it if the id is absent. It is not `remove` then `add`: those can fail between
+the halves and leave the id deleted.
 
-`search` takes an optional beam width — `search(query, k, 64)` — that applies to
-that query alone and leaves `index.ef_search` untouched. Use it to spend extra
-recall on one hard query without paying for it on every later one.
+`ApproxIndex.search` takes an optional beam width — `search(query, k, 64)` —
+that applies to that query alone and leaves `index.ef_search` untouched. Use it
+to spend extra recall on one hard query without paying for it on every later
+one. A width below `k` is raised to `k`, so `0` is the narrowest legal override
+rather than a request to use the index's setting — omit the argument for that.
+
+Neither exists on `FlatIndex`, which is exact and has no beam. JavaScript
+ignores surplus arguments, so `flatIndex.search(query, k, 64)` runs without
+complaint and the width does nothing.
 
 Persistence (`save`/`load`) and disk mapping are not available in WebAssembly:
 there is no filesystem to map.

--- a/vanedb-wasm/src/lib.rs
+++ b/vanedb-wasm/src/lib.rs
@@ -287,11 +287,15 @@ impl WasmIndex {
     /// parallel by index. Ids are never narrowed to `f32`: values at or above
     /// 2^24 are not exactly representable, so distinct records collided and
     /// callers could act on the wrong record (#39).
+    ///
     /// `ef_search` widens the beam for this query alone and leaves the index's
     /// own setting untouched. The property is shared state, so raising it to
     /// rescue one hard query silently pays for it on every later one; this is
-    /// the way to spend that cost once. Below `k` it is raised to `k`, since
-    /// fewer candidates than results is meaningless.
+    /// the way to spend that cost once.
+    ///
+    /// Below `k` it is raised to `k`, so `0` is the narrowest legal override,
+    /// not a request to fall back to the index's setting — omit the argument
+    /// for that. The C ABI reads `0` the other way, and this matches Python.
     pub fn search(
         &self,
         query: &[f32],

--- a/vanedb-wasm/tests/web.rs
+++ b/vanedb-wasm/tests/web.rs
@@ -299,23 +299,62 @@ fn upsert_replaces_in_place_and_inserts_when_absent() {
 
 /// A beam width for one query, leaving the index's own setting alone.
 ///
-/// `ef_search` is a property, so the only way to widen a single hard query was
-/// to raise it, search, and lower it again -- three calls, and every search in
-/// between pays. Rust, Python and the C ABI all take it per call.
+/// The fixture matters more than the assertions. An earlier version used 60
+/// collinear points, where even the narrowest legal beam returns the exact
+/// answer -- so widened and un-widened searches gave identical ids and the
+/// test passed with the parameter wired to nothing. A review proved it by
+/// replacing `search_with` with `search`: all 22 tests stayed green. Recall
+/// has to actually differ for this to detect anything.
 #[wasm_bindgen_test]
-fn per_query_ef_search_leaves_the_shared_setting_alone() {
-    let index = WasmIndex::new(2.0, &JsValue::from_str("l2"), 200.0, 4.0, 8.0, Some(7.0)).unwrap();
-    for i in 0..60u64 {
-        let x = i as f32;
-        index.add(i.into(), &[x, x]).unwrap();
-    }
+fn per_query_ef_search_widens_the_search_and_leaves_the_setting_alone() {
+    const N: usize = 2000;
+    const DIM: usize = 32;
+    const K: usize = 10;
+
+    // A deterministic LCG: a fixed fixture without pulling in a dependency.
+    let mut state = 0x2545_f491_4f6c_dd1d_u64;
+    let mut next = || {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        ((state >> 33) as f32 / (1u32 << 31) as f32) - 0.5
+    };
+    let vectors: Vec<f32> = (0..N * DIM).map(|_| next()).collect();
+
+    // A sparse graph (m=4, ef_construction=8) over random high-dimensional
+    // vectors is where a narrow beam genuinely misses: the adversarial case
+    // for a proximity graph, which is the point.
+    let index = WasmIndex::new(
+        DIM as f64,
+        &JsValue::from_str("l2"),
+        N as f64,
+        4.0,
+        8.0,
+        Some(7.0),
+    )
+    .unwrap();
+    let ids: Vec<u64> = (0..N as u64).collect();
+    index.add_batch(&ids, &vectors).unwrap();
     index.set_ef_search(1.0).unwrap();
 
-    let widened = index.search(&[0.0, 0.0], 5.0, Some(64.0)).unwrap();
-    assert_eq!(
-        widened.ids(),
-        vec![0, 1, 2, 3, 4],
-        "a beam wider than the corpus must return the exact answer"
+    let query = &vectors[..DIM];
+    let mut exact: Vec<(u64, f32)> = (0..N)
+        .map(|i| {
+            let v = &vectors[i * DIM..(i + 1) * DIM];
+            let d: f32 = query.iter().zip(v).map(|(a, b)| (a - b) * (a - b)).sum();
+            (i as u64, d)
+        })
+        .collect();
+    exact.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap().then(a.0.cmp(&b.0)));
+    let truth: Vec<u64> = exact[..K].iter().map(|(id, _)| *id).collect();
+    let found = |hits: Vec<u64>| hits.iter().filter(|id| truth.contains(id)).count();
+
+    let narrow = found(index.search(query, K as f64, None).unwrap().ids());
+    let widened = found(index.search(query, K as f64, Some(400.0)).unwrap().ids());
+    assert!(
+        widened > narrow,
+        "a wider beam must find more true neighbours: narrow {narrow}/{K}, widened \
+         {widened}/{K} — equal means the argument never reached search_with"
     );
     assert_eq!(
         index.ef_search(),
@@ -324,7 +363,9 @@ fn per_query_ef_search_leaves_the_shared_setting_alone() {
     );
 
     // Omitting it falls back to that property, and it is validated like `k`.
-    assert_eq!(index.search(&[0.0, 0.0], 5.0, None).unwrap().length(), 5);
-    assert!(index.search(&[0.0, 0.0], 5.0, Some(-1.0)).is_err());
-    assert!(index.search(&[0.0, 0.0], 5.0, Some(f64::NAN)).is_err());
+    assert_eq!(index.search(query, 5.0, None).unwrap().length(), 5);
+    assert!(index.search(query, 5.0, Some(-1.0)).is_err());
+    assert!(index.search(query, 5.0, Some(f64::NAN)).is_err());
+    // 0 is the narrowest legal override, raised to `k` — not a fallback.
+    assert_eq!(index.search(query, 5.0, Some(0.0)).unwrap().length(), 5);
 }


### PR DESCRIPTION
#185 was merged at `2f9a50e`, before the four-role review's fixes were pushed. This is those fixes. Nothing here changes behaviour — it corrects a test that cannot fail and four documentation claims, two of which are currently false on `main`.

## The test guarding the new parameter could not detect it

A reviewer replaced `search_with` with `search` in `ApproxIndex::search` — wiring the `ef_search` argument to nothing — and **all 22 tests stayed green**.

The fixture was degenerate: 60 collinear points with `m=4`, where even the narrowest legal beam returns the exact answer. The widened and un-widened searches produced identical ids, so the headline assertion held whether or not the parameter reached the core. Only the shared-property assertion had teeth, and it proves a different thing.

It now builds 2000 random 32-dimensional vectors from a deterministic LCG over a sparse graph — the adversarial case for a proximity graph — computes the true ten nearest by brute force, and asserts the wider beam finds strictly more of them. Against the same mutation:

```
a wider beam must find more true neighbours: narrow 7/10, widened 7/10
 — equal means the argument never reached search_with
test result: FAILED. 21 passed; 1 failed
```

and 22/22 with the mutation reverted. Also adds the untested `ef_search = 0` boundary.

## Two claims that are false on `main` right now

**`README.md`** — the repository front page still says WebAssembly "does not expose persistence or upsert". #185 shipped `upsert`. I updated `vanedb-wasm/README.md`, `CHANGELOG.md` and the release notes and missed the GitHub landing page, which is the page the release commit tags. The same file also framed the per-query beam as a Rust construction when every binding now has one.

**`CHANGELOG.md`** — said `index.size` is the JavaScript spelling of the emptiness check. It is a method, so a caller writes `index.size() === 0`.

## Two things that were missing rather than wrong

**`upsert` and the beam width are `ApproxIndex`-only**, and nothing said so. JavaScript ignores surplus arguments, so `flatIndex.search(query, k, 64)` runs without complaint and the width does nothing; `FlatIndex` has no `upsert` at all. Both are now scoped, with that silent-ignore behaviour stated.

**`ef_search = 0` means opposite things across surfaces.** Here and in Python it is the narrowest legal override, raised to `k`; in the C ABI it means "use the handle's stored value". The release notes now claim every binding takes a per-query width, so the divergence needs saying — it is in the doc comment and the README.

Also splits the doc comment's two paragraphs, which ran together in the generated `index.d.ts` — the artifact TypeScript users actually read. The `is_empty` note now links #182 and gives the real reason: it is absent from the C ABI and the C++ engine too, so adding it to two of five surfaces buys no uniformity.

## Verification

fmt, clippy for the workspace and the wasm target, workspace tests, 22/22 wasm, the npm package assembling, and the rewritten test mutation-confirmed in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H
