### PR TITLE
ci(cpp): test the binding layer on two axes, not their product

### DIFF
--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -150,9 +150,28 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
+      # Two axes, not their product. `vanedb-cpp` is never published -- it is
+      # reference code and the second arm of the benchmark comparison -- and the
+      # engine underneath is already built and tested on every platform by the
+      # jobs above, with gcc, clang, msvc, both sanitizers, Linux ARM64, Android
+      # and iOS. What is left for this job to catch is the pybind11-to-CPython
+      # layer, which moves with the interpreter version, and whether the
+      # extension builds at all on a given OS.
+      #
+      # So: every interpreter version on one OS, and the oldest and newest on
+      # the other two. Twelve jobs become eight. The twelve were sixteen of the
+      # seventy-two runner-minutes a push costs, spent on a package that ships
+      # nowhere.
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.11', '3.12', '3.13', '3.14']
+        include:
+          - { os: ubuntu-latest, python-version: '3.11' }
+          - { os: ubuntu-latest, python-version: '3.12' }
+          - { os: ubuntu-latest, python-version: '3.13' }
+          - { os: ubuntu-latest, python-version: '3.14' }
+          - { os: macos-latest, python-version: '3.11' }
+          - { os: macos-latest, python-version: '3.14' }
+          - { os: windows-latest, python-version: '3.11' }
+          - { os: windows-latest, python-version: '3.14' }
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
The C++ Python bindings ran on a full cross-product — 3 operating systems × 4 interpreter versions = **12 jobs, 16 of the 72 runner-minutes a push costs**. For `vanedb-cpp`: a package that is never published, has no publish workflow, and exists as reference code and the second arm of the benchmark comparison.

## Why the product isn't needed

The engine underneath is already built and tested on every platform by the jobs above this one — gcc, clang, msvc, address and undefined sanitizers, Linux ARM64, Android, iOS. What only *this* job can catch is the pybind11-to-CPython layer, and that moves along two independent axes rather than their product:

- **the interpreter version**, where pybind11 meets a changing C API
- **the OS**, where the extension either builds and imports or doesn't

So every interpreter version runs on one OS, and the oldest and newest run on the other two:

```
ubuntu/3.11  ubuntu/3.12  ubuntu/3.13  ubuntu/3.14
macos/3.11                             macos/3.14
windows/3.11                           windows/3.14
```

Every version still covered, every OS still covered. What's gone is the eight-way middle of the grid.

## What this trades away, stated plainly

A failure specific to, say, macOS **and** 3.12 but not macOS/3.11 or macOS/3.14 would now be missed. That's not impossible, so this is a deliberate trade rather than a free saving — and it's priced against a package nothing installs. The cost of missing one is slower discovery on the reference engine, not a defect in anything published.

If you'd rather keep the full grid, the counter-argument is reasonable and I'd take a "no" here; the timeouts and caching in #188 are the changes I'd defend harder.

A further trim to 6 jobs (dropping the second non-Linux version) is available if you want more, but I'd stop here — the oldest/newest pair is where ABI trouble concentrates.

## Verification

`actionlint` clean, and the parsed matrix confirms 3.11–3.14 and all three operating systems are still represented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtmBCmM1nxYVxebAbMNH8H
