### PR TITLE
ci: cache Rust builds, and stop publish jobs hanging for six hours

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -22,6 +22,13 @@ jobs:
   validate-version:
     name: Validate release identity
     runs-on: ubuntu-latest
+      # Without this a hung job holds GitHub's six-hour default. These are
+      # the jobs that carry an OIDC credential and a protected environment,
+      # so they are the ones where that matters most. The ceilings are far
+      # above observed runtimes -- the slowest publish job measured 3m57s --
+      # so they cannot bite a legitimate run. Time spent waiting for the
+      # environment approval is not job runtime and is not counted.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -66,6 +73,7 @@ jobs:
     name: Package and verify
     needs: validate-version
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
@@ -93,6 +101,7 @@ jobs:
     # whatever ref it names.
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/vanedb-crate-v')
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     environment: crates-io
     permissions:
       contents: read

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -22,6 +22,13 @@ jobs:
   validate-version:
     name: Validate release identity
     runs-on: ubuntu-latest
+      # Without this a hung job holds GitHub's six-hour default. These are
+      # the jobs that carry an OIDC credential and a protected environment,
+      # so they are the ones where that matters most. The ceilings are far
+      # above observed runtimes -- the slowest publish job measured 3m57s --
+      # so they cannot bite a legitimate run. Time spent waiting for the
+      # environment approval is not job runtime and is not counted.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -88,6 +95,7 @@ jobs:
     name: Linux wheels (${{ matrix.libc }} ${{ matrix.arch }}, Python 3.11–3.14)
     needs: validate-version
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -132,6 +140,7 @@ jobs:
     name: Test Linux wheel (${{ matrix.arch }}, Python ${{ matrix.python-version }})
     needs: linux
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -172,6 +181,7 @@ jobs:
     name: Test musl wheel (${{ matrix.arch }}, Python ${{ matrix.python-version }})
     needs: linux
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -221,6 +231,7 @@ jobs:
     name: macOS wheels (${{ matrix.target }}, Python ${{ matrix.python-version }})
     needs: validate-version
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -262,6 +273,7 @@ jobs:
     name: Windows wheels (x64, Python ${{ matrix.python-version }})
     needs: validate-version
     runs-on: windows-latest
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -295,6 +307,7 @@ jobs:
     name: Source distribution
     needs: validate-version
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build sdist
@@ -314,6 +327,7 @@ jobs:
     name: Test source distribution
     needs: sdist
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -337,6 +351,7 @@ jobs:
     name: Validate release artifacts
     needs: [linux-test, musl-test, macos, windows, sdist-test]
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -376,6 +391,7 @@ jobs:
     name: Publish vanedb to TestPyPI
     needs: validate-artifacts
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     if: >-
       github.event_name == 'workflow_dispatch' &&
       inputs.publish_testpypi &&
@@ -400,6 +416,7 @@ jobs:
     name: Publish vanedb to PyPI
     needs: validate-artifacts
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/vanedb-v')
     environment:
       name: pypi

--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -20,6 +20,13 @@ jobs:
   verify:
     name: Build and consume the package
     runs-on: ubuntu-latest
+      # Without this a hung job holds GitHub's six-hour default. These are
+      # the jobs that carry an OIDC credential and a protected environment,
+      # so they are the ones where that matters most. The ceilings are far
+      # above observed runtimes -- the slowest publish job measured 3m57s --
+      # so they cannot bite a legitimate run. Time spent waiting for the
+      # environment approval is not job runtime and is not counted.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -103,6 +110,7 @@ jobs:
     # never satisfy it, whatever ref it names.
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/vanedb-wasm-v')
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     environment: npm
     permissions:
       contents: read

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -21,6 +21,20 @@ jobs:
         with:
           toolchain: stable
           components: clippy, rustfmt
+      # Every Rust job compiled the workspace and all of its
+      # dependencies from zero: twenty jobs, thirty-three of the
+      # seventy-two runner-minutes a push costs. The C++ side already
+      # caches its CMake dependencies.
+      #
+      # `integration-ci.yml` is deliberately left uncached. It runs the
+      # bench suite, and `release_identity` documents that it depends on
+      # `build.rs` regenerating the C ABI header there; leaving that
+      # workflow alone keeps the assumption its comment records true.
+      #
+      # Nothing here reads a generated file: the cache holds `target/`,
+      # not the source tree, so a cache hit cannot substitute stale
+      # committed bytes for freshly built ones.
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --exclude vanedb-py --all-targets --features disk --locked -- -D warnings
       # Every test leg below passes `--features disk`, so the default feature
@@ -49,6 +63,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
         with:
           toolchain: stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       # Nothing built the documentation, so nothing could see a link that only
       # breaks in one build. Two dead links sat in the AVX2 module docs, which
       # exist solely on x86-64 — and every local check ran on macOS ARM64,
@@ -71,6 +86,7 @@ jobs:
         with:
           toolchain: stable
           components: clippy
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       # gpu-metal only compiles on Apple platforms, so the Linux lint job
       # cannot see this surface at all. Without a leg here, MetalCompute is
       # public API that never passes clippy or the crate's own missing_docs.
@@ -91,6 +107,7 @@ jobs:
         with:
           toolchain: 1.85.0
           targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.11'
@@ -120,6 +137,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
         with:
           toolchain: stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       # vanedb-py is excluded from the workspace jobs (building a wheel needs
       # maturin), but `cargo check` needs only a Python interpreter, so the
       # crate at least compiling is verified cheaply. Behaviour is covered by
@@ -143,6 +161,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
         with:
           toolchain: stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.11'
@@ -209,6 +228,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
         with:
           toolchain: stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - run: cargo test --workspace --exclude vanedb-py --features ${{ matrix.features }} --locked
       - name: Build and run C consumer acceptance
         # Runs on windows-latest too, where the default shell is pwsh: it does
@@ -252,6 +272,7 @@ jobs:
         with:
           toolchain: stable
           components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       # Installed from crates.io rather than via a new pinned Action: every
       # `uses:` here is SHA-pinned, and adding a dependency means vouching for
       # a SHA. This costs a couple of minutes and adds no new trusted party.
@@ -287,6 +308,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
         with:
           toolchain: stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       # The ctypes example is the C ABI's Python-facing documentation, and a
       # broken example is worse than none because it is what a reader copies.
       # Its unit tests check the signatures statically; this runs it against a
@@ -326,6 +348,7 @@ jobs:
         with:
           toolchain: nightly
           components: rust-src
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Distance kernels and index paths under ASan
         env:
           RUSTFLAGS: -Zsanitizer=address
@@ -357,6 +380,7 @@ jobs:
         with:
           toolchain: stable
           targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Test WASM
@@ -412,6 +436,7 @@ jobs:
         with:
           toolchain: stable
           targets: aarch64-apple-ios, aarch64-apple-ios-sim
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - run: cargo build -p vanedb -p vanedb-capi --target aarch64-apple-ios --features disk --release --locked
       - run: cargo build -p vanedb-capi --target aarch64-apple-ios-sim --release --locked
       - name: Run C ABI acceptance in an iOS simulator
@@ -427,6 +452,7 @@ jobs:
         with:
           toolchain: stable
           targets: aarch64-linux-android, x86_64-linux-android
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Set up Android NDK
         id: ndk
         uses: nttld/setup-ndk@ed92fe6cadad69be94a966a7ee3271275e62f779 # v1


### PR DESCRIPTION
Reviewed all ten workflows against run data rather than by reading them. Two things are worth fixing; several that looked wrong are not, and are listed so they don't get "fixed" later.

## Every Rust job compiled from zero

`rust-ci.yml` had no caching at all, while `cpp-ci.yml` already cached its CMake dependencies. Measured on the last `main` run (53 jobs, 72 runner-minutes for ~7 minutes of wall clock):

| | jobs | runner-minutes |
|---|---|---|
| C++ | 27 | 33 |
| **Rust** | **20** | **33** |
| Cross-engine | 3 | 5 |

Thirteen jobs now restore a cache, keyed per job so a lint job and a sanitizer job don't fight over one entry.

**`integration-ci.yml` is deliberately excluded.** It runs the bench suite, and `bench/tests/release_identity.rs:90` documents that it depends on `build.rs` regenerating the C ABI header *because* that workflow runs uncached. Leaving it alone keeps that comment true.

For the cached jobs the concern doesn't arise — the cache holds `target/`, not the source tree, so a hit can't substitute stale committed bytes for fresh ones. Checked rather than argued: with a warm target directory, corrupting `cpp/Doxyfile`'s version still fails `every_declared_version_agrees` with the correct message, and restoring it passes.

## Publish jobs could hang for six hours

The three publish workflows set no `timeout-minutes` on any of their sixteen jobs, while every other workflow sets one per job. These are precisely the jobs holding an OIDC credential and a protected environment.

Ceilings are far above observed runtimes — the slowest publish job in the 0.1.1 release measured **3m57s** — so they can't bite a legitimate run, and time waiting for environment approval isn't job runtime.

## Looked wrong, isn't — don't "fix" these

- **`ci.yml` concurrency.** `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` cancels superseded PR runs while letting `main` finish. A grep for a literal `true` misses it; I made that mistake first.
- **The one `|| true` in the tree** (`bench.yml:66`, critcmp → step summary) is what makes that workflow report rather than gate, which CLAUDE.md states is the intent.
- **Path filters are sound.** A docs-only change triggers nothing; `README.md` correctly triggers Rust because `vanedb/tests/readme.rs` compiles it.
- No suppressed failures, no pipes to `head`/`tail` inside `run:` steps, every action SHA-pinned.

## Raised separately

Twelve "Python Bindings Tests" jobs — 16 minutes, 22% of every run — cover `vanedb-cpp` on 3 OS × 4 Python versions, for a package that is never published and has no publish workflow. That's a scope judgment rather than a defect, so it belongs in its own PR.

## Verification

`actionlint` clean; the release-identity guard mutation-checked against a warm build in both directions. The caching benefit itself only shows on the second run, since this PR's own run populates the caches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H
